### PR TITLE
Scroll speed changes

### DIFF
--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -41,7 +41,7 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 	{
 		var option:GameplayOption = new GameplayOption('Scroll Speed', 'scrollspeed', 'float', 1);
 		option.scrollSpeed = 1.5;
-		option.minValue = 0.5;
+		option.minValue = 0;
 		option.maxValue = 3;
 		option.changeValue = 0.1;
 		option.displayFormat = '%vX';
@@ -275,7 +275,9 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 		var val:Dynamic = option.getValue();
 		if(option.type == 'percent') val *= 100;
 		var def:Dynamic = option.defaultValue;
+		
 		option.text = text.replace('%v', val).replace('%d', def);
+		if(option.name == "Scroll Speed" && val == 0.0) option.text = "From chart";
 	}
 
 	function clearHold()

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1645,7 +1645,10 @@ class PlayState extends MusicBeatState
 	private function generateSong(dataPath:String):Void
 	{
 		// FlxG.log.add(ChartParser.parse());
-		songSpeed = SONG.speed * ClientPrefs.getGameplaySetting('scrollspeed', 1);
+		
+		// Use player's chosen speed as the actual scroll speed if higher than absolute zero
+		// not a multiplier for the scroll speed chosen on the chart editor
+		songSpeed = ((ClientPrefs.getGameplaySetting('scrollspeed', 1) > 0) ? ClientPrefs.getGameplaySetting('scrollspeed', 1) : SONG.speed);
 		
 		var songData = SONG;
 		Conductor.changeBPM(songData.bpm);
@@ -2921,7 +2924,8 @@ class PlayState extends MusicBeatState
 				if(Math.isNaN(val1)) val1 = 1;
 				if(Math.isNaN(val2)) val2 = 0;
 
-				var newValue:Float = SONG.speed * ClientPrefs.getGameplaySetting('scrollspeed', 1) * val1;
+				// again, change the scroll speed itself, don't multiply over it
+				var newValue:Float = val1;
 
 				if(val2 <= 0)
 				{
@@ -4083,7 +4087,7 @@ class PlayState extends MusicBeatState
 
 		if (generatedMusic)
 		{
-			notes.sort(FlxSort.byY, ClientPrefs.downScroll ? FlxSort.ASCENDING : FlxSort.DESCENDING);
+			notes.sort(FlxSort.byY, (ClientPrefs.downScroll) ? FlxSort.ASCENDING : FlxSort.DESCENDING);
 		}
 
 		if (SONG.notes[Math.floor(curStep / 16)] != null)

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2924,8 +2924,8 @@ class PlayState extends MusicBeatState
 				if(Math.isNaN(val1)) val1 = 1;
 				if(Math.isNaN(val2)) val2 = 0;
 
-				// again, change the scroll speed itself, don't multiply over it
-				var newValue:Float = val1;
+				// ignore scroll speed changes if the player has a custom scroll speed
+				var newValue:Float = ((ClientPrefs.getGameplaySetting('scrollspeed', 1) > 0) ? ClientPrefs.getGameplaySetting('scrollspeed', 1) : val1);
 
 				if(val2 <= 0)
 				{


### PR DESCRIPTION
Scroll speed is no longer treated as a multiplier for the chart's scroll speed (or scroll speed changes throughout the song). Also, it'll ignore scroll speed changes altogether if the player is using a custom scroll speed.

Also implemented this, where you're still allowed to use the chart's scroll speed along with scroll speed changes just fine if you decrease the scroll speed value to zero.
![Screenshot_1](https://user-images.githubusercontent.com/44783518/146270378-14fb01dc-e0f7-4e57-ba21-562963fabfe3.png)

