### PR TITLE
Fix combo count in EditorPlayState

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4450,8 +4450,8 @@ class PlayState extends MusicBeatState
 			if (!note.isSustainNote)
 			{
 				combo += 1;
-				popUpScore(note);
 				if(combo > 9999) combo = 9999;
+				popUpScore(note);
 			}
 			health += note.hitHealth * healthGain;
 

--- a/source/editors/EditorPlayState.hx
+++ b/source/editors/EditorPlayState.hx
@@ -725,10 +725,10 @@ class EditorPlayState extends MusicBeatState
 
 			if (!note.isSustainNote)
 			{
-				popUpScore(note);
 				combo += 1;
 				songHits++;
 				if(combo > 9999) combo = 9999;
+				popUpScore(note);
 			}
 
 			playerStrums.forEach(function(spr:StrumNote)
@@ -896,7 +896,7 @@ class EditorPlayState extends MusicBeatState
 			numScore.velocity.x = FlxG.random.float(-5, 5);
 			numScore.visible = !ClientPrefs.hideHud;
 
-			if (combo >= 10 || combo == 0)
+			//if (combo >= 10 || combo == 0)
 				insert(members.indexOf(strumLineNotes), numScore);
 
 			FlxTween.tween(numScore, {alpha: 0}, 0.2, {


### PR DESCRIPTION
Quick and simple bugfix, this fixes the combo count in EditorPlayState being off by one and only showing past 10, making it function the same as PlayState. This also fixes the combo count going over 9999 in both PlayState and EditorPlayState.