### PR TITLE
Add constant scroll speeds

### DIFF
--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -30,6 +30,16 @@ class ClientPrefs {
 	public static var controllerMode:Bool = false;
 	public static var gameplaySettings:Map<String, Dynamic> = [
 		'scrollspeed' => 1.0,
+		'scrolltype' => 'multiplicative', 
+		// anyone reading this, amod is multiplicative speed mod, cmod is constant speed mod, and xmod is bpm based speed mod.
+		// an amod example would be chartSpeed * multiplier
+		// cmod would just be constantSpeed = chartSpeed
+		// and xmod basically works by basing the speed on the bpm.
+		// iirc (beatsPerSecond * (conductorToNoteDifference / 1000)) * noteSize (110 or something like that depending on it, prolly just use note.height)
+		// bps is calculated by bpm / 60
+		// oh yeah and you'd have to actually convert the difference to seconds which I already do, because this is based on beats and stuff. but it should work
+		// just fine. but I wont implement it because I don't know how you handle sustains and other stuff like that.
+		// oh yeah when you calculate the bps divide it by the songSpeed or rate because it wont scroll correctly when speeds exist.
 		'songspeed' => 1.0,
 		'healthgain' => 1.0,
 		'healthloss' => 1.0,

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -39,18 +39,23 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 
 	function getOptions()
 	{
-		var goption:GameplayOption = new GameplayOption('Scroll Type', 'scrolltype', 'string', 1, ["multiplicative", "constant"]);
+		var goption:GameplayOption = new GameplayOption('Scroll Type', 'scrolltype', 'string', 'multiplicative', ["multiplicative", "constant"]);
 		optionsArray.push(goption);
 
 		var option:GameplayOption = new GameplayOption('Scroll Speed', 'scrollspeed', 'float', 1);
 		option.scrollSpeed = 1.5;
 		option.minValue = 0.5;
-		option.maxValue = 3;
 		option.changeValue = 0.1;
 		if (goption.getValue() != "constant")
+		{
 			option.displayFormat = '%vX';
+			option.maxValue = 3;
+		}
 		else
+		{
 			option.displayFormat = "%v";
+			option.maxValue = 6;
+		}
 		optionsArray.push(option);
 
 		/*var option:GameplayOption = new GameplayOption('Playback Rate', 'songspeed', 'float', 1);
@@ -238,9 +243,14 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 											if (curOption.getValue() == "constant")
 											{
 												oOption.displayFormat = "%v";
+												oOption.maxValue = 6;
 											}
 											else
+											{
 												oOption.displayFormat = "%vX";
+												oOption.maxValue = 3;
+												if(oOption.getValue() > 3) oOption.setValue(3);
+											}
 											updateTextFrom(oOption);
 										}
 									}
@@ -286,6 +296,17 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 						if(leOption.type == 'string')
 						{
 							leOption.curOption = leOption.options.indexOf(leOption.getValue());
+						}
+						updateTextFrom(leOption);
+					}
+
+					if(leOption.name == 'Scroll Speed')
+					{
+						leOption.displayFormat = "%vX";
+						leOption.maxValue = 3;
+						if(leOption.getValue() > 3)
+						{
+							leOption.setValue(3);
 						}
 						updateTextFrom(leOption);
 					}

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -229,7 +229,6 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 
 									curOption.curOption = num;
 									curOption.setValue(curOption.options[num]); //lol
-
 									
 									if (curOption.name == "Scroll Type")
 									{

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -39,12 +39,18 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 
 	function getOptions()
 	{
+		var goption:GameplayOption = new GameplayOption('Scroll Type', 'scrolltype', 'string', 1, ["multiplicative", "constant"]);
+		optionsArray.push(goption);
+
 		var option:GameplayOption = new GameplayOption('Scroll Speed', 'scrollspeed', 'float', 1);
 		option.scrollSpeed = 1.5;
 		option.minValue = 0.5;
 		option.maxValue = 3;
 		option.changeValue = 0.1;
-		option.displayFormat = '%vX';
+		if (goption.getValue() != "constant")
+			option.displayFormat = '%vX';
+		else
+			option.displayFormat = "%v";
 		optionsArray.push(option);
 
 		/*var option:GameplayOption = new GameplayOption('Playback Rate', 'songspeed', 'float', 1);
@@ -79,6 +85,17 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 
 		var option:GameplayOption = new GameplayOption('Botplay', 'botplay', 'bool', false);
 		optionsArray.push(option);
+	}
+
+	public function getOptionByName(name:String)
+	{
+		for(i in optionsArray)
+		{
+			var opt:GameplayOption = i;
+			if (opt.name == name)
+				return opt;
+		}
+		return null;
 	}
 
 	public function new()
@@ -212,6 +229,22 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 
 									curOption.curOption = num;
 									curOption.setValue(curOption.options[num]); //lol
+
+									
+									if (curOption.name == "Scroll Type")
+									{
+										var oOption:GameplayOption = getOptionByName("Scroll Speed");
+										if (oOption != null)
+										{
+											if (curOption.getValue() == "constant")
+											{
+												oOption.displayFormat = "%v";
+											}
+											else
+												oOption.displayFormat = "%vX";
+											updateTextFrom(oOption);
+										}
+									}
 									//trace(curOption.options[num]);
 							}
 							updateTextFrom(curOption);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -103,6 +103,7 @@ class PlayState extends MusicBeatState
 
 	public var songSpeedTween:FlxTween;
 	public var songSpeed(default, set):Float = 1;
+	public var songSpeedType:String = "multiplicative";
 	
 	public var boyfriendGroup:FlxSpriteGroup;
 	public var dadGroup:FlxSpriteGroup;
@@ -1659,7 +1660,15 @@ class PlayState extends MusicBeatState
 	private function generateSong(dataPath:String):Void
 	{
 		// FlxG.log.add(ChartParser.parse());
-		songSpeed = SONG.speed * ClientPrefs.getGameplaySetting('scrollspeed', 1);
+		songSpeedType = ClientPrefs.getGameplaySetting('scrolltype','multiplicative');
+
+		switch(songSpeedType)
+		{
+			case "multiplicative":
+				songSpeed = SONG.speed * ClientPrefs.getGameplaySetting('scrollspeed', 1);
+			case "constant":
+				songSpeed = ClientPrefs.getGameplaySetting('scrollspeed', 1);
+		}
 		
 		var songData = SONG;
 		Conductor.changeBPM(songData.bpm);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2937,6 +2937,8 @@ class PlayState extends MusicBeatState
 				if(bgGirls != null) bgGirls.swapDanceType();
 			
 			case 'Change Scroll Speed':
+				if (songSpeedType == "constant")
+					return;
 				var val1:Float = Std.parseFloat(value1);
 				var val2:Float = Std.parseFloat(value2);
 				if(Math.isNaN(val1)) val1 = 1;


### PR DESCRIPTION
This pull request simply adds constant scroll speeds, allowing the user to override the charts scroll speed to anything they'd like.

Or they can switch back to using a multiplier instead.

![image](https://user-images.githubusercontent.com/26305836/147605300-f30350c8-0309-493c-afb8-a9b73716cd7a.png)
![image](https://user-images.githubusercontent.com/26305836/147605306-43e5500a-bf5e-4437-bea2-f70a36ba82cd.png)


All of this is in the gameplay modifiers section of freeplay.

(also shadow I hope we can become friends in the future, i'm sorry for what I said. <3)