### PR TITLE
fix assets files search at week editor

### DIFF
--- a/source/editors/WeekEditorState.hx
+++ b/source/editors/WeekEditorState.hx
@@ -320,7 +320,7 @@ class WeekEditorState extends MusicBeatState
 		var isMissing:Bool = true;
 		if(assetName != null && assetName.length > 0) {
 			if( #if MODS_ALLOWED FileSystem.exists(Paths.modsImages('menubackgrounds/menu_' + assetName)) || #end
-			Assets.exists(Paths.getPath('images/menubackgrounds/menu_' + assetName, IMAGE), IMAGE)) {
+			Assets.exists(Paths.getPath('images/menubackgrounds/menu_' + assetName + '.png', IMAGE), IMAGE)) {
 				bgSprite.loadGraphic(Paths.image('menubackgrounds/menu_' + assetName));
 				isMissing = false;
 			}
@@ -339,7 +339,7 @@ class WeekEditorState extends MusicBeatState
 		var isMissing:Bool = true;
 		if(assetName != null && assetName.length > 0) {
 			if( #if MODS_ALLOWED FileSystem.exists(Paths.modsImages('storymenu/' + assetName)) || #end
-			Assets.exists(Paths.getPath('images/storymenu/' + assetName, IMAGE), IMAGE)) {
+			Assets.exists(Paths.getPath('images/storymenu/' + assetName + '.png', IMAGE), IMAGE)) {
 				weekThing.loadGraphic(Paths.image('storymenu/' + assetName));
 				isMissing = false;
 			}


### PR DESCRIPTION
i made a bug issue (#3369) that shows the week editor not loading automatically the week and stage bg image assets
i promised that i would make a PR to fix this, and here it is

actually, the error was that the week and bg images was just loading when u write a ".png" after the file name, but the preset was not with this
so, this PR fixes this, now, u don't need to write ".png" after the file's name

small PR? Yes, but it fixes something