### PR TITLE
Gamewindow Movement via lua

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -114,6 +114,12 @@ class FunkinLua {
 		set('screenWidth', FlxG.width);
 		set('screenHeight', FlxG.height);
 
+		// Window shit
+		set('windowX', PlayState.instance.window.x);
+		set('windowY', PlayState.instance.window.y);
+		set('windowW', PlayState.instance.window.width);
+		set('windowH', PlayState.instance.window.height);
+
 		// PlayState cringe ass nae nae bullcrap
 		set('curBeat', 0);
 		set('curStep', 0);
@@ -1968,6 +1974,12 @@ class FunkinLua {
 
 		Lua.close(lua);
 		lua = null;
+		if (!FlxG.fullscreen) {	
+			//PlayState.instance.window.x = PlayState.instance.windowX;
+			//PlayState.instance.window.y = PlayState.instance.windowY;
+			PlayState.instance.window.width = PlayState.instance.windowW;
+			PlayState.instance.window.height = PlayState.instance.windowH;
+		}
 		#end
 	}
 

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -91,6 +91,11 @@ class PlayState extends MusicBeatState
 	public var camGameShaders:Array<ShaderEffect> = [];
 	public var camHUDShaders:Array<ShaderEffect> = [];
 	public var camOtherShaders:Array<ShaderEffect> = [];
+	public var window = Lib.application.window;
+	public var windowX:Int = 320;
+	public var windowY:Int = 180;
+	public var windowW:Int = 1280;
+	public var windowH:Int = 720;
 	//event variables
 	private var isCameraOnForcedPos:Bool = false;
 	#if (haxe >= "4.0.0")
@@ -1762,6 +1767,10 @@ class PlayState extends MusicBeatState
 
 	function startSong():Void
 	{
+		windowX = window.x;
+		windowY = window.y;
+		windowW = window.width;
+		windowH = window.height;
 		startingSong = false;
 
 		previousFrameTime = FlxG.game.ticks;


### PR DESCRIPTION
Hi I made it possible to move the game-window in lua.
I also made it move to its original width,height (x,y can be enabled if wanted) after the song was restarted or exited.
The movement only works in window mode, so not in fullscreen

You can move the game-window in Lua by using, for example, this code:

```
function onUpdate()

    songPos = getSongPosition()
    local currentBeat = (songPos/1000)*(bpm/60)
        setProperty('window.x', windowX + math.sin(currentBeat) * 15)--X axis
        setProperty('window.y', windowY + math.cos(currentBeat) * 15)--Y axis
        setProperty('window.width', windowW + math.sin(currentBeat) * 15)--height
        setProperty('window.height', windowH + math.sin(currentBeat) * 15)--height

end
```
[width and height have a huge performance issue when using the game-capture in a video-recording-software, because the window size is being updated in the video-recording-software. Using the screen capture fixes the performance issue.]

### Issue that still needs to be fixed if too bad ###

the fps display number keeps getting higher when using any width or height movement. The number resets when the game is paused or the song is exited
the fps display number gets a little bit higher when using width or height, but it doesn't keep getting higher.