### PR TITLE
Added the ability to change the amount of damage hurt notes deal via an event

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2964,6 +2964,41 @@ class PlayState extends MusicBeatState
 						}
 					});
 				}
+				
+			case 'Change Hurt Amount':
+				var val1:Float = Std.parseFloat(value1);
+				var val2:Float = Std.parseFloat(value2);
+			
+				if(Math.isNaN(val1))
+					val1 = 0.3;
+				else
+					val1 = Math.abs(val1);
+			
+				if(Math.isNaN(val2))
+					val2 = 0.1;
+				else
+					val2 = Math.abs(val2);
+			
+				for (note in notes)
+				{
+					if(note.noteType == "Hurt Note")
+					{
+						if(note.isSustainNote)
+							note.missHealth = val2;
+						else
+							note.missHealth = val1;
+					}
+				}
+				for (note in unspawnNotes)
+				{
+					if(note.noteType == "Hurt Note")
+					{
+						if(note.isSustainNote)
+							note.missHealth = val2;
+						else
+							note.missHealth = val1;                
+					}
+				}
 		}
 		callOnLuas('onEvent', [eventName, value1, value2]);
 	}

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -82,7 +82,8 @@ class ChartingState extends MusicBeatState
 		['Alt Idle Animation', "Sets a specified suffix after the idle animation name.\nYou can use this to trigger 'idle-alt' if you set\nValue 2 to -alt\n\nValue 1: Character to set (Dad, BF or GF)\nValue 2: New suffix (Leave it blank to disable)"],
 		['Screen Shake', "Value 1: Camera shake\nValue 2: HUD shake\n\nEvery value works as the following example: \"1, 0.05\".\nThe first number (1) is the duration.\nThe second number (0.05) is the intensity."],
 		['Change Character', "Value 1: Character to change (Dad, BF, GF)\nValue 2: New character's name"],
-		['Change Scroll Speed', "Value 1: Scroll Speed Multiplier (1 is default)\nValue 2: Time it takes to change fully in seconds."]
+		['Change Scroll Speed', "Value 1: Scroll Speed Multiplier (1 is default)\nValue 2: Time it takes to change fully in seconds."],
+		['Change Hurt Amount', "Changes the amount of damage Hurt Notes deal\nValue 1: Full notes (0.3 is default)\nValue 2: Sustain tail (0.1 is default)"]
 	];
 
 	var _file:FileReference;


### PR DESCRIPTION
I am using this in a mod I am working on and I thought that this may be useful to some.
Essentially, this allows for people to change the amount of damage both the actual hurt note, along with its tail (if it's a sustain note).
Leaving the entries blank reverts the notes back to their default damage.