### PR TITLE
No Antialiasing Option for Menu Characters

### DIFF
--- a/assets/preload/images/menucharacters/bf.json
+++ b/assets/preload/images/menucharacters/bf.json
@@ -1,11 +1,12 @@
 {
-	
 	"image": "Menu_BF",
+	"scale": 1,
 	"position": [
 		15,
 		-40
 	],
-	"scale": 1,
 	"idle_anim": "M BF Idle",
-	"confirm_anim": "M bf HEY"
+	"confirm_anim": "M bf HEY",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/dad.json
+++ b/assets/preload/images/menucharacters/dad.json
@@ -2,7 +2,7 @@
 	"image": "Menu_Dad",
 	"scale": 1,
 	"position": [
-		-2,
+		0,
 		0
 	],
 	"idle_anim": "M Dad Idle",

--- a/assets/preload/images/menucharacters/dad.json
+++ b/assets/preload/images/menucharacters/dad.json
@@ -1,11 +1,12 @@
 {
-	
 	"image": "Menu_Dad",
+	"scale": 1,
 	"position": [
-		0,
+		-2,
 		0
 	],
-	"scale": 1,
 	"idle_anim": "M Dad Idle",
-	"confirm_anim": "M Dad Idle"
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/gf.json
+++ b/assets/preload/images/menucharacters/gf.json
@@ -1,11 +1,12 @@
 {
-	
 	"image": "Menu_GF",
+	"scale": 1,
 	"position": [
 		0,
 		-25
 	],
-	"scale": 1,
 	"idle_anim": "M GF Idle",
-	"confirm_anim": "M GF Idle"
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/mom.json
+++ b/assets/preload/images/menucharacters/mom.json
@@ -1,10 +1,12 @@
 {
-	"idle_anim": "M Mom Idle",
 	"image": "Menu_Mom",
+	"scale": 1,
 	"position": [
 		0,
 		10
 	],
-	"scale": 1,
-	"confirm_anim": "M Dad Idle"
+	"idle_anim": "M Mom Idle",
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/parents-christmas.json
+++ b/assets/preload/images/menucharacters/parents-christmas.json
@@ -1,10 +1,12 @@
 {
-	"idle_anim": "M Parents Idle",
 	"image": "Menu_Parents",
+	"scale": 1,
 	"position": [
 		110,
 		10
 	],
-	"scale": 1,
-	"confirm_anim": "M Dad Idle"
+	"idle_anim": "M Parents Idle",
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/pico.json
+++ b/assets/preload/images/menucharacters/pico.json
@@ -1,10 +1,12 @@
 {
-	"idle_anim": "M Pico Idle",
 	"image": "Menu_Pico",
+	"scale": 1,
 	"position": [
 		0,
 		-120
 	],
-	"scale": 1,
-	"confirm_anim": "M Dad Idle"
+	"idle_anim": "M Pico Idle",
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/senpai.json
+++ b/assets/preload/images/menucharacters/senpai.json
@@ -1,10 +1,12 @@
 {
-	"idle_anim": "M Senpai Idle",
 	"image": "Menu_Senpai",
+	"scale": 1,
 	"position": [
 		60,
 		-70
 	],
-	"scale": 1,
-	"confirm_anim": "M Dad Idle"
+	"idle_anim": "M Senpai Idle",
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/spooky.json
+++ b/assets/preload/images/menucharacters/spooky.json
@@ -1,10 +1,12 @@
 {
-	"idle_anim": "M Spooky Kids Idle",
 	"image": "Menu_Spooky_Kids",
+	"scale": 1,
 	"position": [
 		0,
 		-80
 	],
-	"scale": 1,
-	"confirm_anim": "M Dad Idle"
+	"idle_anim": "M Spooky Kids Idle",
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/assets/preload/images/menucharacters/tankman.json
+++ b/assets/preload/images/menucharacters/tankman.json
@@ -1,10 +1,12 @@
 {
-	"idle_anim": "M Tankman Idle",
 	"image": "Menu_Tankman",
+	"scale": 1,
 	"position": [
 		0,
 		-95
 	],
-	"scale": 1,
-	"confirm_anim": "M Dad Idle"
+	"idle_anim": "M Tankman Idle",
+	"confirm_anim": "M Dad Idle",
+	"flipX": false,
+	"noAntialiasing": false
 }

--- a/source/MenuCharacter.hx
+++ b/source/MenuCharacter.hx
@@ -17,6 +17,7 @@ typedef MenuCharacterFile = {
 	var idle_anim:String;
 	var confirm_anim:String;
 	var flipX:Bool;
+	var noAntialiasing:Bool;
 }
 
 class MenuCharacter extends FlxSprite
@@ -37,7 +38,7 @@ class MenuCharacter extends FlxSprite
 		if(character == this.character) return;
 
 		this.character = character;
-		antialiasing = ClientPrefs.globalAntialiasing;
+
 		visible = true;
 
 		var dontPlayAnim:Bool = false;
@@ -85,6 +86,11 @@ class MenuCharacter extends FlxSprite
 				}
 
 				flipX = (charFile.flipX == true);
+
+				if (charFile.noAntialiasing == true)
+					antialiasing = false;
+				else if (charFile.noAntialiasing == false)
+					antialiasing = ClientPrefs.globalAntialiasing;
 
 				if(charFile.scale != 1) {
 					scale.set(charFile.scale, charFile.scale);

--- a/source/editors/MenuCharacterEditorState.hx
+++ b/source/editors/MenuCharacterEditorState.hx
@@ -46,7 +46,8 @@ class MenuCharacterEditorState extends MusicBeatState
 			position: [0, 0],
 			idle_anim: 'M Dad Idle',
 			confirm_anim: 'M Dad Idle',
-			flipX: false
+			flipX: false,
+			noAntialiasing: false
 		};
 		#if desktop
 		// Updating Discord Rich Presence
@@ -136,6 +137,7 @@ class MenuCharacterEditorState extends MusicBeatState
 		opponentCheckbox = new FlxUICheckBox(10, 20, null, null, "Opponent", 100);
 		opponentCheckbox.callback = function()
 		{
+			noAntialiasingCheckbox.y = confirmInputText.y + 10;
 			curTypeSelected = 0;
 			updateCharTypeBox();
 		};
@@ -143,6 +145,7 @@ class MenuCharacterEditorState extends MusicBeatState
 		boyfriendCheckbox = new FlxUICheckBox(opponentCheckbox.x, opponentCheckbox.y + 40, null, null, "Boyfriend", 100);
 		boyfriendCheckbox.callback = function()
 		{
+			noAntialiasingCheckbox.y = confirmInputText.y + 15;
 			curTypeSelected = 1;
 			updateCharTypeBox();
 		};
@@ -150,6 +153,7 @@ class MenuCharacterEditorState extends MusicBeatState
 		girlfriendCheckbox = new FlxUICheckBox(boyfriendCheckbox.x, boyfriendCheckbox.y + 40, null, null, "Girlfriend", 100);
 		girlfriendCheckbox.callback = function()
 		{
+			noAntialiasingCheckbox.y = confirmInputText.y + 10;
 			curTypeSelected = 2;
 			updateCharTypeBox();
 		};
@@ -166,6 +170,7 @@ class MenuCharacterEditorState extends MusicBeatState
 	var confirmDescText:FlxText;
 	var scaleStepper:FlxUINumericStepper;
 	var flipXCheckbox:FlxUICheckBox;
+	var noAntialiasingCheckbox:FlxUICheckBox;
 	function addCharacterUI() {
 		var tab_group = new FlxUI(null, UI_mainbox);
 		tab_group.name = "Character";
@@ -184,6 +189,18 @@ class MenuCharacterEditorState extends MusicBeatState
 			characterFile.flipX = flipXCheckbox.checked;
 		};
 
+		noAntialiasingCheckbox = new FlxUICheckBox(10, confirmInputText.y + 10, null, null, "No Antialiasing", 100);
+		noAntialiasingCheckbox.callback = function()
+		{
+			if (noAntialiasingCheckbox.checked) {
+				grpWeekCharacters.members[curTypeSelected].antialiasing = false;
+				characterFile.noAntialiasing = true;
+			} else {
+				grpWeekCharacters.members[curTypeSelected].antialiasing = ClientPrefs.globalAntialiasing;
+				characterFile.noAntialiasing = false;
+			}
+		};
+
 		var reloadImageButton:FlxButton = new FlxButton(140, confirmInputText.y + 30, "Reload Char", function() {
 			reloadSelectedCharacter();
 		});
@@ -195,6 +212,7 @@ class MenuCharacterEditorState extends MusicBeatState
 		tab_group.add(new FlxText(10, idleInputText.y - 18, 0, 'Idle animation on the .XML:'));
 		tab_group.add(new FlxText(scaleStepper.x, scaleStepper.y - 18, 0, 'Scale:'));
 		tab_group.add(flipXCheckbox);
+		tab_group.add(noAntialiasingCheckbox);
 		tab_group.add(reloadImageButton);
 		tab_group.add(confirmDescText);
 		tab_group.add(imageInputText);
@@ -239,6 +257,11 @@ class MenuCharacterEditorState extends MusicBeatState
 		char.animation.addByPrefix('idle', characterFile.idle_anim, 24);
 		if(curTypeSelected == 1) char.animation.addByPrefix('confirm', characterFile.confirm_anim, 24, false);
 		char.flipX = (characterFile.flipX == true);
+
+		if (noAntialiasingCheckbox.checked)
+			char.antialiasing = false;
+		else
+			char.antialiasing = ClientPrefs.globalAntialiasing;
 
 		char.scale.set(characterFile.scale, characterFile.scale);
 		char.updateHitbox();
@@ -368,6 +391,8 @@ class MenuCharacterEditorState extends MusicBeatState
 					idleInputText.text = characterFile.image;
 					confirmInputText.text = characterFile.image;
 					scaleStepper.value = characterFile.scale;
+					flipXCheckbox.checked = characterFile.flipX;
+					noAntialiasingCheckbox.checked = characterFile.noAntialiasing;
 					updateOffset();
 					_file = null;
 					return;


### PR DESCRIPTION
Q: What does this Pull Request do?
A: Gives an option for Disabling Antialiasing for Menu Characters (meaning when enabled it will disable antialiasing for that menu character even if the option for Antialiasing is on!)

Q: How do I enable it
A: just click the "No Antialiasing" button in the Menu Character Editor (It's so simple that even a newborn can do it)

1 small issue:
if the character isn't scaled it doesn't work as expected (bug happens even without this Pull Request I believe)

sorry if I did a terrible job at explaining this LOL