### PR TITLE
Add variable frame health icon support

### DIFF
--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -30,11 +30,19 @@ class HealthIcon extends FlxSprite
 	}
 
 	public function swapOldIcon() {
-		if(isOldIcon = !isOldIcon) changeIcon('bf-old');
-		else changeIcon('bf');
+		changeIcon(if(isOldIcon = !isOldIcon) 'bf-old' else 'bf');
 	}
 
 	private var iconOffsets:Array<Float> = [0, 0];
+
+
+	public dynamic function updateAnim(health:Float){ // Dynamic to prevent having like 20 if statements
+		if (health < 20)
+			animation.curAnim.curFrame = 1;
+		else
+			animation.curAnim.curFrame = 0;
+	}
+
 	public function changeIcon(char:String) {
 		if(this.char != char) {
 			var name:String = 'icons/' + char;
@@ -42,13 +50,35 @@ class HealthIcon extends FlxSprite
 			if(!Paths.fileExists('images/' + name + '.png', IMAGE)) name = 'icons/icon-face'; //Prevents crash from missing icon
 			var file:Dynamic = Paths.image(name);
 
-			loadGraphic(file); //Load stupidly first for getting the file size
-			loadGraphic(file, true, Math.floor(width / 2), Math.floor(height)); //Then load it fr
+			
+			var icoheight:Int = 150;
+			var icowidth:Int = 150;
+			var frameCount = 1; // Has to be 1 instead of 2 due to how compooters handle numbers
+			if(width % 150 != 0 || height % 150 != 0){ // Invalid sized health icon! Split in half
+				icoheight = file.height;
+				icowidth = Std.int(file.width * 0.5);
+			}else{
+				frameCount = Std.int(file.width / 150) - 1; // If this isn't an integer, fucking run
+				if(frameCount == 0) updateAnim = function(health:Float){return;};
+				else if(frameCount == 1) updateAnim = function(health:Float){
+					if (health < 20)
+						animation.curAnim.curFrame = 1;
+					else
+						animation.curAnim.curFrame = 0;
+				};
+				// This goes from Losing to Winning
+				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round(flixel.math.FlxMath.remapToRange(health,0,150,0,animation.curAnim.numFrames));};
+				
+			}
+			loadGraphic(file, true, icowidth, icoheight); //Then load it fr
 			iconOffsets[0] = (width - 150) / 2;
 			iconOffsets[1] = (width - 150) / 2;
 			updateHitbox();
 
-			animation.add(char, [0, 1], 0, false, isPlayer);
+
+			frameCount = frameCount + 1;
+			animation.add(char, if(frameCount > 1)[for (i in 0 ... frameCount) i] else [0,1], 0, false, isPlayer);
+
 			animation.play(char);
 			this.char = char;
 

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -67,7 +67,7 @@ class HealthIcon extends FlxSprite
 						animation.curAnim.curFrame = 0;
 				};
 				// This goes from Losing to Winning
-				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round( frameCount * (health / 100) );};
+				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round( animation.curAnim.frameCount * (health / 100) );};
 				
 			}
 			loadGraphic(file, true, icowidth, icoheight); //Then load it fr

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -67,7 +67,7 @@ class HealthIcon extends FlxSprite
 						animation.curAnim.curFrame = 0;
 				};
 				// This goes from Losing to Winning
-				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round(flixel.math.FlxMath.remapToRange(health,0,150,0,animation.curAnim.numFrames));};
+				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round( frameCount * (health / 100) );};
 				
 			}
 			loadGraphic(file, true, icowidth, icoheight); //Then load it fr

--- a/source/HealthIcon.hx
+++ b/source/HealthIcon.hx
@@ -67,7 +67,7 @@ class HealthIcon extends FlxSprite
 						animation.curAnim.curFrame = 0;
 				};
 				// This goes from Losing to Winning
-				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round( animation.curAnim.frameCount * (health / 100) );};
+				else if(frameCount > 1) updateAnim = function(health:Float){animation.curAnim.curFrame = Math.round( animation.curAnim.numFrames * (health / 100) );};
 				
 			}
 			loadGraphic(file, true, icowidth, icoheight); //Then load it fr

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2370,16 +2370,8 @@ class PlayState extends MusicBeatState
 
 		if (health > 2)
 			health = 2;
-
-		if (healthBar.percent < 20)
-			iconP1.animation.curAnim.curFrame = 1;
-		else
-			iconP1.animation.curAnim.curFrame = 0;
-
-		if (healthBar.percent > 80)
-			iconP2.animation.curAnim.curFrame = 1;
-		else
-			iconP2.animation.curAnim.curFrame = 0;
+		iconP1.updateAnim(healthBar.percent);
+		iconP2.updateAnim(100 - healthBar.percent);
 
 		if (FlxG.keys.anyJustPressed(debugKeysCharacter) && !endingSong && !inCutscene) {
 			persistentUpdate = false;


### PR DESCRIPTION
Allows health icons of any frame count to be used while still supporting vanilla icons. Anything higher than 2 frames will be treated going from Losing(left) to (Right)Winning, up to 100 frames can be defined inside of the png, no xml's required. Only caveat is that every frame has to be 150 px in width and height, if they don't comply then it'll be treated as a vanilla health icon with 2 frames