### PR TITLE
Options Shortcut on the Pause Menu (for Charting Mode)

### DIFF
--- a/source/MainMenuState.hx
+++ b/source/MainMenuState.hx
@@ -244,6 +244,7 @@ class MainMenuState extends MusicBeatState
 									case 'credits':
 										MusicBeatState.switchState(new CreditsState());
 									case 'options':
+										PauseSubState.toOptions = false;
 										LoadingState.loadAndSwitchState(new options.OptionsState());
 								}
 							});

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -55,7 +55,7 @@ class PauseSubState extends MusicBeatSubstate
 			menuItemsOG.insert(3 + num, 'End Song');
 			menuItemsOG.insert(4 + num, 'Toggle Practice Mode');
 			menuItemsOG.insert(5 + num, 'Toggle Botplay');
-			menuItemsOG.insert(6 + num, 'Exit to Options');
+			menuItemsOG.insert(7, 'Exit to Options');
 		}
 		menuItems = menuItemsOG;
 

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -33,10 +33,14 @@ class PauseSubState extends MusicBeatSubstate
 
 	public static var songName:String = '';
 
+	public static var toOptions:Bool = false;
+
 	public function new(x:Float, y:Float)
 	{
 		super();
 		if(CoolUtil.difficulties.length < 2) menuItemsOG.remove('Change Difficulty'); //No need to change difficulty if there is only one!
+
+		toOptions = false;
 
 		if(PlayState.chartingMode)
 		{
@@ -51,6 +55,7 @@ class PauseSubState extends MusicBeatSubstate
 			menuItemsOG.insert(3 + num, 'End Song');
 			menuItemsOG.insert(4 + num, 'Toggle Practice Mode');
 			menuItemsOG.insert(5 + num, 'Toggle Botplay');
+			menuItemsOG.insert(6 + num, 'Exit to Options');
 		}
 		menuItems = menuItemsOG;
 
@@ -257,6 +262,10 @@ class PauseSubState extends MusicBeatSubstate
 					PlayState.instance.botplayTxt.visible = PlayState.instance.cpuControlled;
 					PlayState.instance.botplayTxt.alpha = 1;
 					PlayState.instance.botplaySine = 0;
+				case "Exit to Options":
+					toOptions = true;
+					MusicBeatState.switchState(new options.OptionsState());
+					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				case "Exit to menu":
 					PlayState.deathCounter = 0;
 					PlayState.seenCutscene = false;

--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -106,7 +106,12 @@ class OptionsState extends MusicBeatState
 
 		if (controls.BACK) {
 			FlxG.sound.play(Paths.sound('cancelMenu'));
-			MusicBeatState.switchState(new MainMenuState());
+			if (PauseSubState.toOptions) {
+				MusicBeatState.switchState(new PlayState());
+				FlxG.sound.music.stop();
+				} else {
+				MusicBeatState.switchState(new MainMenuState());
+				}
 		}
 
 		if (controls.ACCEPT) {


### PR DESCRIPTION
on Charting Mode, you can now exit to the Options Menu, and go back directly to the same song you were before

![image](https://user-images.githubusercontent.com/45212377/171783374-303fc72f-9eff-4a5c-bf3a-933ef3090cc9.png)