### PR TITLE
Fixed scoring and slightly adjusted accuracy

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2176,11 +2176,7 @@ class PlayState extends MusicBeatState
 
 		super.update(elapsed);
 
-		if(ratingName == '?') {
-			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName;
-		} else {
-			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + Highscore.floorDecimal(ratingPercent * 100, 2) + '%)' + ' - ' + ratingFC;//peeps wanted no integer rating
-		}
+		scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + Highscore.floorDecimal(ratingPercent * 100, 2) + '%)' + ratingFC;//peeps wanted no integer rating
 
 		if(botplayTxt.visible) {
 			botplaySine += 180 * elapsed;
@@ -3264,13 +3260,16 @@ class PlayState extends MusicBeatState
 		switch (daRating)
 		{
 			case "shit": // shit
-				totalNotesHit += 0;
+				totalNotesHit += 0.25;
+				score = 50;
 				shits++;
 			case "bad": // bad
 				totalNotesHit += 0.5;
+				score = 150;
 				bads++;
 			case "good": // good
 				totalNotesHit += 0.75;
+				score = 200;
 				goods++;
 			case "sick": // sick
 				totalNotesHit += 1;
@@ -4284,38 +4283,35 @@ class PlayState extends MusicBeatState
 		if(ret != FunkinLua.Function_Stop)
 		{
 			if(totalPlayed < 1) //Prevent divide by 0
-				ratingName = '?';
+				ratingPercent = 1;
 			else
-			{
 				// Rating Percent
 				ratingPercent = Math.min(1, Math.max(0, totalNotesHit / totalPlayed));
-				//trace((totalNotesHit / totalPlayed) + ', Total: ' + totalPlayed + ', notes hit: ' + totalNotesHit);
 
-				// Rating Name
-				if(ratingPercent >= 1)
+			// Rating Name
+			if(ratingPercent >= 1)
+			{
+				ratingName = ratingStuff[ratingStuff.length-1][0]; //Uses last string
+			}
+			else
+			{
+				for (i in 0...ratingStuff.length-1)
 				{
-					ratingName = ratingStuff[ratingStuff.length-1][0]; //Uses last string
-				}
-				else
-				{
-					for (i in 0...ratingStuff.length-1)
+					if(ratingPercent < ratingStuff[i][1])
 					{
-						if(ratingPercent < ratingStuff[i][1])
-						{
-							ratingName = ratingStuff[i][0];
-							break;
-						}
+						ratingName = ratingStuff[i][0];
+						break;
 					}
 				}
 			}
 
 			// Rating FC
 			ratingFC = "";
-			if (sicks > 0) ratingFC = "SFC";
-			if (goods > 0) ratingFC = "GFC";
-			if (bads > 0 || shits > 0) ratingFC = "FC";
-			if (songMisses > 0 && songMisses < 10) ratingFC = "SDCB";
-			else if (songMisses >= 10) ratingFC = "Clear";
+			if (sicks > 0) ratingFC = " - SFC";
+			if (goods > 0) ratingFC = " - GFC";
+			if (bads > 0 || shits > 0) ratingFC = " - FC";
+			if (songMisses > 0 && songMisses < 10) ratingFC = " - SDCB";
+			else if (songMisses >= 10) ratingFC = " - Clear";
 		}
 		setOnLuas('rating', ratingPercent);
 		setOnLuas('ratingName', ratingName);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2176,7 +2176,11 @@ class PlayState extends MusicBeatState
 
 		super.update(elapsed);
 
-		scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + Highscore.floorDecimal(ratingPercent * 100, 2) + '%)' + ratingFC;//peeps wanted no integer rating
+		if(ratingName == '?') {
+			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName;
+		} else {
+			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + Highscore.floorDecimal(ratingPercent * 100, 2) + '%)' + ' - ' + ratingFC;//peeps wanted no integer rating
+		}
 
 		if(botplayTxt.visible) {
 			botplaySine += 180 * elapsed;
@@ -4282,36 +4286,33 @@ class PlayState extends MusicBeatState
 		var ret:Dynamic = callOnLuas('onRecalculateRating', []);
 		if(ret != FunkinLua.Function_Stop)
 		{
-			if(totalPlayed < 1) //Prevent divide by 0
-				ratingPercent = 1;
-			else
+			if(totalPlayed > 0) //Prevent divide by 0
+			{
 				// Rating Percent
 				ratingPercent = Math.min(1, Math.max(0, totalNotesHit / totalPlayed));
 
-			// Rating Name
-			if(ratingPercent >= 1)
-			{
-				ratingName = ratingStuff[ratingStuff.length-1][0]; //Uses last string
-			}
-			else
-			{
-				for (i in 0...ratingStuff.length-1)
+				// Rating Name
+				if(ratingPercent >= 1)
+					ratingName = ratingStuff[ratingStuff.length-1][0]; //Uses last string
+				else
 				{
-					if(ratingPercent < ratingStuff[i][1])
+					for (i in 0...ratingStuff.length-1)
 					{
-						ratingName = ratingStuff[i][0];
-						break;
+						if(ratingPercent < ratingStuff[i][1])
+						{
+							ratingName = ratingStuff[i][0];
+							break;
+						}
 					}
 				}
 			}
-
 			// Rating FC
 			ratingFC = "";
-			if (sicks > 0) ratingFC = " - SFC";
-			if (goods > 0) ratingFC = " - GFC";
-			if (bads > 0 || shits > 0) ratingFC = " - FC";
-			if (songMisses > 0 && songMisses < 10) ratingFC = " - SDCB";
-			else if (songMisses >= 10) ratingFC = " - Clear";
+			if (sicks > 0) ratingFC = "SFC";
+			if (goods > 0) ratingFC = "GFC";
+			if (bads > 0 || shits > 0) ratingFC = "FC";
+			if (songMisses > 0 && songMisses < 10) ratingFC = "SDCB";
+			else if (songMisses >= 10) ratingFC = "Clear";
 		}
 		setOnLuas('rating', ratingPercent);
 		setOnLuas('ratingName', ratingName);


### PR DESCRIPTION
Opening another pull request since #2590 was never reopened

* Fixes an issue where you would always receive `350` score, regardless of your note judgement/rating
* `Shit` rating now adds `0.25` to `totalNotesHit` instead of `0`
* Removed a redundant variable assignment in `RecalcuateRating()` (it's a side effect of a reverted change)