### PR TITLE
Dialogue Enhancements

### DIFF
--- a/source/DialogueBoxPsych.hx
+++ b/source/DialogueBoxPsych.hx
@@ -41,6 +41,7 @@ typedef DialogueAnimArray = {
 // love u Shubs no homo :flushedh4:
 typedef DialogueFile = {
 	var dialogue:Array<DialogueLine>;
+	var song:Null<String>;
 }
 
 typedef DialogueLine = {

--- a/source/GameOverSubstate.hx
+++ b/source/GameOverSubstate.hx
@@ -82,6 +82,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			FlxG.sound.music.stop();
 			PlayState.deathCounter = 0;
 			PlayState.seenCutscene = false;
+			PlayState.setOnLuas('seenCutscene', false);
 
 			if (PlayState.isStoryMode)
 				MusicBeatState.switchState(new StoryMenuState());

--- a/source/GameOverSubstate.hx
+++ b/source/GameOverSubstate.hx
@@ -19,8 +19,6 @@ class GameOverSubstate extends MusicBeatSubstate
 
 	var stageSuffix:String = "";
 
-	var lePlayState:PlayState;
-
 	public static var characterName:String = 'bf';
 	public static var deathSoundName:String = 'fnf_loss_sfx';
 	public static var loopSoundName:String = 'gameOver';
@@ -33,10 +31,9 @@ class GameOverSubstate extends MusicBeatSubstate
 		endSoundName = 'gameOverEnd';
 	}
 
-	public function new(x:Float, y:Float, camX:Float, camY:Float, state:PlayState)
+	public function new(x:Float, y:Float, camX:Float, camY:Float)
 	{
-		lePlayState = state;
-		state.setOnLuas('inGameOver', true);
+		PlayState.STATE.setOnLuas('inGameOver', true);
 		super();
 
 		Conductor.songPosition = 0;
@@ -66,7 +63,7 @@ class GameOverSubstate extends MusicBeatSubstate
 	{
 		super.update(elapsed);
 
-		lePlayState.callOnLuas('onUpdate', [elapsed]);
+		PlayState.STATE.setOnLuas('onUpdate', [elapsed]);
 		if(updateCamera) {
 			var lerpVal:Float = CoolUtil.boundTo(elapsed * 0.6, 0, 1);
 			camFollowPos.setPosition(FlxMath.lerp(camFollowPos.x, camFollow.x, lerpVal), FlxMath.lerp(camFollowPos.y, camFollow.y, lerpVal));
@@ -82,7 +79,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			FlxG.sound.music.stop();
 			PlayState.deathCounter = 0;
 			PlayState.seenCutscene = false;
-			PlayState.setOnLuas('seenCutscene', false);
+			PlayState.STATE.setOnLuas('seenCutscene', false);
 
 			if (PlayState.isStoryMode)
 				MusicBeatState.switchState(new StoryMenuState());
@@ -90,7 +87,7 @@ class GameOverSubstate extends MusicBeatSubstate
 				MusicBeatState.switchState(new FreeplayState());
 
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
-			lePlayState.callOnLuas('onGameOverConfirm', [false]);
+			PlayState.STATE.setOnLuas('onGameOverConfirm', [false]);
 		}
 
 		if (bf.animation.curAnim.name == 'firstDeath')
@@ -112,7 +109,7 @@ class GameOverSubstate extends MusicBeatSubstate
 		{
 			Conductor.songPosition = FlxG.sound.music.time;
 		}
-		lePlayState.callOnLuas('onUpdatePost', [elapsed]);
+		PlayState.STATE.setOnLuas('onUpdatePost', [elapsed]);
 	}
 
 	override function beatHit()
@@ -144,7 +141,7 @@ class GameOverSubstate extends MusicBeatSubstate
 					MusicBeatState.resetState();
 				});
 			});
-			lePlayState.callOnLuas('onGameOverConfirm', [true]);
+			PlayState.STATE.setOnLuas('onGameOverConfirm', [true]);
 		}
 	}
 }

--- a/source/GitarooPause.hx
+++ b/source/GitarooPause.hx
@@ -66,7 +66,7 @@ class GitarooPause extends MusicBeatState
 				PlayState.usedPractice = false;
 				PlayState.changedDifficulty = false;
 				PlayState.seenCutscene = false;
-				PlayState.setOnLuas('seenCutscene', false);
+				PlayState.STATE.setOnLuas('seenCutscene', false);
 				PlayState.deathCounter = 0;
 				PlayState.cpuControlled = false;
 				MusicBeatState.switchState(new MainMenuState());

--- a/source/GitarooPause.hx
+++ b/source/GitarooPause.hx
@@ -66,6 +66,7 @@ class GitarooPause extends MusicBeatState
 				PlayState.usedPractice = false;
 				PlayState.changedDifficulty = false;
 				PlayState.seenCutscene = false;
+				PlayState.setOnLuas('seenCutscene', false);
 				PlayState.deathCounter = 0;
 				PlayState.cpuControlled = false;
 				MusicBeatState.switchState(new MainMenuState());

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -177,7 +177,7 @@ class PauseSubState extends MusicBeatSubstate
 				case "Exit to menu":
 					PlayState.deathCounter = 0;
 					PlayState.seenCutscene = false;
-					PlayState.setOnLuas('seenCutscene', false);
+					PlayState.STATE.setOnLuas('seenCutscene', false);
 					CustomFadeTransition.nextCamera = transCamera;
 					if(PlayState.isStoryMode) {
 						MusicBeatState.switchState(new StoryMenuState());

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -177,6 +177,7 @@ class PauseSubState extends MusicBeatSubstate
 				case "Exit to menu":
 					PlayState.deathCounter = 0;
 					PlayState.seenCutscene = false;
+					PlayState.setOnLuas('seenCutscene', false);
 					CustomFadeTransition.nextCamera = transCamera;
 					if(PlayState.isStoryMode) {
 						MusicBeatState.switchState(new StoryMenuState());

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1157,7 +1157,7 @@ class PlayState extends MusicBeatState
 			inCutscene = true;
 			CoolUtil.precacheSound('dialogue');
 			CoolUtil.precacheSound('dialogueClose');
-			var doof:DialogueBoxPsych = new DialogueBoxPsych(dialogueFile, song);
+			var doof:DialogueBoxPsych = new DialogueBoxPsych(dialogueFile, (dialogueFile.song != null ? dialogueFile.song : song));
 			doof.scrollFactor.set();
 			if(endingSong) {
 				doof.finishThing = endSong;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2838,17 +2838,20 @@ class PlayState extends MusicBeatState
 		var songName:String = Paths.formatToSongPath(SONG.song);
 
 		var dialogueJson:DialogueFile = null;
-		var file:String = Paths.json(songName + '/dialogueEND'); //Checks for json/Psych Engine dialogue
-		if (OpenFlAssets.exists(file)) {
-			dialogueJson = DialogueBoxPsych.parseDialogue(file);
-		}
 
-		#if MODS_ALLOWED
-		var file:String = Paths.modsJson(songName + '/dialogueEND'); //Checks for json/Psych Engine dialogue in mod folder
-		if(dialogueJson == null && FileSystem.exists(file)) { // Only check if dialogue has not already been found
-			dialogueJson = DialogueBoxPsych.parseDialogue(file);
+		if(isStoryMode) {
+			var file:String = Paths.json(songName + '/dialogueEND'); //Checks for json/Psych Engine dialogue
+			if (OpenFlAssets.exists(file)) {
+				dialogueJson = DialogueBoxPsych.parseDialogue(file);
+			}
+
+			#if MODS_ALLOWED
+			var file:String = Paths.modsJson(songName + '/dialogueEND'); //Checks for json/Psych Engine dialogue in mod folder
+			if(dialogueJson == null && FileSystem.exists(file)) { // Only check if dialogue has not already been found
+				dialogueJson = DialogueBoxPsych.parseDialogue(file);
+			}
+			#end
 		}
-		#end
 
 		if(ClientPrefs.noteOffset <= 0) {
 			if(dialogueJson != null) startDialogue(dialogueJson);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1020,6 +1020,7 @@ class PlayState extends MusicBeatState
 					else startCountdown();
 			}
 			seenCutscene = true;
+			setOnLuas('seenCutscene', true);
 		} else {
 			startCountdown();
 		}
@@ -2868,6 +2869,7 @@ class PlayState extends MusicBeatState
 
 		deathCounter = 0;
 		seenCutscene = false;
+		setOnLuas('seenCutscene', false);
 
 		#if ACHIEVEMENTS_ALLOWED
 		if(achievementObj != null) {

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -61,6 +61,8 @@ class PlayState extends MusicBeatState
 	public static var STRUM_X = 42;
 	public static var STRUM_X_MIDDLESCROLL = -278;
 
+	public static var STATE:PlayState;
+
 	public static var ratingStuff:Array<Dynamic> = [
 		['You Suck!', 0.2], //From 0% to 19%
 		['Shit', 0.4], //From 20% to 39%
@@ -249,6 +251,8 @@ class PlayState extends MusicBeatState
 
 	override public function create()
 	{
+		PlayState.STATE = this;
+
 		#if MODS_ALLOWED
 		Paths.destroyLoadedImages(resetSpriteCache);
 		#end
@@ -2389,7 +2393,7 @@ class PlayState extends MusicBeatState
 				vocals.stop();
 				FlxG.sound.music.stop();
 
-				openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y, camFollowPos.x, camFollowPos.y, this));
+				openSubState(new GameOverSubstate(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y, camFollowPos.x, camFollowPos.y));
 				for (tween in modchartTweens) {
 					tween.active = true;
 				}
@@ -2885,7 +2889,6 @@ class PlayState extends MusicBeatState
 			}
 		}
 		#end
-
 		
 		#if LUA_ALLOWED
 		var ret:Dynamic = callOnLuas('onEndSong', []);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -751,6 +751,13 @@ class PlayState extends MusicBeatState
 			dialogueJson = DialogueBoxPsych.parseDialogue(file);
 		}
 
+		#if MODS_ALLOWED
+		var file:String = Paths.modsJson(songName + '/dialogue'); //Checks for json/Psych Engine dialogue in mod folder
+		if(dialogueJson == null && FileSystem.exists(file)) { // Only check if dialogue has not already been found
+			dialogueJson = DialogueBoxPsych.parseDialogue(file);
+		}
+		#end
+
 		var file:String = Paths.txt(songName + '/' + songName + 'Dialogue'); //Checks for vanilla/Senpai dialogue
 		if (OpenFlAssets.exists(file)) {
 			dialogue = CoolUtil.coolTextFile(file);
@@ -1009,7 +1016,8 @@ class PlayState extends MusicBeatState
 					schoolIntro(doof);
 
 				default:
-					startCountdown();
+					if(dialogueJson != null) startDialogue(dialogueJson)
+					else startCountdown();
 			}
 			seenCutscene = true;
 		} else {

--- a/source/editors/DialogueEditorState.hx
+++ b/source/editors/DialogueEditorState.hx
@@ -60,7 +60,8 @@ class DialogueEditorState extends MusicBeatState
 		dialogueFile = {
 			dialogue: [
 				copyDefaultLine()
-			]
+			],
+			song: "Breakfast"
 		};
 		
 		character = new DialogueCharacter();
@@ -81,6 +82,7 @@ class DialogueEditorState extends MusicBeatState
 		add(box);
 
 		addEditorBox();
+		addSongBox();
 		FlxG.mouse.visible = true;
 
 		var addLineText:FlxText = new FlxText(10, 10, FlxG.width - 20, 'Press O to remove the current dialogue line, Press P to add another line after the current one.', 8);
@@ -113,6 +115,20 @@ class DialogueEditorState extends MusicBeatState
 		UI_box.scrollFactor.set();
 		UI_box.alpha = 0.8;
 		addDialogueLineUI();
+		add(UI_box);
+	}
+
+	function addSongBox() {
+		var tabs = [
+			{name: 'Background Music', label: 'Background Music'},
+		];
+		UI_box = new FlxUITabMenu(null, tabs, true);
+		UI_box.resize(100, 50);
+		UI_box.x = FlxG.width - UI_box.width - 250 - 20;
+		UI_box.y = 10;
+		UI_box.scrollFactor.set();
+		UI_box.alpha = 0.8;
+		addSongUI();
 		add(UI_box);
 	}
 
@@ -156,6 +172,18 @@ class DialogueEditorState extends MusicBeatState
 		tab_group.add(lineInputText);
 		tab_group.add(loadButton);
 		tab_group.add(saveButton);
+		UI_box.addGroup(tab_group);
+	}
+
+	var songInputText:FlxUIInputText;
+	function addSongUI() {
+		var tab_group = new FlxUI(null, UI_box);
+		tab_group.name = "Background Music";
+
+		songInputText = new FlxUIInputText(10, 5, 80, null, 8);
+		blockPressWhileTypingOn.push(songInputText);
+
+		tab_group.add(songInputText);
 		UI_box.addGroup(tab_group);
 	}
 
@@ -253,7 +281,7 @@ class DialogueEditorState extends MusicBeatState
 	}
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
-		if(id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText)) {
+		if(id == FlxUIInputText.CHANGE_EVENT && (sender == characterInputText || sender == lineInputText || sender == songInputText)) {
 			if(sender == characterInputText) {
 				character.reloadCharacterJson(characterInputText.text);
 				reloadCharacter();
@@ -273,6 +301,8 @@ class DialogueEditorState extends MusicBeatState
 			} else if(sender == lineInputText) {
 				reloadText(0);
 				dialogueFile.dialogue[curSelected].text = lineInputText.text;
+			} else if(sender == songInputText) {
+				dialogueFile.song = songInputText.text;
 			}
 		} else if(id == FlxUINumericStepper.CHANGE_EVENT && (sender == speedStepper)) {
 			reloadText(speedStepper.value);


### PR DESCRIPTION
Changelog:
```diff
+ Allow dialogue files to be executed without source changes per song
+ Allow dialogue background music to be configured in the dialogue json and via the dialogue editor
+ Adds new dialogueEND support to allow dialogue to be played when a song ends
```

I have tested this to be compatible with 0.4.2.

![image](https://user-images.githubusercontent.com/15234414/138580983-8abc5632-08fa-44bf-944b-d4b315403f22.png)

Inside of your `mods/data/SONG` folder:
`dialogue.json` for dialogue when song starts
`dialogueEND.json` for dialogue when song ends


Closes #578