### PR TITLE
added option to disable autopause

### DIFF
--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -10,6 +10,9 @@ class ClientPrefs {
 	public static var downScroll:Bool = false;
 	public static var middleScroll:Bool = false;
 	public static var showFPS:Bool = true;
+	#if desktop
+	public static var autoPause:Bool = true;
+	#end
 	public static var flashing:Bool = true;
 	public static var globalAntialiasing:Bool = true;
 	public static var noteSplashes:Bool = true;
@@ -92,6 +95,9 @@ class ClientPrefs {
 		FlxG.save.data.downScroll = downScroll;
 		FlxG.save.data.middleScroll = middleScroll;
 		FlxG.save.data.showFPS = showFPS;
+		#if desktop
+		FlxG.save.data.autoPause = autoPause;
+		#end
 		FlxG.save.data.flashing = flashing;
 		FlxG.save.data.globalAntialiasing = globalAntialiasing;
 		FlxG.save.data.noteSplashes = noteSplashes;
@@ -143,6 +149,11 @@ class ClientPrefs {
 				Main.fpsVar.visible = showFPS;
 			}
 		}
+		#if desktop
+		if(FlxG.save.data.autoPause != null) {
+			autoPause = FlxG.save.data.autoPause;
+		}
+		#end
 		if(FlxG.save.data.flashing != null) {
 			flashing = FlxG.save.data.flashing;
 		}

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -87,6 +87,10 @@ class Main extends Sprite
 		}
 		#end
 
+		#if desktop
+		FlxG.autoPause = ClientPrefs.autoPause;
+		#end
+
 		#if html5
 		FlxG.autoPause = false;
 		FlxG.mouse.visible = false;

--- a/source/options/GameplaySettingsSubState.hx
+++ b/source/options/GameplaySettingsSubState.hx
@@ -63,6 +63,17 @@ class GameplaySettingsSubState extends BaseOptionsMenu
 			true);
 		addOption(option);
 
+		#if desktop
+		var option:Option = new Option('Auto Pause',
+			"If checked, the game will automatically freeze itself when not in focus.",
+			'autoPause',
+			'bool',
+			true);
+		addOption(option);
+
+		option.onChange = onToggleAutoPause;
+		#end
+
 		var option:Option = new Option('Disable Reset Button',
 			"If checked, pressing Reset won't do anything.",
 			'noReset',
@@ -138,4 +149,11 @@ class GameplaySettingsSubState extends BaseOptionsMenu
 
 		super();
 	}
+
+	#if desktop
+	function onToggleAutoPause ()
+	{
+		FlxG.autoPause = ClientPrefs.autoPause;
+	}
+	#end
 }


### PR DESCRIPTION
there are several mods i know that have excessively long intros to songs or drawn out unskippable cutscenes and being forced to sit through them in their entirety without even being able to touch anything else is kinda annoying. since i usually pause before alt+tabbing anyways having the option to toggle off the autopause is a nice feature