### PR TITLE
Swap section note datas

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -824,6 +824,15 @@ class FunkinLua {
 				object.scrollFactor.set(scrollX, scrollY);
 			}
 		});
+
+		Lua_helper.add_callback(lua, "setObjectOrigin", function(obj:String, originX:Float, originY:Float) {
+			if (PlayState.instance.modchartSprites.exists(obj)) {
+				PlayState.instance.modchartSprites.get(obj).origin.set(originX, originY);
+				return;
+			}
+
+			//FlxObject has no field "origin", I think this one is only for the modchartSprites.
+		});
 		Lua_helper.add_callback(lua, "addLuaSprite", function(tag:String, front:Bool = false) {
 			if(PlayState.instance.modchartSprites.exists(tag)) {
 				var shit:ModchartSprite = PlayState.instance.modchartSprites.get(tag);

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -824,15 +824,6 @@ class FunkinLua {
 				object.scrollFactor.set(scrollX, scrollY);
 			}
 		});
-
-		Lua_helper.add_callback(lua, "setObjectOrigin", function(obj:String, originX:Float, originY:Float) {
-			if (PlayState.instance.modchartSprites.exists(obj)) {
-				PlayState.instance.modchartSprites.get(obj).origin.set(originX, originY);
-				return;
-			}
-
-			//FlxObject has no field "origin", I think this one is only for the modchartSprites.
-		});
 		Lua_helper.add_callback(lua, "addLuaSprite", function(tag:String, front:Bool = false) {
 			if(PlayState.instance.modchartSprites.exists(tag)) {
 				var shit:ModchartSprite = PlayState.instance.modchartSprites.get(tag);

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -730,6 +730,36 @@ class ChartingState extends MusicBeatState
 		copyLastButton.setGraphicSize(80, 30);
 		copyLastButton.updateHitbox();
 
+		var invertNotesLeftSide:FlxButton = new FlxButton(10, 330, "Invert notes (left side)", function()
+			{
+				if (_song.notes[curSection].sectionNotes != null) {
+					for (note in _song.notes[curSection].sectionNotes)
+						{
+							if (note[1] < 4 && note[1] > -1) {
+								note[1] = 3 - note[1];
+							}
+						}
+				}
+				updateGrid();
+			});
+		invertNotesLeftSide.setGraphicSize(80, 30);
+		invertNotesLeftSide.updateHitbox();
+
+		var invertNotesRightSide:FlxButton = new FlxButton(110, 330, "Invert notes (right side)", function()
+			{
+				if (_song.notes[curSection].sectionNotes != null) {
+					for (note in _song.notes[curSection].sectionNotes)
+						{
+							if (note[1] > 3) {
+								note[1] = 7 - (note[1] - 4);
+							}
+						}
+				}
+				updateGrid();
+			});
+		invertNotesRightSide.setGraphicSize(80, 30);
+		invertNotesRightSide.updateHitbox();
+
 		tab_group_section.add(stepperLength);
 		tab_group_section.add(stepperSectionBPM);
 		tab_group_section.add(check_mustHitSection);
@@ -742,6 +772,8 @@ class ChartingState extends MusicBeatState
 		tab_group_section.add(swapSection);
 		tab_group_section.add(stepperCopy);
 		tab_group_section.add(copyLastButton);
+		tab_group_section.add(invertNotesLeftSide);
+		tab_group_section.add(invertNotesRightSide);
 
 		UI_box.addGroup(tab_group_section);
 	}


### PR DESCRIPTION
What was added:
### Two buttons to swap notes on both sides of the section.
Each button will invert notedata of a note in the left side (or right side) of the current section. Example:
I have a left note in the left side of the current section. I will click on the "Invert notes (left side)" button and it will become a right note.
Same with the right side.
It does not affect event notes.

Useful if you're charting a song with a lot of random patterns. I don't really know lol.