### PR TITLE
Discord RPC Presence Callback

### DIFF
--- a/source/Discord.hx
+++ b/source/Discord.hx
@@ -3,6 +3,11 @@ package;
 import Sys.sleep;
 import discord_rpc.DiscordRpc;
 
+#if LUA_ALLOWED
+import llua.Lua;
+import llua.State;
+#end
+
 using StringTools;
 
 class DiscordClient
@@ -84,4 +89,12 @@ class DiscordClient
 
 		//trace('Discord RPC Updated. Arguments: $details, $state, $smallImageKey, $hasStartTimestamp, $endTimestamp');
 	}
+
+	#if LUA_ALLOWED
+	public static function addLuaCallbacks(lua:State) {
+		Lua_helper.add_callback(lua, "changePresence", function(details:String, state:Null<String>, ?smallImageKey:String, ?hasStartTimestamp:Bool, ?endTimestamp:Float) {
+			changePresence(details, state, smallImageKey, hasStartTimestamp, endTimestamp);
+		});
+	}
+	#end
 }

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -28,6 +28,10 @@ import Type.ValueType;
 import Controls;
 import DialogueBoxPsych;
 
+#if desktop
+import Discord;
+#end
+
 using StringTools;
 
 class FunkinLua {
@@ -1137,6 +1141,9 @@ class FunkinLua {
 			FlxG.sound.music.fadeOut(duration, toValue);
 			luaTrace('musicFadeOut is deprecated! Use soundFadeOut instead.', false, true);
 		});
+
+		Discord.DiscordClient.addLuaCallbacks(lua);
+
 		call('onCreate', []);
 		#end
 	}

--- a/source/editors/EditorLua.hx
+++ b/source/editors/EditorLua.hx
@@ -27,6 +27,10 @@ import Type.ValueType;
 import Controls;
 import DialogueBoxPsych;
 
+#if desktop
+import Discord;
+#end
+
 using StringTools;
 
 class EditorLua {
@@ -180,6 +184,9 @@ class EditorLua {
 				return;
 			}
 		});
+
+		Discord.DiscordClient.addLuaCallbacks(lua);
+
 		call('onCreate', []);
 		#end
 	}


### PR DESCRIPTION
Simply adds a Lua callback for modifying the RPC Display of the running RPC client.
Sample usage is literally just `changePresence("DETAILS", "STATE", nil, nil, nil)`.
Can be put in pretty much any invoked function in a `.lua` file.