### PR TITLE
Faster playback rates

### DIFF
--- a/source/Conductor.hx
+++ b/source/Conductor.hx
@@ -23,6 +23,7 @@ class Conductor
 	public static var songPosition:Float=0;
 	public static var lastSongPos:Float;
 	public static var offset:Float = 0;
+	public static var playbackRate:Float = 1;
 
 	//public static var safeFrames:Int = 10;
 	public static var safeZoneOffset:Float = (ClientPrefs.safeFrames / 60) * 1000; // is calculated in create(), is safeFrames in milliseconds
@@ -38,7 +39,7 @@ class Conductor
 		var data:Array<Rating> = PlayState.instance.ratingsData; //shortening cuz fuck u
 		for(i in 0...data.length-1) //skips last window (Shit)
 		{
-			if (diff <= data[i].hitWindow)
+			if (diff <= data[i].hitWindow * playbackRate)
 			{
 				return data[i];
 			}

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -154,6 +154,7 @@ class FunkinLua {
 		set('instakillOnMiss', PlayState.instance.instakillOnMiss);
 		set('botPlay', PlayState.instance.cpuControlled);
 		set('practice', PlayState.instance.practiceMode);
+		set('playbackRate', PlayState.instance.playbackRate);
 
 		for (i in 0...4) {
 			set('defaultPlayerStrumX' + i, 0);
@@ -652,6 +653,7 @@ class FunkinLua {
 				name = PlayState.SONG.song;
 			if (difficultyNum == -1)
 				difficultyNum = PlayState.storyDifficulty;
+			FlxG.timeScale = 1;
 
 			var poop = Highscore.formatSong(name, difficultyNum);
 			PlayState.SONG = Song.loadFromJson(poop, name);
@@ -1260,6 +1262,7 @@ class FunkinLua {
 				FlxTransitionableState.skipNextTransIn = true;
 				FlxTransitionableState.skipNextTransOut = true;
 			}
+			FlxG.timeScale = 1;
 
 			PlayState.cancelMusicFadeTween();
 			CustomFadeTransition.nextCamera = PlayState.instance.camOther;

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -58,13 +58,16 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 		}
 		optionsArray.push(option);
 
-		/*var option:GameplayOption = new GameplayOption('Playback Rate', 'songspeed', 'float', 1);
+		#if cpp
+		var option:GameplayOption = new GameplayOption('Playback Rate', 'songspeed', 'float', 1);
 		option.scrollSpeed = 1;
-		option.minValue = 0.5;
+		option.minValue = 1;
 		option.maxValue = 2.5;
-		option.changeValue = 0.1;
+		option.decimals = 2;
+		option.changeValue = 0.01;
 		option.displayFormat = '%vX';
-		optionsArray.push(option);*/
+		optionsArray.push(option);
+		#end
 
 		var option:GameplayOption = new GameplayOption('Health Gain Multiplier', 'healthgain', 'float', 1);
 		option.scrollSpeed = 2.5;

--- a/source/PauseSubState.hx
+++ b/source/PauseSubState.hx
@@ -283,6 +283,7 @@ class PauseSubState extends MusicBeatSubstate
 
 	public static function restartSong(noTrans:Bool = false)
 	{
+		FlxG.timeScale = 1;
 		PlayState.instance.paused = true; // For lua
 		FlxG.sound.music.volume = 0;
 		PlayState.instance.vocals.volume = 0;
@@ -382,6 +383,6 @@ class PauseSubState extends MusicBeatSubstate
 
 	function updateSkipTimeText()
 	{
-		skipTimeText.text = FlxStringUtil.formatTime(Math.max(0, Math.floor(curTime / 1000)), false) + ' / ' + FlxStringUtil.formatTime(Math.max(0, Math.floor(FlxG.sound.music.length / 1000)), false);
+		skipTimeText.text = FlxStringUtil.formatTime(Math.max(0, Math.floor(curTime / Conductor.playbackRate / 1000)), false) + ' / ' + FlxStringUtil.formatTime(Math.max(0, Math.floor(FlxG.sound.music.length / Conductor.playbackRate / 1000)), false);
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2743,6 +2743,9 @@ class PlayState extends MusicBeatState
 			@:privateAccess
 			{
 				var audio = [FlxG.sound.music, vocals];
+				for (sound in modchartSounds) {
+					audio.push(sound);
+				}
 				for (i in audio) {
 					if (i != null && i.playing && i._channel != null && i._channel.__source != null && i._channel.__source.__backend != null && i._channel.__source.__backend.handle != null) {
 						AL.sourcef(i._channel.__source.__backend.handle, AL.PITCH, playbackRate);

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2720,10 +2720,10 @@ class PlayState extends MusicBeatState
 	{
 		if (FlxG.sound.music == null || vocals == null || startingSong || endingSong || finishTimer != null) return;
 
-		if (playbackRate != 1) FlxG.sound.music.pause();
+		if (playbackRate < 1) FlxG.sound.music.pause();
 		vocals.pause();
 
-		if (playbackRate == 1) {
+		if (playbackRate >= 1) {
 			FlxG.sound.music.play();
 			Conductor.songPosition = FlxG.sound.music.time;
 		} else {


### PR DESCRIPTION
Adds the unused gameplay modifier that changes the song's playback rate, up to 2.5x speed. It uses `FlxG.timeScale` so basically everything will automatically be sped up, including timers, tweens, and animations, without having to do it manually.
Slower playback rates are _possible_ but they cause audio errors near the end of the song so I opted to remove them for now.

Would've included a video but there's an upload size limit.