### PR TITLE
Add the ability to make backdrops via Lua

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -1366,10 +1366,10 @@ class FunkinLua {
 			PlayState.instance.modchartSprites.set(tag, leSprite);
 		});
 
-		Lua_helper.add_callback(lua, "makeLuaBackdrop", function(tag:String, image:String, x:Float, y:Float, ?repeatX:Bool = true, ?repeatY:Bool = true) {
+		Lua_helper.add_callback(lua, "makeLuaBackdrop", function(tag:String, image:String, x:Float, y:Float) {
 			tag = tag.replace('.', '');
 			resetBackdropTag(tag);
-			var leSprite:ModchartBackdrop = new ModchartBackdrop(x, y, repeatX, repeatY);
+			var leSprite:ModchartBackdrop = new ModchartBackdrop(x, y);
 			if(image != null && image.length > 0)
 			{
 				leSprite.loadGraphic(Paths.image(image));

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -84,6 +84,7 @@ class PlayState extends MusicBeatState
 	];
 	public var modchartTweens:Map<String, FlxTween> = new Map<String, FlxTween>();
 	public var modchartSprites:Map<String, ModchartSprite> = new Map<String, ModchartSprite>();
+	public var modchartBackdrops:Map<String, ModchartBackdrop> = new Map<String, ModchartBackdrop>();
 	public var modchartTimers:Map<String, FlxTimer> = new Map<String, FlxTimer>();
 	public var modchartSounds:Map<String, FlxSound> = new Map<String, FlxSound>();
 	public var modchartTexts:Map<String, ModchartText> = new Map<String, ModchartText>();

--- a/source/flixel/addons/display/FlxBackdrop.hx
+++ b/source/flixel/addons/display/FlxBackdrop.hx
@@ -1,0 +1,325 @@
+package flixel.addons.display;
+
+import flash.display.BitmapData;
+import flash.geom.Point;
+import flash.geom.Rectangle;
+import flixel.FlxG;
+import flixel.FlxSprite;
+import flixel.graphics.FlxGraphic;
+import flixel.graphics.frames.FlxFrame;
+import flixel.graphics.tile.FlxDrawTilesItem;
+import flixel.math.FlxPoint;
+import flixel.math.FlxPoint.FlxCallbackPoint;
+import flixel.system.FlxAssets.FlxGraphicAsset;
+import flixel.util.FlxColor;
+import flixel.util.FlxDestroyUtil;
+
+using flixel.util.FlxColorTransformUtil;
+
+/**
+ * Used for showing infinitely scrolling backgrounds.
+ * @author Chevy Ray
+ */
+class FlxBackdrop extends FlxSprite
+{
+	var _ppoint:Point;
+	var _scrollW:Int = 0;
+	var _scrollH:Int = 0;
+	var _repeatX:Bool = false;
+	var _repeatY:Bool = false;
+
+	var _spaceX:Int = 0;
+	var _spaceY:Int = 0;
+
+	/**
+	 * Frame used for tiling
+	 */
+	var _tileFrame:FlxFrame;
+
+	var _tileInfo:Array<Float>;
+	var _numTiles:Int = 0;
+
+	// TODO: remove this hack and add docs about how to avoid tearing problem by preparing assets and some code...
+
+	/**
+	 * Try to eliminate 1 px gap between tiles in tile render mode by increasing tile scale,
+	 * so the tile will look one pixel wider than it is.
+	 */
+	public var useScaleHack:Bool = true;
+
+	/**
+	 * Creates an instance of the FlxBackdrop class, used to create infinitely scrolling backgrounds.
+	 *
+	 * @param   Graphic		The image you want to use for the backdrop.
+	 * @param   ScrollX 	Scrollrate on the X axis.
+	 * @param   ScrollY 	Scrollrate on the Y axis.
+	 * @param   RepeatX 	If the backdrop should repeat on the X axis.
+	 * @param   RepeatY 	If the backdrop should repeat on the Y axis.
+	 * @param	SpaceX		Amount of spacing between tiles on the X axis
+	 * @param	SpaceY		Amount of spacing between tiles on the Y axis
+	 */
+	public function new(?Graphic:FlxGraphicAsset, ScrollX:Float = 1, ScrollY:Float = 1, RepeatX:Bool = true, RepeatY:Bool = true, SpaceX:Int = 0,
+			SpaceY:Int = 0)
+	{
+		super();
+
+		scale = new FlxCallbackPoint(scaleCallback);
+		scale.set(1, 1);
+
+		_repeatX = RepeatX;
+		_repeatY = RepeatY;
+
+		_spaceX = SpaceX;
+		_spaceY = SpaceY;
+
+		_ppoint = new Point();
+
+		scrollFactor.x = ScrollX;
+		scrollFactor.y = ScrollY;
+
+		if (Graphic != null)
+			loadGraphic(Graphic);
+
+		FlxG.signals.gameResized.add(onGameResize);
+	}
+
+	override public function destroy():Void
+	{
+		_tileInfo = null;
+		_ppoint = null;
+		scale = FlxDestroyUtil.destroy(scale);
+		setTileFrame(null);
+
+		FlxG.signals.gameResized.remove(onGameResize);
+
+		super.destroy();
+	}
+
+	override public function loadGraphic(Graphic:FlxGraphicAsset, Animated:Bool = false, Width:Int = 0, Height:Int = 0, Unique:Bool = false,
+			?Key:String):FlxSprite
+	{
+		var tileGraphic:FlxGraphic = FlxG.bitmap.add(Graphic);
+		setTileFrame(tileGraphic.imageFrame.frame);
+
+		var w:Int = Std.int(_tileFrame.sourceSize.x + _spaceX);
+		var h:Int = Std.int(_tileFrame.sourceSize.y + _spaceY);
+
+		_scrollW = w;
+		_scrollH = h;
+
+		regenGraphic();
+
+		return this;
+	}
+
+	public function loadFrame(Frame:FlxFrame):FlxBackdrop
+	{
+		setTileFrame(Frame);
+
+		var w:Int = Std.int(_tileFrame.sourceSize.x + _spaceX);
+		var h:Int = Std.int(_tileFrame.sourceSize.y + _spaceY);
+
+		_scrollW = w;
+		_scrollH = h;
+
+		regenGraphic();
+
+		return this;
+	}
+
+	override public function draw():Void
+	{
+		var isColored:Bool = (alpha != 1) || (color != 0xffffff);
+		var hasColorOffsets:Bool = (colorTransform != null && colorTransform.hasRGBAOffsets());
+
+		for (camera in cameras)
+		{
+			if (!camera.visible || !camera.exists)
+				continue;
+
+			var ssw:Float = _scrollW * Math.abs(scale.x);
+			var ssh:Float = _scrollH * Math.abs(scale.y);
+
+			// Find x position
+			if (_repeatX)
+			{
+				_ppoint.x = ((x - offset.x - camera.scroll.x * scrollFactor.x) % ssw);
+
+				if (_ppoint.x > 0)
+					_ppoint.x -= ssw;
+			}
+			else
+			{
+				_ppoint.x = (x - offset.x - camera.scroll.x * scrollFactor.x);
+			}
+
+			// Find y position
+			if (_repeatY)
+			{
+				_ppoint.y = ((y - offset.y - camera.scroll.y * scrollFactor.y) % ssh);
+
+				if (_ppoint.y > 0)
+					_ppoint.y -= ssh;
+			}
+			else
+			{
+				_ppoint.y = (y - offset.y - camera.scroll.y * scrollFactor.y);
+			}
+
+			// Draw to the screen
+			if (FlxG.renderBlit)
+			{
+				if (graphic == null)
+					return;
+
+				if (dirty)
+					calcFrame(useFramePixels);
+
+				_flashRect2.setTo(0, 0, graphic.width, graphic.height);
+				camera.copyPixels(frame, framePixels, _flashRect2, _ppoint, colorTransform, blend, antialiasing, shader);
+			}
+			else
+			{
+				if (_tileFrame == null)
+					return;
+
+				var drawItem = camera.startQuadBatch(_tileFrame.parent, isColored, hasColorOffsets, blend, antialiasing, shader);
+
+				_tileFrame.prepareMatrix(_matrix);
+
+				var scaleX:Float = scale.x;
+				var scaleY:Float = scale.y;
+
+				if (useScaleHack)
+				{
+					scaleX += 1 / (_tileFrame.sourceSize.x * camera.totalScaleX);
+					scaleY += 1 / (_tileFrame.sourceSize.y * camera.totalScaleY);
+				}
+
+				_matrix.scale(scaleX, scaleY);
+
+				var tx:Float = _matrix.tx;
+				var ty:Float = _matrix.ty;
+
+				for (j in 0..._numTiles)
+				{
+					var currTileX = _tileInfo[j * 2];
+					var currTileY = _tileInfo[(j * 2) + 1];
+
+					_matrix.tx = tx + (_ppoint.x + currTileX);
+					_matrix.ty = ty + (_ppoint.y + currTileY);
+
+					drawItem.addQuad(_tileFrame, _matrix, colorTransform);
+				}
+			}
+		}
+	}
+
+	function regenGraphic():Void
+	{
+		var sx:Float = Math.abs(scale.x);
+		var sy:Float = Math.abs(scale.y);
+
+		var ssw:Int = Std.int(_scrollW * sx);
+		var ssh:Int = Std.int(_scrollH * sy);
+
+		var w:Int = ssw;
+		var h:Int = ssh;
+
+		var frameBitmap:BitmapData = null;
+
+		if (_repeatX)
+			w += FlxG.width;
+		if (_repeatY)
+			h += FlxG.height;
+
+		if (FlxG.renderBlit)
+		{
+			if (graphic == null || (graphic.width != w || graphic.height != h))
+			{
+				makeGraphic(w, h, FlxColor.TRANSPARENT, true);
+			}
+		}
+		else
+		{
+			_tileInfo = [];
+			_numTiles = 0;
+
+			width = frameWidth = w;
+			height = frameHeight = h;
+		}
+
+		_ppoint.x = _ppoint.y = 0;
+
+		if (FlxG.renderBlit)
+		{
+			pixels.lock();
+			_flashRect2.setTo(0, 0, graphic.width, graphic.height);
+			pixels.fillRect(_flashRect2, FlxColor.TRANSPARENT);
+			_matrix.identity();
+			_matrix.scale(sx, sy);
+			frameBitmap = _tileFrame.paint();
+		}
+
+		while (_ppoint.y < h)
+		{
+			while (_ppoint.x < w)
+			{
+				if (FlxG.renderBlit)
+				{
+					pixels.draw(frameBitmap, _matrix);
+					_matrix.tx += ssw;
+				}
+				else
+				{
+					_tileInfo.push(_ppoint.x);
+					_tileInfo.push(_ppoint.y);
+					_numTiles++;
+				}
+				_ppoint.x += ssw;
+			}
+			if (FlxG.renderBlit)
+			{
+				_matrix.tx = 0;
+				_matrix.ty += ssh;
+			}
+
+			_ppoint.x = 0;
+			_ppoint.y += ssh;
+		}
+
+		if (FlxG.renderBlit)
+		{
+			frameBitmap.dispose();
+			pixels.unlock();
+			dirty = true;
+			calcFrame();
+		}
+	}
+
+	function onGameResize(_, _):Void
+	{
+		if (_tileFrame != null)
+			regenGraphic();
+	}
+
+	inline function scaleCallback(Scale:FlxPoint)
+	{
+		if (_tileFrame != null)
+			regenGraphic();
+	}
+
+	function setTileFrame(Frame:FlxFrame):FlxFrame
+	{
+		if (Frame != _tileFrame)
+		{
+			if (_tileFrame != null)
+				_tileFrame.parent.useCount--;
+
+			if (Frame != null)
+				Frame.parent.useCount++;
+		}
+
+		return _tileFrame = Frame;
+	}
+}

--- a/source/flixel/addons/display/FlxBackdrop.hx
+++ b/source/flixel/addons/display/FlxBackdrop.hx
@@ -47,6 +47,16 @@ class FlxBackdrop extends FlxSprite
 	 */
 	public var useScaleHack:Bool = true;
 
+	// TODO: remove this hack and have the backdrop properly scale with the camera zoom for both tile and blit modes
+
+	/**
+	 * The lowest zoom value that the backdrop will support before
+	 * it starts to show the bounding area.
+	 */
+	public var lowestCamZoom:Float = 1;
+
+	var _camZoom:Float = 1;
+
 	/**
 	 * Creates an instance of the FlxBackdrop class, used to create infinitely scrolling backgrounds.
 	 *
@@ -137,6 +147,12 @@ class FlxBackdrop extends FlxSprite
 			if (!camera.visible || !camera.exists)
 				continue;
 
+			if (_camZoom != lowestCamZoom)
+			{
+				_camZoom = lowestCamZoom;
+				regenGraphic();
+			}
+
 			var ssw:Float = _scrollW * Math.abs(scale.x);
 			var ssh:Float = _scrollH * Math.abs(scale.y);
 
@@ -226,12 +242,15 @@ class FlxBackdrop extends FlxSprite
 		var w:Int = ssw;
 		var h:Int = ssh;
 
+		var bw:Int = Std.int(FlxG.width - (FlxG.width / _camZoom));
+		var bh:Int = Std.int(FlxG.height - (FlxG.height / _camZoom));
+
 		var frameBitmap:BitmapData = null;
 
 		if (_repeatX)
-			w += FlxG.width;
+			w += Std.int(FlxG.width / _camZoom);
 		if (_repeatY)
-			h += FlxG.height;
+			h += Std.int(FlxG.height / _camZoom);
 
 		if (FlxG.renderBlit)
 		{
@@ -249,7 +268,8 @@ class FlxBackdrop extends FlxSprite
 			height = frameHeight = h;
 		}
 
-		_ppoint.x = _ppoint.y = 0;
+		_ppoint.x = bw;
+		_ppoint.y = bh;
 
 		if (FlxG.renderBlit)
 		{
@@ -284,7 +304,7 @@ class FlxBackdrop extends FlxSprite
 				_matrix.ty += ssh;
 			}
 
-			_ppoint.x = 0;
+			_ppoint.x = bw;
 			_ppoint.y += ssh;
 		}
 

--- a/source/flixel/addons/display/FlxBackdrop.hx
+++ b/source/flixel/addons/display/FlxBackdrop.hx
@@ -25,8 +25,9 @@ class FlxBackdrop extends FlxSprite
 	var _ppoint:Point;
 	var _scrollW:Int = 0;
 	var _scrollH:Int = 0;
-	var _repeatX:Bool = false;
-	var _repeatY:Bool = false;
+
+	public var repeatX:Bool = false;
+	public var repeatY:Bool = false;
 
 	var _spaceX:Int = 0;
 	var _spaceY:Int = 0;
@@ -76,8 +77,8 @@ class FlxBackdrop extends FlxSprite
 		scale = new FlxCallbackPoint(scaleCallback);
 		scale.set(1, 1);
 
-		_repeatX = RepeatX;
-		_repeatY = RepeatY;
+		repeatX = RepeatX;
+		repeatY = RepeatY;
 
 		_spaceX = SpaceX;
 		_spaceY = SpaceY;
@@ -157,7 +158,7 @@ class FlxBackdrop extends FlxSprite
 			var ssh:Float = _scrollH * Math.abs(scale.y);
 
 			// Find x position
-			if (_repeatX)
+			if (repeatX)
 			{
 				_ppoint.x = ((x - offset.x - camera.scroll.x * scrollFactor.x) % ssw);
 
@@ -170,7 +171,7 @@ class FlxBackdrop extends FlxSprite
 			}
 
 			// Find y position
-			if (_repeatY)
+			if (repeatY)
 			{
 				_ppoint.y = ((y - offset.y - camera.scroll.y * scrollFactor.y) % ssh);
 
@@ -247,9 +248,9 @@ class FlxBackdrop extends FlxSprite
 
 		var frameBitmap:BitmapData = null;
 
-		if (_repeatX)
+		if (repeatX)
 			w += Std.int(FlxG.width / _camZoom);
-		if (_repeatY)
+		if (repeatY)
 			h += Std.int(FlxG.height / _camZoom);
 
 		if (FlxG.renderBlit)


### PR DESCRIPTION
This adds the ability to add backdrops (infinitely scrolling backgrounds) via Lua. Useful for adding stage elements like clouds and such, or moving backgrounds like in DDTO. A modified FlxBackdrop is included that allows it to support antialiasing, blending, and shaders.

https://user-images.githubusercontent.com/15317421/155866727-791f3d77-7083-40a3-9a0d-29c8ba108f76.mp4

Usage:
```lua
makeLuaBackdrop(tag, image, x, y);
addLuaBackdrop(tag, front);
removeLuaBackdrop(tag, destroy);
```

Example:
```lua
makeLuaBackdrop('clouds', 'funkyClouds', 0, 40);
setProperty('clouds.repeatY', false);
addLuaBackdrop('clouds');
```

It's worth noting that any other callbacks that work with LuaSprite will work just fine with LuaBackdrop.

However, FlxBackdrop does have one major issue: If you zoom the camera out (from stage's default zoom) during a song, you will see the bounding area in which the backdrop displays in.
![2022-02-22_11-00-48_PsychEngine](https://user-images.githubusercontent.com/15317421/155205764-aaa54aef-1c7b-412f-baa7-29eee6a04dfa.png)

To mitigate this issue for the moment, I have added a variable that allows you to change how big the area is. This is based off the value that you give it.
```lua
setProperty('clouds.lowestCamZoom', 0.8);
```
![2022-02-22_13-45-04_PsychEngine](https://user-images.githubusercontent.com/15317421/155866745-bfa8db2e-f409-4ac2-87b0-1219f8ba9ac2.png)
Please note that this can drastically hurt performance if it's set to extreme values. (values close to 0)

There's also a chance for FlxBackdrop to crash the game when using setGraphicSize, so the ability to do so has been disabled. 
This isn't a major issue though as you can just use scaleObject on it instead.
```lua
scaleObject('clouds', 1.2, 1.2);
```