### PR TITLE
Enable/Disable Lua Scripts

### DIFF
--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -8,6 +8,7 @@ import Controls;
 
 class ClientPrefs {
 	public static var downScroll:Bool = false;
+	public static var userLuaScripts:Bool = true;
 	public static var middleScroll:Bool = false;
 	public static var showFPS:Bool = true;
 	public static var flashing:Bool = true;
@@ -90,6 +91,7 @@ class ClientPrefs {
 
 	public static function saveSettings() {
 		FlxG.save.data.downScroll = downScroll;
+		FlxG.save.data.userLuaScripts = userLuaScripts;
 		FlxG.save.data.middleScroll = middleScroll;
 		FlxG.save.data.showFPS = showFPS;
 		FlxG.save.data.flashing = flashing;
@@ -133,6 +135,9 @@ class ClientPrefs {
 	public static function loadPrefs() {
 		if(FlxG.save.data.downScroll != null) {
 			downScroll = FlxG.save.data.downScroll;
+			
+		if(FlxG.save.data.userLuaScripts != null {
+			userLuaScripts = FlxG.save.data.userLuaScripts;
 		}
 		if(FlxG.save.data.middleScroll != null) {
 			middleScroll = FlxG.save.data.middleScroll;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1048,7 +1048,7 @@ class PlayState extends MusicBeatState
 			#if MODS_ALLOWED
 			foldersToCheck.insert(0, Paths.mods('data/' + Paths.formatToSongPath(SONG.song) + '/'));
 			if(Paths.currentModDirectory != null && Paths.currentModDirectory.length > 0)
-				foldersToCheck.insert(0, Paths.mods(Paths.currentModDirectory + '/data/' + Paths.formatToSongPath(SONG.song) + '/'));
+			foldersToCheck.insert(0, Paths.mods(Paths.currentModDirectory + '/data/' + Paths.formatToSongPath(SONG.song) + '/'));
 			#end
 
 			for (folder in foldersToCheck)
@@ -1065,7 +1065,6 @@ class PlayState extends MusicBeatState
 					}
 				}
 			}
-		}
 		#end
 		
 		var daSong:String = Paths.formatToSongPath(curSong);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1040,25 +1040,28 @@ class PlayState extends MusicBeatState
 
 		// SONG SPECIFIC SCRIPTS
 		#if LUA_ALLOWED
-		var filesPushed:Array<String> = [];
-		var foldersToCheck:Array<String> = [Paths.getPreloadPath('data/' + Paths.formatToSongPath(SONG.song) + '/')];
+			if(ClientPrefs.userLuaScript) {
+			
+			var filesPushed:Array<String> = [];
+			var foldersToCheck:Array<String> = [Paths.getPreloadPath('data/' + Paths.formatToSongPath(SONG.song) + '/')];
 
-		#if MODS_ALLOWED
-		foldersToCheck.insert(0, Paths.mods('data/' + Paths.formatToSongPath(SONG.song) + '/'));
-		if(Paths.currentModDirectory != null && Paths.currentModDirectory.length > 0)
-			foldersToCheck.insert(0, Paths.mods(Paths.currentModDirectory + '/data/' + Paths.formatToSongPath(SONG.song) + '/'));
-		#end
+			#if MODS_ALLOWED
+			foldersToCheck.insert(0, Paths.mods('data/' + Paths.formatToSongPath(SONG.song) + '/'));
+			if(Paths.currentModDirectory != null && Paths.currentModDirectory.length > 0)
+				foldersToCheck.insert(0, Paths.mods(Paths.currentModDirectory + '/data/' + Paths.formatToSongPath(SONG.song) + '/'));
+			#end
 
-		for (folder in foldersToCheck)
-		{
-			if(FileSystem.exists(folder))
+			for (folder in foldersToCheck)
 			{
-				for (file in FileSystem.readDirectory(folder))
+				if(FileSystem.exists(folder))
 				{
-					if(file.endsWith('.lua') && !filesPushed.contains(file))
+					for (file in FileSystem.readDirectory(folder))
 					{
-						luaArray.push(new FunkinLua(folder + file));
-						filesPushed.push(file);
+						if(file.endsWith('.lua') && !filesPushed.contains(file))
+						{
+							luaArray.push(new FunkinLua(folder + file));
+							filesPushed.push(file);
+						}
 					}
 				}
 			}

--- a/source/options/GameplaySettingsSubState.hx
+++ b/source/options/GameplaySettingsSubState.hx
@@ -55,7 +55,14 @@ class GameplaySettingsSubState extends BaseOptionsMenu
 			'bool',
 			false);
 		addOption(option);
-
+		
+		var option:Option = new Option('Modcharts',
+			"If checked, adds small effects to the charts.\nNot available on all songs.",
+			'userLuaScripts',
+			'bool',
+			true);
+		addOption(option);
+		
 		var option:Option = new Option('Ghost Tapping',
 			"If checked, you won't get misses from pressing keys\nwhile there are no notes able to be hit.",
 			'ghostTapping',


### PR DESCRIPTION
This allows the user to enable / disable the script.json from the song's data folder, in case they don't like it, or it's too distracting. Simple enough.