### PR TITLE
Prevent lua scripts from bypassing disabled antialiasing

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -336,6 +336,9 @@ class FunkinLua {
 		Lua_helper.add_callback(lua, "setProperty", function(variable:String, value:Dynamic) {
 			var killMe:Array<String> = variable.split('.');
 			if(killMe.length > 1) {
+				if(!ClientPrefs.globalAntialiasing && killMe[killMe.length-1] == 'antialiasing') {
+					value = false;
+				}
 				setVarInArray(getPropertyLoopThingWhatever(killMe), killMe[killMe.length-1], value);
 				return true;
 			}


### PR DESCRIPTION
This will prevent people from setting an object's antialiasing property (via lua) to true if the user has disabled antialiasing in options.

Example code: (based off alley.lua in Whitty Definitive)
```lua
function onCreate()
	makeLuaSprite('stageback', 'whittyBack', -420, -130);
	setLuaSpriteScrollFactor('stageback', 1.0, 1.0);
	setProperty('stageback.antialiasing', true);
	debugPrint(getProperty('stageback.antialiasing'));
	debugPrint('stageback.antialiasing:');

	makeLuaSprite('stagefront', 'whittyFront', -300, 670);
	setLuaSpriteScrollFactor('stagefront', 1.0, 1.0);

	addLuaSprite('stageback', false);
	addLuaSprite('stagefront', false);
	
	close(true);
end
```

Before this PR:

https://user-images.githubusercontent.com/15317421/155424712-add59d6b-11e0-4d65-95ff-56401a738bde.mp4

![2022-02-23_15-10-26_PsychEngine](https://user-images.githubusercontent.com/15317421/155424986-7641cb45-c07f-4543-a3aa-5b2bb37a7917.png)

With this PR:

https://user-images.githubusercontent.com/15317421/155424737-52e645ef-090f-4b10-b8ce-bde6586ecf5e.mp4