### PR TITLE
Fix chart editor null error

### DIFF
--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -2697,7 +2697,7 @@ class ChartingState extends MusicBeatState
 	function loadJson(song:String):Void
 	{
 		//make it look sexier if possible
-		if (CoolUtil.difficulties[PlayState.storyDifficulty] != "Normal"){
+		if (CoolUtil.difficulties[PlayState.storyDifficulty] != "Normal" && CoolUtil.difficulties[PlayState.storyDifficulty] != null){ // GAME WOULD CRASH IF SOMEONE TRIED TO LOAD A JSON BEFORE PLAYING A SONG.
 		PlayState.SONG = Song.loadFromJson(song.toLowerCase()+"-"+CoolUtil.difficulties[PlayState.storyDifficulty], song.toLowerCase());
 			
 		}else{


### PR DESCRIPTION
This change should fix an error in the chart editor where attempting to load a song JSON while no difficulty is set in PlayState would cause a "song-null.json" error.