### PR TITLE
Adding drag and drop for character editor

### DIFF
--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -154,7 +154,9 @@ class CharacterEditorState extends MusicBeatState
 			\nArrow Keys - Move Character Offset
 			\nR - Reset Current Offset
 			\nHold Shift to Move 10x faster
-			\n", 12);
+			", 12);
+			/*\nOptionally: Drag and drop to move animation
+			\nShift to drag the entire character*/
 		tipText.cameras = [camHUD];
 		tipText.setFormat(null, 12, FlxColor.WHITE, CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		tipText.scrollFactor.set();
@@ -1208,15 +1210,27 @@ class CharacterEditorState extends MusicBeatState
 						else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
 						{
 							// If you click during the transition, this sometimes crashes cause 
-							// Null object error
+							// Null object error, because the character won't be loaded
 							var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
 							var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
+							// Moves the entire character
+							if(FlxG.keys.pressed.SHIFT)
+							{
+								positionXStepper.value += xDiff;
+								positionYStepper.value += yDiff;
+								getEvent(FlxUINumericStepper.CHANGE_EVENT,positionXStepper,null);
+								getEvent(FlxUINumericStepper.CHANGE_EVENT,positionYStepper,null);
+							}
+							// Moves the animation
+							else
+							{
+								char.animationsArray[curAnim].offsets[0] -= xDiff;
+								char.animationsArray[curAnim].offsets[1] -= yDiff;
+								char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+								ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+								
 
-							char.animationsArray[curAnim].offsets[0] -= xDiff;
-							char.animationsArray[curAnim].offsets[1] -= yDiff;
-							char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-							ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-							
+							}
 							char.playAnim(char.animationsArray[curAnim].anim, false);
 							if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
 								ghostChar.playAnim(char.animation.curAnim.name, false);

--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -33,6 +33,7 @@ import Character;
 import flixel.system.debug.interaction.tools.Pointer.GraphicCursorCross;
 import lime.system.Clipboard;
 import flixel.animation.FlxAnimation;
+import flixel.math.FlxPoint;
 
 #if MODS_ALLOWED
 import sys.FileSystem;
@@ -77,6 +78,9 @@ class CharacterEditorState extends MusicBeatState
 
 	var cameraFollowPointer:FlxSprite;
 	var healthBarBG:FlxSprite;
+
+	// The begining mouse location that all drag movements are in reference of
+	private var mouseLocation:FlxPoint;
 
 	override function create()
 	{
@@ -1079,6 +1083,7 @@ class CharacterEditorState extends MusicBeatState
 		#end
 	}
 
+	
 	override function update(elapsed:Float)
 	{
 		if(char.animationsArray[curAnim] != null) {
@@ -1188,10 +1193,34 @@ class CharacterEditorState extends MusicBeatState
 					genBoyOffsets();
 				}
 
-				var controlArray:Array<Bool> = [FlxG.keys.justPressed.LEFT, FlxG.keys.justPressed.RIGHT, FlxG.keys.justPressed.UP, FlxG.keys.justPressed.DOWN];
+				if(true)
+				{
+					var mouseLoc = FlxG.mouse.getPosition();
+					if(FlxG.mouse.justPressed)
+					{
+						mouseLocation = mouseLoc;
+					}
+					else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
+					{
+						var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
+						var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
+
+						char.animationsArray[curAnim].offsets[0] -= xDiff;
+						char.animationsArray[curAnim].offsets[1] -= yDiff;
+						char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+						ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+						
+						char.playAnim(char.animationsArray[curAnim].anim, false);
+						if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
+							ghostChar.playAnim(char.animation.curAnim.name, false);
+						}
+						genBoyOffsets();
+						mouseLocation = mouseLoc;
+					}
+				}
+
 				
-				
-				
+				var controlArray:Array<Bool> = [FlxG.keys.justPressed.LEFT, FlxG.keys.justPressed.RIGHT, FlxG.keys.justPressed.UP, FlxG.keys.justPressed.DOWN];				
 				for (i in 0...controlArray.length) {
 					if(controlArray[i]) {
 						var holdShift = FlxG.keys.pressed.SHIFT;

--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -1194,31 +1194,41 @@ class CharacterEditorState extends MusicBeatState
 					genBoyOffsets();
 				}
 
-
+				// Drag and Drop is active when clicking over anything except for the UI boxes.
 				var mouseLoc = FlxG.mouse.getPosition();
-				if(!FlxG.mouse.overlaps(UI_box) && !FlxG.mouse.overlaps(UI_characterbox))
+				// Refer to 1210
+				try
 				{
-					if(FlxG.mouse.justPressed)
+					if(!FlxG.mouse.overlaps(UI_box) && !FlxG.mouse.overlaps(UI_characterbox))
 					{
-						mouseLocation = mouseLoc;
-					}
-					else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
-					{
-						var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
-						var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
-
-						char.animationsArray[curAnim].offsets[0] -= xDiff;
-						char.animationsArray[curAnim].offsets[1] -= yDiff;
-						char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-						ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-						
-						char.playAnim(char.animationsArray[curAnim].anim, false);
-						if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
-							ghostChar.playAnim(char.animation.curAnim.name, false);
+						if(FlxG.mouse.justPressed)
+						{
+							mouseLocation = mouseLoc;
 						}
-						genBoyOffsets();
-						mouseLocation = mouseLoc;
+						else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
+						{
+							// If you click during the transition, this sometimes crashes cause 
+							// Null object error
+							var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
+							var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
+
+							char.animationsArray[curAnim].offsets[0] -= xDiff;
+							char.animationsArray[curAnim].offsets[1] -= yDiff;
+							char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+							ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+							
+							char.playAnim(char.animationsArray[curAnim].anim, false);
+							if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
+								ghostChar.playAnim(char.animation.curAnim.name, false);
+							}
+							genBoyOffsets();
+							mouseLocation = mouseLoc;
+						}
 					}
+				}
+				catch(e)
+				{
+					trace("Temporary error caught");
 				}
 				
 				var controlArray:Array<Bool> = [FlxG.keys.justPressed.LEFT, FlxG.keys.justPressed.RIGHT, FlxG.keys.justPressed.UP, FlxG.keys.justPressed.DOWN];				

--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -1193,30 +1193,28 @@ class CharacterEditorState extends MusicBeatState
 					genBoyOffsets();
 				}
 
-				if(true)
-				{
-					var mouseLoc = FlxG.mouse.getPosition();
-					if(FlxG.mouse.justPressed)
-					{
-						mouseLocation = mouseLoc;
-					}
-					else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
-					{
-						var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
-						var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
 
-						char.animationsArray[curAnim].offsets[0] -= xDiff;
-						char.animationsArray[curAnim].offsets[1] -= yDiff;
-						char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-						ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-						
-						char.playAnim(char.animationsArray[curAnim].anim, false);
-						if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
-							ghostChar.playAnim(char.animation.curAnim.name, false);
-						}
-						genBoyOffsets();
-						mouseLocation = mouseLoc;
+				var mouseLoc = FlxG.mouse.getPosition();
+				if(FlxG.mouse.justPressed)
+				{
+					mouseLocation = mouseLoc;
+				}
+				else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
+				{
+					var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
+					var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
+
+					char.animationsArray[curAnim].offsets[0] -= xDiff;
+					char.animationsArray[curAnim].offsets[1] -= yDiff;
+					char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+					ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+					
+					char.playAnim(char.animationsArray[curAnim].anim, false);
+					if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
+						ghostChar.playAnim(char.animation.curAnim.name, false);
 					}
+					genBoyOffsets();
+					mouseLocation = mouseLoc;
 				}
 
 				

--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -64,7 +64,7 @@ class CharacterEditorState extends MusicBeatState
 		this.daAnim = daAnim;
 		this.goToPlayState = goToPlayState;
 	}
-
+	
 	var UI_box:FlxUITabMenu;
 	var UI_characterbox:FlxUITabMenu;
 
@@ -153,7 +153,8 @@ class CharacterEditorState extends MusicBeatState
 			\nSpace - Play Animation
 			\nArrow Keys - Move Character Offset
 			\nR - Reset Current Offset
-			\nHold Shift to Move 10x faster\n", 12);
+			\nHold Shift to Move 10x faster
+			\n", 12);
 		tipText.cameras = [camHUD];
 		tipText.setFormat(null, 12, FlxColor.WHITE, CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		tipText.scrollFactor.set();
@@ -1195,28 +1196,30 @@ class CharacterEditorState extends MusicBeatState
 
 
 				var mouseLoc = FlxG.mouse.getPosition();
-				if(FlxG.mouse.justPressed)
+				if(!FlxG.mouse.overlaps(UI_box) && !FlxG.mouse.overlaps(UI_characterbox))
 				{
-					mouseLocation = mouseLoc;
-				}
-				else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
-				{
-					var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
-					var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
-
-					char.animationsArray[curAnim].offsets[0] -= xDiff;
-					char.animationsArray[curAnim].offsets[1] -= yDiff;
-					char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-					ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
-					
-					char.playAnim(char.animationsArray[curAnim].anim, false);
-					if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
-						ghostChar.playAnim(char.animation.curAnim.name, false);
+					if(FlxG.mouse.justPressed)
+					{
+						mouseLocation = mouseLoc;
 					}
-					genBoyOffsets();
-					mouseLocation = mouseLoc;
-				}
+					else if(FlxG.mouse.pressed && FlxG.mouse.justMoved)
+					{
+						var xDiff:Int = Std.int(mouseLoc.x - mouseLocation.x);
+						var yDiff:Int = Std.int(mouseLoc.y - mouseLocation.y);
 
+						char.animationsArray[curAnim].offsets[0] -= xDiff;
+						char.animationsArray[curAnim].offsets[1] -= yDiff;
+						char.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+						ghostChar.addOffset(char.animationsArray[curAnim].anim, char.animationsArray[curAnim].offsets[0], char.animationsArray[curAnim].offsets[1]);
+						
+						char.playAnim(char.animationsArray[curAnim].anim, false);
+						if(ghostChar.animation.curAnim != null && char.animation.curAnim != null && char.animation.curAnim.name == ghostChar.animation.curAnim.name) {
+							ghostChar.playAnim(char.animation.curAnim.name, false);
+						}
+						genBoyOffsets();
+						mouseLocation = mouseLoc;
+					}
+				}
 				
 				var controlArray:Array<Bool> = [FlxG.keys.justPressed.LEFT, FlxG.keys.justPressed.RIGHT, FlxG.keys.justPressed.UP, FlxG.keys.justPressed.DOWN];				
 				for (i in 0...controlArray.length) {

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -776,6 +776,7 @@ class ChartingState extends MusicBeatState
 			{
 				var strum = note[0] + Conductor.stepCrochet * (_song.notes[daSec].lengthInSteps * value);
 
+				
 				var copiedNote:Array<Dynamic> = [strum, note[1], note[2], note[3]];
 				_song.notes[daSec].sectionNotes.push(copiedNote);
 			}
@@ -799,6 +800,50 @@ class ChartingState extends MusicBeatState
 			}
 			updateGrid();
 		});
+		var duetButton:FlxButton = new FlxButton(10, 320, "Duet Notes", function()
+		{
+			var duetNotes:Array<Array<Dynamic>> = [];
+			for (note in _song.notes[curSection].sectionNotes)
+			{
+				var boob = note[1];
+				if (boob>3){
+					boob -= 4;
+				}else{
+					boob += 4;
+				}
+				
+				var copiedNote:Array<Dynamic> = [note[0], boob, note[2], note[3]];
+				duetNotes.push(copiedNote);
+			}
+			
+			for (i in duetNotes){
+			_song.notes[curSection].sectionNotes.push(i);
+				
+			}
+			
+			updateGrid();
+		});
+		var mirrorButton:FlxButton = new FlxButton(10, 350, "Mirror Notes", function()
+		{
+			var duetNotes:Array<Array<Dynamic>> = [];
+			for (note in _song.notes[curSection].sectionNotes)
+			{
+				var boob = note[1]%4;
+				boob = 3 - boob;
+				if (note[1] > 3) boob += 4;
+				
+				note[1] = boob;
+				var copiedNote:Array<Dynamic> = [note[0], boob, note[2], note[3]];
+				//duetNotes.push(copiedNote);
+			}
+			
+			for (i in duetNotes){
+			//_song.notes[curSection].sectionNotes.push(i);
+				
+			}
+			
+			updateGrid();
+		});
 		copyLastButton.setGraphicSize(80, 30);
 		copyLastButton.updateHitbox();
 
@@ -814,6 +859,8 @@ class ChartingState extends MusicBeatState
 		tab_group_section.add(swapSection);
 		tab_group_section.add(stepperCopy);
 		tab_group_section.add(copyLastButton);
+		tab_group_section.add(duetButton);
+		tab_group_section.add(mirrorButton);
 
 		UI_box.addGroup(tab_group_section);
 	}


### PR DESCRIPTION
Since FlxG.mouse.overlap() does not take into consideration of offsets, it could not be used to make drag and drop only occur when you click on the character. 
So Instead, drag and drop occurs at all times when you click on anything and move the mouse, except when the mouse is over a UI box. This is to prevent accidental drag and drop when clicking on a drop-down menu. 
resolves #3053 