### PR TITLE
Remove unnecesary checks & instatiating in TitleState

### DIFF
--- a/source/TitleState.hx
+++ b/source/TitleState.hx
@@ -526,12 +526,12 @@ class TitleState extends MusicBeatState
 
 	function createCoolText(textArray:Array<String>, ?offset:Float = 0)
 	{
-		for (i in 0...textArray.length)
-		{
-			var money:Alphabet = new Alphabet(0, 0, textArray[i], true, false);
-			money.screenCenter(X);
-			money.y += (i * 60) + 200 + offset;
-			if(credGroup != null && textGroup != null) {
+		if (credGroup != null) {
+			for (i in 0...textArray.length)
+			{
+				var money:Alphabet = new Alphabet(0, 0, textArray[i], true, false);
+				money.screenCenter(X);
+				money.y += (i * 60) + 200 + offset;
 				credGroup.add(money);
 				textGroup.add(money);
 			}
@@ -540,7 +540,7 @@ class TitleState extends MusicBeatState
 
 	function addMoreText(text:String, ?offset:Float = 0)
 	{
-		if(textGroup != null && credGroup != null) {
+		if(credGroup != null) {
 			var coolText:Alphabet = new Alphabet(0, 0, text, true, false);
 			coolText.screenCenter(X);
 			coolText.y += (textGroup.length * 60) + 200 + offset;


### PR DESCRIPTION
Originally, createCoolText() only had the null checks when adding the Alphabet objects, but it still meant instantiating them, this change moves the if statement to only run the for loop which instantiates and adds title text if credGroup is not null.

I also removed the textGroup check as textGroup is never removed from the state (and is never added), and I doubt most people are using the createCoolText() and addMoreText() functions before textGroup is instatiated.

I doubt this optimizes the game by a lot, but I guess it's still one.