### PR TITLE
Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.yml
+++ b/.github/ISSUE_TEMPLATE/bugs.yml
@@ -1,0 +1,16 @@
+name: Bug report
+description: Report bugs with the engine here
+labels: [bug]
+body:
+  - type: textarea
+    attributes:
+      label: Bug report
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Did you edit anything? If so, mention or summarize your changes.
+      description: 'For example: "Yes, i edited PlayState.hx and tried to mess with how health icon animation frames are handled" or "No, everything is the same as the base engine!"'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,9 @@
+name: Feature Request
+description: No, i won't add 6K/etc to the engine or winning icons, stop asking for it.
+labels: [enhancement]
+body:
+  - type: textarea
+    attributes:
+      label: What feature do you want to get added on the base engine?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/help.yml
+++ b/.github/ISSUE_TEMPLATE/help.yml
@@ -1,0 +1,19 @@
+name: Help wanted
+description: If you need help using the engine.
+labels: [help wanted]
+body:
+
+  - type: dropdown
+    attributes:
+      label: Are you trying to code on Source Code (Haxe) or on the Downloaded Build (Lua)?
+      options:
+        - Source Code
+        - Downloaded Build
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Show an screenshot/video of your problem.
+      description: Put down here an screenshot of your compiling issue or whatever is happening to you.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/missing-docs.yml
+++ b/.github/ISSUE_TEMPLATE/missing-docs.yml
@@ -1,0 +1,10 @@
+name: Missing Documentation
+description: Ask for documentation if something is missing.
+labels: [documentation]
+body:
+  - type: textarea
+    attributes:
+      label: What needs to be documented?
+      description: 'For example: "There is no page explaining how to create an Achievement!"'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,9 @@
+name: Question
+description: Ask about something here.
+labels: [question]
+body:
+  - type: textarea
+    attributes:
+      label: What is your question?
+    validations:
+      required: true


### PR DESCRIPTION
This uses the new github issue forms for the issue templates.

See what they look like here: https://github.com/DevScyu/FNF-PsychEngine/tree/github-issues/.github/ISSUE_TEMPLATE