### PR TITLE
Fix hit sounds being played on Ignore Notes when botplay is enabled

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3867,12 +3867,12 @@ class PlayState extends MusicBeatState
 	{
 		if (!note.wasGoodHit)
 		{
+			if(cpuControlled && (note.ignoreNote || note.hitCausesMiss)) return;
+
 			if (ClientPrefs.hitsoundVolume > 0 && !note.hitsoundDisabled)
 			{
 				FlxG.sound.play(Paths.sound('hitsound'), ClientPrefs.hitsoundVolume);
 			}
-
-			if(cpuControlled && (note.ignoreNote || note.hitCausesMiss)) return;
 
 			if(note.hitCausesMiss) {
 				noteMiss(note);


### PR DESCRIPTION
Issue: When botplay is enabled, hit sounds will play when Ignore Notes/notes that cause a miss (such as Hurt Notes) pass by

Cause: Since botplay basically "spams" all 4 keys, it hits all hurt notes, but there's [a line of code that stops anything from happening](https://github.com/ShadowMario/FNF-PsychEngine/blob/main/source/PlayState.hx#L3875).
However, [the line that is responsible for playing the hit sound](https://github.com/ShadowMario/FNF-PsychEngine/blob/main/source/PlayState.hx#L3875) was placed *before* the `return` line, causing multiple hit sounds to be played when a Hurt Note passes by

Fix: Move the `return` line above (before) the line that plays the hit sound