### PR TITLE
BPMs in chart editor are no longer capped at 339

### DIFF
--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -463,7 +463,7 @@ class ChartingState extends MusicBeatState
 		clear_notes.color = FlxColor.RED;
 		clear_notes.label.color = FlxColor.WHITE;
 
-		var stepperBPM:FlxUINumericStepper = new FlxUINumericStepper(10, 70, 1, 1, 1, 339, 1);
+		var stepperBPM:FlxUINumericStepper = new FlxUINumericStepper(10, 70, 1, 1, 1, 1000, 1);
 		stepperBPM.value = Conductor.bpm;
 		stepperBPM.name = 'song_bpm';
 		blockPressWhileTypingOnStepper.push(stepperBPM);


### PR DESCRIPTION
removed completely arbitrary limitation. now you can make songs up to 1000 bpm which is way more than youd ever need so enjoy