### PR TITLE
Wrap Unchecked Path.mods() Invocation in MODS_ALLOWED Check (WeekData.hx)

### DIFF
--- a/source/WeekData.hx
+++ b/source/WeekData.hx
@@ -102,9 +102,12 @@ class WeekData {
 					var week:WeekFile = getWeekFile(fileToCheck);
 					if(week != null) {
 						var weekFile:WeekData = new WeekData(week);
+
+						#if MODS_ALLOWED
 						if(j >= originalLength) {
 							weekFile.folder = directories[j].substring(Paths.mods().length, directories[j].length-1);
 						}
+						#end
 
 						if(weekFile != null && (isStoryMode == null || (isStoryMode && !weekFile.hideStoryMode) || (!isStoryMode && !weekFile.hideFreeplay))) {
 							weeksLoaded.set(sexList[i], weekFile);


### PR DESCRIPTION
Previously not wrapped in a check for whether mods were allowed during compilation, meaning the code would be unable to compile without the MODS_ALLOWED flag.

If mods aren't allowed (and therefore not loaded), we shouldn't overflow above the default expected amount of directories (and weeks), making this code irrelevant to "vanilla".