### PR TITLE
Lowercase and trim event character values

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2840,7 +2840,7 @@ class PlayState extends MusicBeatState
 
 			case 'Alt Idle Animation':
 				var char:Character = dad;
-				switch(value1.toLowerCase()) {
+				switch(value1.toLowerCase().trim()) {
 					case 'gf' | 'girlfriend':
 						char = gf;
 					case 'boyfriend' | 'bf':
@@ -2877,7 +2877,7 @@ class PlayState extends MusicBeatState
 
 			case 'Change Character':
 				var charType:Int = 0;
-				switch(value1) {
+				switch(value1.toLowerCase().trim()) {
 					case 'gf' | 'girlfriend':
 						charType = 2;
 					case 'dad' | 'opponent':


### PR DESCRIPTION
Formats the 'Alt Idle Animation' and 'Change Character' character type values. Mainly to prevent stuff like #3025, plus other events like 'Hey!' and 'Play Animation' already do it