### PR TITLE
Change fps text size back to how it was before

### DIFF
--- a/source/openfl/display/FPS.hx
+++ b/source/openfl/display/FPS.hx
@@ -46,7 +46,7 @@ class FPS extends TextField
 		currentFPS = 0;
 		selectable = false;
 		mouseEnabled = false;
-		defaultTextFormat = new TextFormat("_sans", 14, color);
+		defaultTextFormat = new TextFormat("_sans", 12, color);
 		autoSize = LEFT;
 		multiline = true;
 		text = "FPS: ";


### PR DESCRIPTION
the fps text size in the current verison seemed different so i changed the size back to how it was before 0.5.2