### PR TITLE
Fix achievements menu not having a fade transition back to main menu state.

### DIFF
--- a/source/AchievementsMenuState.hx
+++ b/source/AchievementsMenuState.hx
@@ -85,7 +85,7 @@ class AchievementsMenuState extends MusicBeatState
 
 		if (controls.BACK) {
 			FlxG.sound.play(Paths.sound('cancelMenu'));
-			FlxG.switchState(new MainMenuState());
+			MusicBeatState.switchState(new MainMenuState());
 		}
 	}
 


### PR DESCRIPTION
Seemingly an oversight with the new transition system. Readds the fade transition when going back on the achievements menu.