### PR TITLE
Game-Window movement/positioning for lua

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -110,6 +110,12 @@ class FunkinLua {
 		set('screenWidth', FlxG.width);
 		set('screenHeight', FlxG.height);
 
+		// Window shit
+		set('windowX', PlayState.instance.window.x);
+		set('windowY', PlayState.instance.window.y);
+		set('windowW', PlayState.instance.window.width);
+		set('windowH', PlayState.instance.window.height);
+
 		// PlayState cringe ass nae nae bullcrap
 		set('curBeat', 0);
 		set('curStep', 0);
@@ -1964,6 +1970,12 @@ class FunkinLua {
 
 		Lua.close(lua);
 		lua = null;
+		if (!FlxG.fullscreen) {	
+			PlayState.instance.window.x = PlayState.instance.windowX;
+			PlayState.instance.window.y = PlayState.instance.windowY;
+			PlayState.instance.window.width = PlayState.instance.windowW;
+			PlayState.instance.window.height = PlayState.instance.windowH;
+		}
 		#end
 	}
 

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -1971,8 +1971,8 @@ class FunkinLua {
 		Lua.close(lua);
 		lua = null;
 		if (!FlxG.fullscreen) {	
-			PlayState.instance.window.x = PlayState.instance.windowX;
-			PlayState.instance.window.y = PlayState.instance.windowY;
+			/*PlayState.instance.window.x = PlayState.instance.windowX;
+			PlayState.instance.window.y = PlayState.instance.windowY;*/
 			PlayState.instance.window.width = PlayState.instance.windowW;
 			PlayState.instance.window.height = PlayState.instance.windowH;
 		}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -92,8 +92,8 @@ class PlayState extends MusicBeatState
 	public var camHUDShaders:Array<ShaderEffect> = [];
 	public var camOtherShaders:Array<ShaderEffect> = [];
 	public var window = Lib.application.window;
-	public var windowX:Int = 320;
-	public var windowY:Int = 180;
+	/*public var windowX:Int = 320;
+	public var windowY:Int = 180;*/
 	public var windowW:Int = 1280;
 	public var windowH:Int = 720;
 	//event variables
@@ -1175,8 +1175,8 @@ class PlayState extends MusicBeatState
 		}
 
 		Conductor.safeZoneOffset = (ClientPrefs.safeFrames / 60) * 1000;
-		windowX = window.x;
-		windowY = window.y;
+		/*windowX = window.x;
+		windowY = window.y;*/
 		windowW = window.width;
 		windowH = window.height;
 		callOnLuas('onCreatePost', []);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1175,6 +1175,10 @@ class PlayState extends MusicBeatState
 		}
 
 		Conductor.safeZoneOffset = (ClientPrefs.safeFrames / 60) * 1000;
+		windowX = window.x;
+		windowY = window.y;
+		windowW = window.width;
+		windowH = window.height;
 		callOnLuas('onCreatePost', []);
 		
 		super.create();
@@ -1759,10 +1763,6 @@ class PlayState extends MusicBeatState
 
 	function startSong():Void
 	{
-		windowX = window.x;
-		windowY = window.y;
-		windowW = window.width;
-		windowH = window.height;
 		startingSong = false;
 
 		previousFrameTime = FlxG.game.ticks;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -91,6 +91,11 @@ class PlayState extends MusicBeatState
 	public var camGameShaders:Array<ShaderEffect> = [];
 	public var camHUDShaders:Array<ShaderEffect> = [];
 	public var camOtherShaders:Array<ShaderEffect> = [];
+	public var window = Lib.application.window;
+	public var windowX:Int = 320;
+	public var windowY:Int = 180;
+	public var windowW:Int = 1280;
+	public var windowH:Int = 720;
 	//event variables
 	private var isCameraOnForcedPos:Bool = false;
 	#if (haxe >= "4.0.0")
@@ -1754,6 +1759,10 @@ class PlayState extends MusicBeatState
 
 	function startSong():Void
 	{
+		windowX = window.x;
+		windowY = window.y;
+		windowW = window.width;
+		windowH = window.height;
 		startingSong = false;
 
 		previousFrameTime = FlxG.game.ticks;


### PR DESCRIPTION
Hi I made it possible to move the game-window in lua.
I also made it move to its original x,y,width,height after the song was restarted or exited.

You can move the game-window in Lua by using, for example, this code:
```
function onUpdate()

    songPos = getSongPosition()
    local currentBeat = (songPos/1000)*(bpm/60)
        setProperty('window.x', windowX + math.sin(currentBeat) * 15)--X axis
        setProperty('window.y', windowY + math.cos(currentBeat) * 15)--Y axis
        setProperty('window.width', windowW + math.sin(currentBeat) * 15)--height
        setProperty('window.height', windowH + math.sin(currentBeat) * 15)--height

end
```

[width and height have a huge performance issue when using the game-capture in a video-recording-software, because the window size is being updated in the video-recording-software. Using the screen capture fixes the performance issue.]

### Issue that still needs to be fixed if too bad ###
_the fps display number keeps getting higher when using any width or height movement. The number resets when the game is paused or the song is exited
the fps display number gets a little bit higher when using width or height, but it doesn't keep getting higher._