### PR TITLE
Add RAM peak counter

### DIFF
--- a/source/openfl/display/FPS.hx
+++ b/source/openfl/display/FPS.hx
@@ -31,6 +31,7 @@ class FPS extends TextField
 		The current frame rate, expressed using frames-per-second
 	**/
 	public var currentFPS(default, null):Int;
+	private var memoryMegasPeak:Float = 0;
 
 	@:noCompletion private var cacheCount:Int;
 	@:noCompletion private var currentTime:Float;
@@ -46,7 +47,7 @@ class FPS extends TextField
 		currentFPS = 0;
 		selectable = false;
 		mouseEnabled = false;
-		defaultTextFormat = new TextFormat("_sans", 14, color);
+		defaultTextFormat = new TextFormat("_sans", 12, color);
 		autoSize = LEFT;
 		multiline = true;
 		text = "FPS: ";
@@ -87,7 +88,10 @@ class FPS extends TextField
 			
 			#if openfl
 			memoryMegas = Math.abs(FlxMath.roundDecimal(System.totalMemory / 1000000, 1));
-			text += "\nMemory: " + memoryMegas + " MB";
+
+			if (memoryMegas > memoryMegasPeak) memoryMegasPeak = memoryMegas;
+			
+			text += "\nRAM: " + memoryMegas + "mb/" + memoryMegasPeak + "mb";
 			#end
 
 			textColor = 0xFFFFFFFF;

--- a/source/openfl/display/FPS.hx
+++ b/source/openfl/display/FPS.hx
@@ -47,7 +47,7 @@ class FPS extends TextField
 		currentFPS = 0;
 		selectable = false;
 		mouseEnabled = false;
-		defaultTextFormat = new TextFormat("_sans", 12, color);
+		defaultTextFormat = new TextFormat("_sans", 14, color);
 		autoSize = LEFT;
 		multiline = true;
 		text = "FPS: ";


### PR DESCRIPTION
Tells you the highest the ram counter ever went, just like the one from the current dev build of fnf (you can see it on mastereric's twitter or here: https://twitter.com/EliteMasterEric/status/1508977572461359111)