### PR TITLE
Fix Newgrounds logo antialiasing

### DIFF
--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -375,7 +375,7 @@ class TitleState extends MusicBeatState
 		ngSpr.setGraphicSize(Std.int(ngSpr.width * 0.8));
 		ngSpr.updateHitbox();
 		ngSpr.screenCenter(X);
-		ngSpr.antialiasing = true;
+		ngSpr.antialiasing = ClientPrefs.globalAntialiasing;
 
 		FlxTween.tween(credTextShit, {y: credTextShit.y + 20}, 2.9, {ease: FlxEase.quadInOut, type: PINGPONG});
 


### PR DESCRIPTION
Newgrounds logo is now affected by the player's antialiasing preference.