### PR TITLE
update freeplay colors for Monster, Winter Horrorland and Thorns

### DIFF
--- a/assets/preload/weeks/week2.json
+++ b/assets/preload/weeks/week2.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Spookeez", "spooky", [34, 51, 68]],
 		["South", "spooky", [34, 51, 68]],
-		["Monster", "monster", [34, 51, 68]]
+		["Monster", "monster", [120, 122, 35]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week5.json
+++ b/assets/preload/weeks/week5.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Cocoa", "parents", [160, 209, 255]],
 		["Eggnog", "parents", [160, 209, 255]],
-		["Winter Horrorland", "monster", [160, 209, 255]]
+		["Winter Horrorland", "monster", [120, 122, 35]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week6.json
+++ b/assets/preload/weeks/week6.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Senpai", "senpai-pixel", [255, 120, 191]],
 		["Roses", "senpai-pixel", [255, 120, 191]],
-		["Thorns", "spirit-pixel", [255, 120, 191]]
+		["Thorns", "spirit-pixel", [153, 17, 44]]
 	],
 
 	"weekCharacters": [


### PR DESCRIPTION
self explanatory name, it will add colors that makes sense with the characters that changed in some weeks (Week 2, Week 5 and Week 6)

**Screenshots:**
![image](https://user-images.githubusercontent.com/72695242/143771176-59a22ee9-11d1-4f1a-b888-7696654fa546.png)
![image](https://user-images.githubusercontent.com/72695242/143771183-23ca104c-a2f1-4409-bacb-335b687883ea.png)
![image](https://user-images.githubusercontent.com/72695242/143771189-7b2143e6-8afc-4342-8a71-04d8e3e0c063.png)
