### PR TITLE
Make updateHitbox for setGraphicSize and scaleObject optional

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -1087,34 +1087,34 @@ class FunkinLua {
 				}
 			}
 		});
-		Lua_helper.add_callback(lua, "setGraphicSize", function(obj:String, x:Int, y:Int = 0) {
+		Lua_helper.add_callback(lua, "setGraphicSize", function(obj:String, x:Int, y:Int = 0, updateHitbox:Bool = true) {
 			if(PlayState.instance.modchartSprites.exists(obj)) {
 				var shit:ModchartSprite = PlayState.instance.modchartSprites.get(obj);
 				shit.setGraphicSize(x, y);
-				shit.updateHitbox();
+				if(updateHitbox) shit.updateHitbox();
 				return;
 			}
 
 			var poop:FlxSprite = Reflect.getProperty(getInstance(), obj);
 			if(poop != null) {
 				poop.setGraphicSize(x, y);
-				poop.updateHitbox();
+				if(updateHitbox) poop.updateHitbox();
 				return;
 			}
 			luaTrace('Couldnt find object: ' + obj);
 		});
-		Lua_helper.add_callback(lua, "scaleObject", function(obj:String, x:Float, y:Float) {
+		Lua_helper.add_callback(lua, "scaleObject", function(obj:String, x:Float, y:Float, updateHitbox:Bool = true) {
 			if(PlayState.instance.modchartSprites.exists(obj)) {
 				var shit:ModchartSprite = PlayState.instance.modchartSprites.get(obj);
 				shit.scale.set(x, y);
-				shit.updateHitbox();
+				if(updateHitbox) shit.updateHitbox();
 				return;
 			}
 
 			var poop:FlxSprite = Reflect.getProperty(getInstance(), obj);
 			if(poop != null) {
 				poop.scale.set(x, y);
-				poop.updateHitbox();
+				if(updateHitbox) poop.updateHitbox();
 				return;
 			}
 			luaTrace('Couldnt find object: ' + obj);


### PR DESCRIPTION
Adds a bool to setGraphicSize and scaleObject where if it's set to false, it will not call updateHitbox. Useful towards recreating Week 6's schoolEvil stage, or other stuff that scales the object but forgets to update its hitbox.

```lua
	makeAnimatedLuaSprite('bg', 'stages/schoolEvil-devilmachine/animatedEvilSchool', 400, 200);
	addAnimationByPrefix('bg', 'idle', 'background 2', 24, true);
	setScrollFactor('bg', 0.8, 0.9);
	scaleObject('bg', 6, 6, false);
	setProperty('bg.antialiasing', false);
	addLuaSprite('bg', false);
```

![2022-03-15_13-37-02_PsychEngine](https://user-images.githubusercontent.com/15317421/158468112-ee8c8c84-168c-47c0-8d7d-91f1fa770c24.png)

It is set to true by default so it doesn't break currently existing mods.