### PR TITLE
Chart editor crash fix involving events.

### DIFF
--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1462,7 +1462,7 @@ class ChartingState extends MusicBeatState
 			else if(curSelectedNote != null)
 			{
 				// this prevents a crash involving placing an event and then a note but still writing values to the event
-				var keepYourselfSafe = curSelectedNote[1] != null && curSelectedNote[1][curEventSelected] != null;
+				var keepYourselfSafe:Bool = curSelectedNote[1] != null && curSelectedNote[1][curEventSelected] != null;
 				if (keepYourselfSafe && sender == value1InputText) {
 					curSelectedNote[1][curEventSelected][1] = value1InputText.text;
 					updateGrid();

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1461,15 +1461,17 @@ class ChartingState extends MusicBeatState
 			}
 			else if(curSelectedNote != null)
 			{
-				if(sender == value1InputText) {
+				// this prevents a crash involving placing an event and then a note but still writing values to the event
+				var keepYourselfSafe = curSelectedNote[1] != null && curSelectedNote[1][curEventSelected] != null;
+				if (keepYourselfSafe && sender == value1InputText) {
 					curSelectedNote[1][curEventSelected][1] = value1InputText.text;
 					updateGrid();
 				}
-				else if(sender == value2InputText) {
+				else if (keepYourselfSafe && sender == value2InputText) {
 					curSelectedNote[1][curEventSelected][2] = value2InputText.text;
 					updateGrid();
 				}
-				else if(sender == strumTimeInputText) {
+				else if (sender == strumTimeInputText) {
 					var value:Float = Std.parseFloat(strumTimeInputText.text);
 					if(Math.isNaN(value)) value = 0;
 					curSelectedNote[0] = value;


### PR DESCRIPTION
This pull requests goal is to help save a few charts or annoying crashes by getting rid of a bug that may not be too hard to run into.
The bug in question is a Null Object Reference that causes the game to crash immediately due to a small oversight.

How to activate the bug:
- Step 1: Open the latest version of Psych Engine.
- Step 2: Hit 7 on the menu or enter a free play song.
- Step 3: Enter the chart editor. (Option in menu, 7 in free play)
- Step 4: Place an event randomly. It doesn't need any data, but you can add it if you wish.
- Step 5: Place a note randomly. It doesn't matter what note, just anything but an event.
- Step 6: Type inside of "Value 1" or "Value 2" in the event tab. This will cause the game to crash.

The cause:
- A small oversight on [this line](https://github.com/ShadowMario/FNF-PsychEngine/blob/main/source/editors/ChartingState.hx#L1465) and [this other line](https://github.com/ShadowMario/FNF-PsychEngine/blob/main/source/editors/ChartingState.hx#L1469) of [ChartingState.hx](https://github.com/ShadowMario/FNF-PsychEngine/blob/main/source/editors/ChartingState.hx).

Changes in the pull request to fix the issue:
- A bool that checks for nullified values of _curSelectedNote[1]_ and _curSelectedNote[1][curEventSelected]_.