### PR TITLE
Add a prompt on credits menu to prevent malicious links, and make titlescreen transitioning faster.

### DIFF
--- a/source/CreditsState.hx
+++ b/source/CreditsState.hx
@@ -10,6 +10,7 @@ import flixel.addons.display.FlxGridOverlay;
 import flixel.group.FlxGroup.FlxTypedGroup;
 import flixel.math.FlxMath;
 import flixel.text.FlxText;
+import flixel.ui.FlxButton;
 import flixel.util.FlxColor;
 import flixel.tweens.FlxTween;
 #if MODS_ALLOWED
@@ -22,16 +23,19 @@ using StringTools;
 
 class CreditsState extends MusicBeatState
 {
-	var curSelected:Int = -1;
+	public var curSelected:Int = -1;
+
+	public var warningText:FlxText;
 
 	private var grpOptions:FlxTypedGroup<Alphabet>;
 	private var iconArray:Array<AttachedSprite> = [];
-	private var creditsStuff:Array<Array<String>> = [];
+	public var creditsStuff:Array<Array<String>> = [];
 
 	var bg:FlxSprite;
 	var descText:FlxText;
 	var intendedColor:Int;
 	var colorTween:FlxTween;
+	var isVisible:Bool = false;
 
 	override function create()
 	{
@@ -143,6 +147,9 @@ class CreditsState extends MusicBeatState
 		descText.scrollFactor.set();
 		descText.borderSize = 2.4;
 		add(descText);
+		
+		warningText = new FlxText(0, 0, FlxG.width, "", 48);
+		add(warningText);
 
 		bg.color = getCurrentBGColor();
 		intendedColor = bg.color;
@@ -152,11 +159,23 @@ class CreditsState extends MusicBeatState
 
 	override function update(elapsed:Float)
 	{
+
+		warningText.screenCenter();
+		warningText.text = "WARNING!!!\nYOU ARE ABOUT TO GO TO: \n" + creditsStuff[curSelected][3] + "\nARE YOU ABSOLUTELY SURE YOU WANT TO GO TO THIS URL? \n(Y - Yes, N - No)";
+		warningText.setFormat(Paths.font("vcr.ttf"), 32, FlxColor.WHITE, CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
+		warningText.scrollFactor.set();
+		warningText.borderSize = 2;
+        warningText.visible = false;
+		if (isVisible){
+			warningText.visible = true;
+		}
+
 		if (FlxG.sound.music.volume < 0.7)
 		{
 			FlxG.sound.music.volume += 0.5 * FlxG.elapsed;
 		}
 
+		
 		var upP = controls.UI_UP_P;
 		var downP = controls.UI_DOWN_P;
 
@@ -177,10 +196,19 @@ class CreditsState extends MusicBeatState
 			FlxG.sound.play(Paths.sound('cancelMenu'));
 			MusicBeatState.switchState(new MainMenuState());
 		}
-		if(controls.ACCEPT) {
-			CoolUtil.browserLoad(creditsStuff[curSelected][3]);
+	if(FlxG.keys.pressed.ENTER) {
+		isVisible = true;
+	}
+	if (isVisible) {
+		if(FlxG.keys.pressed.Y){
+		CoolUtil.browserLoad(creditsStuff[curSelected][3]);
+		isVisible = false;
 		}
-		super.update(elapsed);
+		if(FlxG.keys.pressed.N){
+		isVisible = false;
+		}
+	}
+	super.update(elapsed);
 	}
 
 	function changeSelection(change:Int = 0)

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -446,7 +446,7 @@ class TitleState extends MusicBeatState
 				transitioning = true;
 				// FlxG.sound.music.stop();
 
-				new FlxTimer().start(1, function(tmr:FlxTimer)
+				new FlxTimer().start(0.1, function(tmr:FlxTimer)
 				{
 					if (mustUpdate) {
 						MusicBeatState.switchState(new OutdatedState());


### PR DESCRIPTION
### **Summary Of This Pull Request**
Add a prompt on the credits menu showing users the link they are about to visit and the option to opt out if the link looks suspicious. I have also tinkered with the timer in the titlestate to make the transition from titlestate to mainmenu/outdated extremely fast.

### **Why You Should Merge**
Pretty self explanatory, to prevent users with malicious intent on precompiled builds from using the credits menu for malicious purposes, like giving IP grabbers. Also makes titlescreen transitioning very fast.
