### PR TITLE
Change minimum delay to -500 miliseconds

### DIFF
--- a/source/options/NoteOffsetState.hx
+++ b/source/options/NoteOffsetState.hx
@@ -31,7 +31,7 @@ class NoteOffsetState extends MusicBeatState
 	var dumbTexts:FlxTypedGroup<FlxText>;
 
 	var barPercent:Float = 0;
-	var delayMin:Int = 0;
+	var delayMin:Int = -500;
 	var delayMax:Int = 500;
 	var timeBarBG:FlxSprite;
 	var timeBar:FlxBar;


### PR DESCRIPTION
-500 is probably unrealistically low, but it makes the bar nice and even. More to the point, this fixes #8465.

I expected this to involve more pain, like changing an unsigned integer type or changing how the configuration is saved. It's none of that.