### PR TITLE
Fix score adding again

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3949,12 +3949,12 @@ class PlayState extends MusicBeatState
 
 		//tryna do MS based judgment due to popular demand
 		var daRating:Rating = Conductor.judgeNote(note, noteDiff);
-		var ratingNum:Int = 0;
 
 		totalNotesHit += daRating.ratingMod;
 		note.ratingMod = daRating.ratingMod;
 		if(!note.ratingDisabled) daRating.increase();
 		note.rating = daRating.name;
+		score = daRating.score;
 
 		if(daRating.noteSplash && !note.noteSplashDisabled)
 		{


### PR DESCRIPTION
**Issue:**
You can be as bad as you can, but your score will look like you're a god (`shit = +350, bad = +350` etc.)
**Fix:**
Use `Rating.score` to determine what score to award

**Introduced in:** 
https://github.com/ShadowMario/FNF-PsychEngine/commit/87cd7d2e6c842a4727f404a7af01a3d264055692

**Notes:** 
ShadowMario, HOW???
Also I deleted the `ratingNum` variable because it is unused