### PR TITLE
Add option to toggle HaxeFlixel's autopause

### DIFF
--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -31,6 +31,7 @@ class ClientPrefs {
 	public static var controllerMode:Bool = false;
 	public static var hitsoundVolume:Float = 0;
 	public static var pauseMusic:String = 'Tea Time';
+	public static var autoPause:Bool = true;
 	public static var gameplaySettings:Map<String, Dynamic> = [
 		'scrollspeed' => 1.0,
 		'scrolltype' => 'multiplicative', 
@@ -126,6 +127,7 @@ class ClientPrefs {
 		FlxG.save.data.controllerMode = controllerMode;
 		FlxG.save.data.hitsoundVolume = hitsoundVolume;
 		FlxG.save.data.pauseMusic = pauseMusic;
+		FlxG.save.data.autoPause = autoPause;
 	
 		FlxG.save.flush();
 
@@ -234,6 +236,10 @@ class ClientPrefs {
 		}
 		if(FlxG.save.data.pauseMusic != null) {
 			pauseMusic = FlxG.save.data.pauseMusic;
+		}
+		if(FlxG.save.data.autoPause != null) {
+			autoPause = FlxG.save.data.autoPause;
+			FlxG.autoPause = autoPause;
 		}
 		if(FlxG.save.data.gameplaySettings != null)
 		{

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -85,7 +85,6 @@ class Main extends Sprite
 		#end
 
 		#if html5
-		FlxG.autoPause = false;
 		FlxG.mouse.visible = false;
 		#end
 	}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2632,7 +2632,7 @@ class PlayState extends MusicBeatState
 	override public function onFocusLost():Void
 	{
 		#if desktop
-		if (health > 0 && !paused)
+		if (health > 0 && !paused && FlxG.autoPause)
 		{
 			DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
 		}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2638,7 +2638,7 @@ class PlayState extends MusicBeatState
 		}
 		#end
 
-		if (!FlxG.autoPause && !paused && canPause)
+		if (!FlxG.autoPause && !paused && canPause && !cpuControlled)
 		{
 			pauseState();
 		}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2638,6 +2638,11 @@ class PlayState extends MusicBeatState
 		}
 		#end
 
+		if (!FlxG.autoPause && !paused && canPause)
+		{
+			pauseState();
+		}
+
 		super.onFocusLost();
 	}
 
@@ -2823,31 +2828,7 @@ class PlayState extends MusicBeatState
 
 		if (controls.PAUSE && startedCountdown && canPause)
 		{
-			var ret:Dynamic = callOnLuas('onPause', []);
-			if(ret != FunkinLua.Function_Stop) {
-				persistentUpdate = false;
-				persistentDraw = true;
-				paused = true;
-
-				// 1 / 1000 chance for Gitaroo Man easter egg
-				/*if (FlxG.random.bool(0.1))
-				{
-					// gitaroo man easter egg
-					cancelMusicFadeTween();
-					MusicBeatState.switchState(new GitarooPause());
-				}
-				else {*/
-				if(FlxG.sound.music != null) {
-					FlxG.sound.music.pause();
-					vocals.pause();
-				}
-				openSubState(new PauseSubState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
-				//}
-
-				#if desktop
-				DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
-				#end
-			}
+			pauseState();
 		}
 
 		if (FlxG.keys.anyJustPressed(debugKeysChart) && !endingSong && !inCutscene)
@@ -3121,6 +3102,35 @@ class PlayState extends MusicBeatState
 		setOnLuas('cameraY', camFollowPos.y);
 		setOnLuas('botPlay', cpuControlled);
 		callOnLuas('onUpdatePost', [elapsed]);
+	}
+
+	function pauseState()
+	{
+		var ret:Dynamic = callOnLuas('onPause', []);
+		if(ret != FunkinLua.Function_Stop) {
+			persistentUpdate = false;
+			persistentDraw = true;
+			paused = true;
+
+			// 1 / 1000 chance for Gitaroo Man easter egg
+			/*if (FlxG.random.bool(0.1))
+			{
+				// gitaroo man easter egg
+				cancelMusicFadeTween();
+				MusicBeatState.switchState(new GitarooPause());
+			}
+			else {*/
+			if(FlxG.sound.music != null) {
+				FlxG.sound.music.pause();
+				vocals.pause();
+			}
+			openSubState(new PauseSubState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
+			//}
+
+			#if desktop
+			DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
+			#end
+		}
 	}
 
 	function openChartEditor()

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2638,7 +2638,7 @@ class PlayState extends MusicBeatState
 		}
 		#end
 
-		if (!FlxG.autoPause && !paused && canPause && !cpuControlled)
+		if (!FlxG.autoPause && !paused && canPause && startedCountdown && !cpuControlled)
 		{
 			pauseState();
 		}

--- a/source/options/VisualsUISubState.hx
+++ b/source/options/VisualsUISubState.hx
@@ -98,6 +98,14 @@ class VisualsUISubState extends BaseOptionsMenu
 		addOption(option);
 		option.onChange = onChangeFPSCounter;
 		#end
+
+		var option:Option = new Option('Auto Pause',
+			'If checked, pauses the game when unfocused.',
+			'autoPause',
+			'bool',
+			true);
+		option.onChange = onChangeAutoPause;
+		addOption(option);
 		
 		var option:Option = new Option('Pause Screen Song:',
 			"What song do you prefer for the Pause Screen?",
@@ -107,14 +115,6 @@ class VisualsUISubState extends BaseOptionsMenu
 			['None', 'Breakfast', 'Tea Time']);
 		addOption(option);
 		option.onChange = onChangePauseMusic;
-
-		var option:Option = new Option('Auto Pause',
-			'If checked, pauses the game when unfocused.',
-			'autoPause',
-			'bool',
-			true);
-		option.onChange = onChangeAutoPause;
-		addOption(option);
 
 		super();
 	}

--- a/source/options/VisualsUISubState.hx
+++ b/source/options/VisualsUISubState.hx
@@ -108,6 +108,14 @@ class VisualsUISubState extends BaseOptionsMenu
 		addOption(option);
 		option.onChange = onChangePauseMusic;
 
+		var option:Option = new Option('Auto Pause',
+			'If checked, pauses the game when unfocused.',
+			'autoPause',
+			'bool',
+			true);
+		option.onChange = onChangeAutoPause;
+		addOption(option);
+
 		super();
 	}
 
@@ -135,4 +143,9 @@ class VisualsUISubState extends BaseOptionsMenu
 			Main.fpsVar.visible = ClientPrefs.showFPS;
 	}
 	#end
+
+	function onChangeAutoPause()
+	{
+		FlxG.autoPause = ClientPrefs.autoPause;
+	}
 }


### PR DESCRIPTION
Normally enabled by default (disabled for HTML5 compilation), this is now an option that anyone can toggle on or off.

If auto pause is enabled (default), HaxeFlixel will automatically pause the game when it loses focus.
If auto pause is disabled, HaxeFlixel will no longer automatically pause the game when it loses focus.

https://user-images.githubusercontent.com/15317421/152661143-574510a8-c275-4af4-81dc-a88ffd7b4f21.mp4

However if it's disabled, the game itself will automatically pause during a song to prevent the user from accidently clicking off and missing notes. This functionality is ignored if Botplay is enabled, so that people can record mod footage in the background.

Enabled:

https://user-images.githubusercontent.com/15317421/152661135-0c206b71-a565-488b-ae1a-5ed6dff48280.mp4

Disabled:

https://user-images.githubusercontent.com/15317421/152661137-3f5f0cb1-ee03-4b5d-8a6f-803f0701abb7.mp4