### PR TITLE
Feat: fix `xdg-open` bug on Linux.

### DIFF
--- a/source/CoolUtil.hx
+++ b/source/CoolUtil.hx
@@ -71,7 +71,7 @@ class CoolUtil
 
 	public static function browserLoad(site:String) {
 		#if linux
-		Sys.command('/usr/bin/xdg-open', [site, "&"]);
+		Sys.command('/usr/bin/xdg-open', [site]);
 		#else
 		FlxG.openURL(site);
 		#end


### PR DESCRIPTION
The `&` operator is not a valid term for the `xdg-open` command. `&` simply denotes being disowned from being inside a shell, and as this is a non-terminal program, the `&` actually causes `xdg-open` to fail. Removing the `&` fixes this issue.