### PR TITLE
added scaling modes (resolution fix)

### DIFF
--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -29,6 +29,9 @@ class ClientPrefs {
 	public static var healthBarAlpha:Float = 1;
 	public static var controllerMode:Bool = false;
 	public static var screenRes:String = "1280 x 720";
+	public static var screenResTemp:String = "1280 x 720"; // dummy value that isn't saved, used so that if the player cancels instead of hitting space the resolution isn't applied
+	public static var screenScaleMode:String = "Letterbox";
+	public static var screenScaleModeTemp:String = "Letterbox";
 	public static var gameplaySettings:Map<String, Dynamic> = [
 		'scrollspeed' => 1.0,
 		'scrolltype' => 'multiplicative', 
@@ -129,6 +132,7 @@ class ClientPrefs {
 		FlxG.save.data.gameplaySettings = gameplaySettings;
 		FlxG.save.data.controllerMode = controllerMode;
 		FlxG.save.data.screenRes = screenRes;
+		FlxG.save.data.screenScaleMode = screenScaleMode;
 	
 		FlxG.save.flush();
 
@@ -231,6 +235,9 @@ class ClientPrefs {
 		}
 		if(FlxG.save.data.screenRes != null) {
 			screenRes = FlxG.save.data.screenRes;
+		}
+		if(FlxG.save.data.screenScaleMode != null) {
+			screenScaleMode = FlxG.save.data.screenScaleMode;
 		}
 		if(FlxG.save.data.gameplaySettings != null)
 		{

--- a/source/MusicBeatState.hx
+++ b/source/MusicBeatState.hx
@@ -35,19 +35,24 @@ class MusicBeatState extends FlxUIState
 	override function create() {
 		var skip:Bool = FlxTransitionableState.skipNextTransOut;
 		super.create();
-musInstance = this;
+		musInstance = this;
 		// Custom made Trans out
 		
 		modeRatio = new RatioScaleMode();
 		modeStage = new StageSizeScaleMode();
 		
-//	thx Cary for the res code < 333
+		//	thx Cary for the res code < 333
+		// fixAspectRatio();
 		
 		
 		if(!skip) {
 			openSubState(new CustomFadeTransition(1, true));
 		}
 		FlxTransitionableState.skipNextTransOut = false;
+
+		// FlxG.signals.gameResized.add(onGameResized);
+		// this makes the game crash immediately for some reason, i'll try to figure it out later but this would allow
+		// resizing the window and having the aspect ratio update with it
 	}
 	
 	#if (VIDEOS_ALLOWED && windows)
@@ -76,11 +81,17 @@ musInstance = this;
 			stepHit();
 			
 			
-			
+		/*
 		if (FlxG.keys.pressed.ALT && FlxG.keys.justPressed.ENTER){//to disable this fucker
 			FlxG.fullscreen = !FlxG.fullscreen;
 		}
-			
+		*/ // this fucker should remain enabled bruh being able to toggle fullscreen at any point is a good feature
+		   // regardless this is a janky and bad way to do this, like, please don't ever do this
+		   // the visual effect this causes is going to make every person ever think this is a glitch
+
+		if (FlxG.keys.pressed.ALT && FlxG.keys.justPressed.ENTER && FlxG.fullscreen && ClientPrefs.screenScaleMode == "ADAPTIVE") {
+			FlxG.fullscreen = false;
+		} // only disabling this when adaptive is enabled is better as a warning about jankiness is given for adaptive anyways
 			
 
 		super.update(elapsed);
@@ -115,13 +126,13 @@ musInstance = this;
 			leState.openSubState(new CustomFadeTransition(0.7, false));
 			if(nextState == FlxG.state) {
 				CustomFadeTransition.finishCallback = function() {
-					musInstance.onStateSwitch();
+					musInstance.fixAspectRatio();
 					FlxG.resetState();
 				};
 				//trace('resetted');
 			} else {
 				CustomFadeTransition.finishCallback = function() {
-					musInstance.onStateSwitch();
+					musInstance.fixAspectRatio();
 					FlxG.switchState(nextState);
 				};
 				//trace('changed state');
@@ -136,12 +147,22 @@ musInstance = this;
 		MusicBeatState.switchState(FlxG.state);
 	}
 
-	public function onStateSwitch(){
-		
-		options.GraphicsSettingsSubState.onChangeRes();
-		FlxG.scaleMode = modeStage;
+	
+	public function fixAspectRatio() {
+		// options.GraphicsSettingsSubState.onChangeRes();
 
-		if (FlxG.fullscreen)FlxG.scaleMode = modeRatio;
+		if (ClientPrefs.screenScaleMode == "LETTERBOX") {
+			FlxG.scaleMode = new RatioScaleMode (false);
+		} else if (ClientPrefs.screenScaleMode == "PAN") {
+			FlxG.scaleMode = new RatioScaleMode (true);
+		} else if (ClientPrefs.screenScaleMode == "STRETCH") {
+			FlxG.scaleMode = new FillScaleMode ();
+		} else if (ClientPrefs.screenScaleMode == "ADAPTIVE") {
+			FlxG.scaleMode = modeStage;
+		}
+
+		//FlxG.scaleMode = modeStage; // https://coinflipstudios.com/devblog/?p=418#:~:text=StageSizeScaleMode%C2%A0%C2%A0
+		//if (FlxG.fullscreen) FlxG.scaleMode = modeRatio;
 	}
 	public static function getState():MusicBeatState {
 		var curState:Dynamic = FlxG.state;

--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -410,7 +410,7 @@ class TitleState extends MusicBeatState
 			Conductor.songPosition = FlxG.sound.music.time;
 		// FlxG.watch.addQuick('amp', FlxG.sound.music.amplitude);
 
-		if (FlxG.keys.justPressed.F)
+		if (FlxG.keys.justPressed.F && ClientPrefs.screenScaleMode != "ADAPTIVE")
 		{
 			FlxG.fullscreen = !FlxG.fullscreen;
 		}

--- a/source/options/GraphicsSettingsSubState.hx
+++ b/source/options/GraphicsSettingsSubState.hx
@@ -128,7 +128,7 @@ class GraphicsSettingsSubState extends BaseOptionsMenu
 				ClientPrefs.screenRes = ClientPrefs.screenResTemp;
 				if (ClientPrefs.screenRes == "FULLSCREEN" && ClientPrefs.screenScaleMode == "ADAPTIVE") ClientPrefs.screenScaleMode = "LETTERBOX";
 				onChangeRes ();
-				FlxG.resetState ();
+				MusicBeatState.switchState (new options.OptionsState ());
 				FlxG.sound.play(Paths.sound('confirmMenu'));
 			} else if (curOption.name == "Scale Mode")
 			{

--- a/source/options/GraphicsSettingsSubState.hx
+++ b/source/options/GraphicsSettingsSubState.hx
@@ -134,6 +134,7 @@ class GraphicsSettingsSubState extends BaseOptionsMenu
 			{
 				var shouldReset:Bool = ClientPrefs.screenScaleMode == "ADAPTIVE" || ClientPrefs.screenScaleModeTemp == "ADAPTIVE";
 				ClientPrefs.screenScaleMode = ClientPrefs.screenScaleModeTemp;
+				if (ClientPrefs.screenScaleMode == "ADAPTIVE") onChangeRes ();
 				if (shouldReset) MusicBeatState.switchState (new options.OptionsState ());
 				else MusicBeatState.musInstance.fixAspectRatio ();
 				FlxG.sound.play(Paths.sound('confirmMenu'));


### PR DESCRIPTION
sorry i added another one of these, github randomly merged the entirety of my main branch to this one so i had to deal with that first since i don't want to include a bunch of irrelevant shit with my pr

recently an update was pushed that disabled alt+enter in order to allow for adaptive aspect ratios which, i mean, fair at first but StageScaleMode is buggy, it should not be the default and it really should NOT be prioritized over the ability to toggle fullscreen in-game. i added a screen scaling mode option, changed the way the resolution is applied so it's triggered by pressing enter instead of backing out into the main menu, and i made it so you can use alt+enter again unless the player is in adaptive mode which is the mode where alt+enter would cause problems