### PR TITLE
Automatically grab refresh rate for first time saves

### DIFF
--- a/source/ClientPrefs.hx
+++ b/source/ClientPrefs.hx
@@ -4,6 +4,7 @@ import flixel.FlxG;
 import flixel.util.FlxSave;
 import flixel.input.keyboard.FlxKey;
 import flixel.graphics.FlxGraphic;
+import lime.app.Application;
 import Controls;
 
 class ClientPrefs {
@@ -168,13 +169,27 @@ class ClientPrefs {
 		}
 		if(FlxG.save.data.framerate != null) {
 			framerate = FlxG.save.data.framerate;
-			if(framerate > FlxG.drawFramerate) {
-				FlxG.updateFramerate = framerate;
-				FlxG.drawFramerate = framerate;
-			} else {
-				FlxG.drawFramerate = framerate;
-				FlxG.updateFramerate = framerate;
+		}
+		#if !html5
+		else
+		{
+			var refreshRate:Int = Application.current.window.displayMode.refreshRate;
+			if(framerate != refreshRate) {
+				framerate = refreshRate;
+				if(framerate < 60) {
+					framerate = 60;
+				} else if(framerate > 240) {
+					framerate = 240;
+				}
 			}
+		}
+		#end
+		if(framerate > FlxG.drawFramerate) {
+			FlxG.updateFramerate = framerate;
+			FlxG.drawFramerate = framerate;
+		} else {
+			FlxG.drawFramerate = framerate;
+			FlxG.updateFramerate = framerate;
 		}
 		/*if(FlxG.save.data.cursing != null) {
 			cursing = FlxG.save.data.cursing;


### PR DESCRIPTION
This PR makes it so any save created for the first time will have Psych automatically grab the display's refresh rate and set its framerate cap to that, instead of the user having to go into options to set it themselves.

If the monitor's refresh rate is either under or over the FPS cap range, Psych Engine will cap it.

This PR also simplifies the code for setting the game's framerate cap.