### PR TITLE
add an extra 0 to accuracy display

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2320,7 +2320,7 @@ class PlayState extends MusicBeatState
 				{
 					if (convertedAccDisplay.charAt(i + 2) == '')
 					{
-						accuracy += '0';
+						convertedAccDisplay += '0';
 						break;
 					}
 				}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2307,10 +2307,16 @@ class PlayState extends MusicBeatState
 
 		super.update(elapsed);
 
-		if(ratingName == '?') {
+		if (ratingName == '?') {
 			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName;
 		} else {
-			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + Highscore.floorDecimal(ratingPercent * 100, 2) + '%)' + ' - ' + ratingFC;//peeps wanted no integer rating
+			var convertedAccDisplay:String;
+			convertedAccDisplay = Std.string(Highscore.floorDecimal(ratingPercent * 100, 2));
+
+			if (convertedAccDisplay.length == 4)
+				convertedAccDisplay += '0';
+
+			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + convertedAccDisplay + '%)' + ' - ' + ratingFC;//peeps wanted no integer rating
 		}
 
 		if(botplayTxt.visible) {

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2311,10 +2311,20 @@ class PlayState extends MusicBeatState
 			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName;
 		} else {
 			var convertedAccDisplay:String;
+			
 			convertedAccDisplay = Std.string(Highscore.floorDecimal(ratingPercent * 100, 2));
-
-			if (convertedAccDisplay.length == 4)
-				convertedAccDisplay += '0';
+			
+			for (i in 0...convertedAccDisplay.length)
+			{
+				if (convertedAccDisplay.charAt(i) == '.')
+				{
+					if (convertedAccDisplay.charAt(i + 2) == '')
+					{
+						accuracy += '0';
+						break;
+					}
+				}
+			}
 
 			scoreTxt.text = 'Score: ' + songScore + ' | Misses: ' + songMisses + ' | Rating: ' + ratingName + ' (' + convertedAccDisplay + '%)' + ' - ' + ratingFC;//peeps wanted no integer rating
 		}


### PR DESCRIPTION
This makes it so that on the accuracy display, It adds an extra 0 when the accuracy reaches numbers that reach a length of 4 (87.50%)

So, generally, by adding a 0, this fixes the accuracy display a bit, here's a few examples:

(87.6% > 87.60%)
(44.4% > 44.40%)
(99.9% > 99.90%)

![image](https://user-images.githubusercontent.com/71162374/162124589-952a5ed1-4c59-4f30-b01c-58f782671e5d.png)

Not happening when it comes to those like (85.51%)
![image](https://user-images.githubusercontent.com/71162374/162124643-b87e7cde-ceff-48af-8fce-238eff927952.png)

