### PR TITLE
Ignore unsupported types in returns and fixes Function_Stop

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2729,6 +2729,24 @@ class FunkinLua {
 		#end
 	}
 
+	// some fuckery fucks with linc_luajit
+	function getResult(l:State, result:Int):Any {
+		var ret:Any = null;
+
+		switch(Lua.type(l, result)) {
+			case Lua.LUA_TNIL:
+				ret = null;
+			case Lua.LUA_TBOOLEAN:
+				ret = Lua.toboolean(l, -1);
+			case Lua.LUA_TNUMBER:
+				ret = Lua.tonumber(l, -1);
+			case Lua.LUA_TSTRING:
+				ret = Lua.tostring(l, -1);
+		}
+		
+		return ret;
+	}
+
 	var lastCalledFunction:String = '';
 	public function call(func:String, args:Array<Dynamic>): Dynamic{
 		#if LUA_ALLOWED
@@ -2757,7 +2775,7 @@ class FunkinLua {
 			}
 			else
 			{
-				var conv:Dynamic = Convert.fromLua(lua, -1); // it's -1 instead of result idfk how lua works IT DOESNT RETURN WHEN ITS NOT -1
+				var conv:Dynamic = cast getResult(lua, result);
 				Lua.pop(lua, 1);
 				if(conv == null) conv = Function_Continue;
 				return conv;

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2791,7 +2791,8 @@ class FunkinLua {
 
 	#if LUA_ALLOWED
 	function resultIsAllowed(leLua:State, leResult:Null<Int>) { //Makes it ignore warnings
-		return Lua.type(leLua, leResult) >= Lua.LUA_TNIL;
+		var type:Int = Lua.type(leLua, leResult);
+		return type >= Lua.LUA_TNIL && type < Lua.LUA_TTABLE && type != Lua.LUA_TLIGHTUSERDATA;
 	}
 
 	function isErrorAllowed(error:String) {

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2739,6 +2739,10 @@ class FunkinLua {
 			if(lua == null) return Function_Continue;
 
 			Lua.getglobal(lua, func);
+			var type:Int = Lua.type(lua, -1);
+			if (type != Lua.LUA_TFUNCTION) {
+				return Function_Continue;
+			}
 			
 			for(arg in args) {
 				Convert.toLua(lua, arg);
@@ -2753,7 +2757,7 @@ class FunkinLua {
 			}
 			else
 			{
-				var conv:Dynamic = Convert.fromLua(lua, result);
+				var conv:Dynamic = Convert.fromLua(lua, -1); // it's -1 instead of result idfk how lua works IT DOESNT RETURN WHEN ITS NOT -1
 				Lua.pop(lua, 1);
 				if(conv == null) conv = Function_Continue;
 				return conv;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4958,8 +4958,11 @@ class PlayState extends MusicBeatState
 			if(ret == FunkinLua.Function_StopLua && !ignoreStops)
 				break;
 			
-			if(ret != FunkinLua.Function_Continue)
+			// had to do this because there is a bug in haxe where Stop != Continue doesnt work
+			var bool:Bool = ret == FunkinLua.Function_Continue;
+			if(!bool) {
 				returnVal = ret;
+			}
 		}
 		#end
 		//trace(event, returnVal);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4961,7 +4961,7 @@ class PlayState extends MusicBeatState
 			// had to do this because there is a bug in haxe where Stop != Continue doesnt work
 			var bool:Bool = ret == FunkinLua.Function_Continue;
 			if(!bool) {
-				returnVal = ret;
+				returnVal = cast ret;
 			}
 		}
 		#end


### PR DESCRIPTION
this fixes random crashes (no it isnt panic error, it was a sudden crash)
this example script crashes psych without this pr
```lua
local song = {
asdasd = "",
cool = ""
}

function onSongStart()
	song.cool = "nice"
end
```

~~just a two line changes on resultIsAllowed function~~ << lol nvm
(not sure if this would work for other peoples or for old lincluajit, please test this out and lmk if it works)
(edit: it works with old lincluajit and for other pc)