### PR TITLE
add new colors to freeplay

### DIFF
--- a/assets/preload/weeks/week2.json
+++ b/assets/preload/weeks/week2.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Spookeez", "spooky", [34, 51, 68]],
 		["South", "spooky", [34, 51, 68]],
-		["Monster", "monster", [34, 51, 68]]
+		["Monster", "monster", [120, 122, 35]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week2.json
+++ b/assets/preload/weeks/week2.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Spookeez", "spooky", [34, 51, 68]],
 		["South", "spooky", [34, 51, 68]],
-		["Monster", "monster", [120, 122, 35]]
+		["Monster", "monster", [243, 255, 110]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week5.json
+++ b/assets/preload/weeks/week5.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Cocoa", "parents", [160, 209, 255]],
 		["Eggnog", "parents", [160, 209, 255]],
-		["Winter Horrorland", "monster", [120, 122, 35]]
+		["Winter Horrorland", "monster", [243, 255, 110]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week5.json
+++ b/assets/preload/weeks/week5.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Cocoa", "parents", [160, 209, 255]],
 		["Eggnog", "parents", [160, 209, 255]],
-		["Winter Horrorland", "monster", [160, 209, 255]]
+		["Winter Horrorland", "monster", [120, 122, 35]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week6.json
+++ b/assets/preload/weeks/week6.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Senpai", "senpai-pixel", [255, 120, 191]],
 		["Roses", "senpai-pixel", [255, 120, 191]],
-		["Thorns", "spirit-pixel", [255, 120, 191]]
+		["Thorns", "spirit-pixel", [153, 17, 44]]
 	],
 
 	"weekCharacters": [

--- a/assets/preload/weeks/week6.json
+++ b/assets/preload/weeks/week6.json
@@ -2,7 +2,7 @@
 	"songs": [
 		["Senpai", "senpai-pixel", [255, 120, 191]],
 		["Roses", "senpai-pixel", [255, 120, 191]],
-		["Thorns", "spirit-pixel", [153, 17, 44]]
+		["Thorns", "spirit-pixel", [255, 60, 110]]
 	],
 
 	"weekCharacters": [


### PR DESCRIPTION
this PR fixes the color thing at Monster, Winter Horrorland and Thorns by the characters' icon colors (like #386)

**screenshots:**
![image](https://user-images.githubusercontent.com/72695242/143794514-eef41017-ea9e-474f-9d5f-70f965c29926.png)
![image](https://user-images.githubusercontent.com/72695242/143794555-a9e8bc08-d823-4e90-b741-cd37672ac1c4.png)
![image](https://user-images.githubusercontent.com/72695242/143794567-87922029-d41b-4c01-8150-e11d6dc02314.png)
