### PR TITLE
Fix crashes with Character Editor when using Forbidden Windows names.

### DIFF
--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -758,7 +758,28 @@ class CharacterEditorState extends MusicBeatState
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
 		if(id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText)) {
-			if(sender == healthIconInputText) {
+			if(sender == healthIconInputText && healthIconInputText.text != 'AUX' // Fix crash when using forbidden Windows names.
+				|| healthIconInputText.text != 'CON'
+			    || healthIconInputText.text != 'PRN'
+				|| healthIconInputText.text != 'NUL'
+				|| healthIconInputText.text != 'COM1'
+				|| healthIconInputText.text != 'COM2'
+				|| healthIconInputText.text != 'COM3'
+				|| healthIconInputText.text != 'COM4'
+				|| healthIconInputText.text != 'COM5'
+				|| healthIconInputText.text != 'COM6'
+				|| healthIconInputText.text != 'COM7'
+				|| healthIconInputText.text != 'COM8'
+				|| healthIconInputText.text != 'COM9'
+				|| healthIconInputText.text != 'LPT1'
+				|| healthIconInputText.text != 'LPT2'
+				|| healthIconInputText.text != 'LPT3'
+				|| healthIconInputText.text != 'LPT4'
+				|| healthIconInputText.text != 'LPT5'
+				|| healthIconInputText.text != 'LPT6'
+				|| healthIconInputText.text != 'LPT7'
+				|| healthIconInputText.text != 'LPT8'
+				|| healthIconInputText.text != 'LPT9') {
 				leHealthIcon.changeIcon(healthIconInputText.text);
 				char.healthIcon = healthIconInputText.text;
 				updatePresence();

--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -758,28 +758,16 @@ class CharacterEditorState extends MusicBeatState
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
 		if(id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText)) {
-			if(sender == healthIconInputText && healthIconInputText.text != 'AUX' // Fix crash when using forbidden Windows names.
-				|| healthIconInputText.text != 'CON'
-			    || healthIconInputText.text != 'PRN'
-				|| healthIconInputText.text != 'NUL'
-				|| healthIconInputText.text != 'COM1'
-				|| healthIconInputText.text != 'COM2'
-				|| healthIconInputText.text != 'COM3'
-				|| healthIconInputText.text != 'COM4'
-				|| healthIconInputText.text != 'COM5'
-				|| healthIconInputText.text != 'COM6'
-				|| healthIconInputText.text != 'COM7'
-				|| healthIconInputText.text != 'COM8'
-				|| healthIconInputText.text != 'COM9'
-				|| healthIconInputText.text != 'LPT1'
-				|| healthIconInputText.text != 'LPT2'
-				|| healthIconInputText.text != 'LPT3'
-				|| healthIconInputText.text != 'LPT4'
-				|| healthIconInputText.text != 'LPT5'
-				|| healthIconInputText.text != 'LPT6'
-				|| healthIconInputText.text != 'LPT7'
-				|| healthIconInputText.text != 'LPT8'
-				|| healthIconInputText.text != 'LPT9') {
+			if (sender == healthIconInputText) {
+				var forbidden:Array<String> = ['AUX', 'CON', 'PRN', 'NUL']; // thanks kingyomoma
+				for (i in 1...9) {
+					forbidden.push('COM$i');
+					forbidden.push('LPT$i');
+				}
+			
+				for (donot in forbidden) {
+					if (sender.text == donot) return;
+				}
 				leHealthIcon.changeIcon(healthIconInputText.text);
 				char.healthIcon = healthIconInputText.text;
 				updatePresence();

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -2899,18 +2899,28 @@ class ChartingState extends MusicBeatState
 
 	function loadJson(song:String):Void
 	{
-		//shitty null fix, i fucking hate it when this happens
-		//make it look sexier if possible
-		if (CoolUtil.difficulties[PlayState.storyDifficulty] != CoolUtil.defaultDifficulty) {
-			if(CoolUtil.difficulties[PlayState.storyDifficulty] == null){
-				PlayState.SONG = Song.loadFromJson(song.toLowerCase(), song.toLowerCase());
-			}else{
-				PlayState.SONG = Song.loadFromJson(song.toLowerCase() + "-" + CoolUtil.difficulties[PlayState.storyDifficulty], song.toLowerCase());
-			}
-		}else{
-		PlayState.SONG = Song.loadFromJson(song.toLowerCase(), song.toLowerCase());
+		var forbidden:Array<String> = ['AUX', 'CON', 'PRN', 'NUL']; // thanks kingyomoma
+		for (i in 1...9) {
+			forbidden.push('COM$i');
+			forbidden.push('LPT$i');
 		}
-		MusicBeatState.resetState();
+		for(donot in forbidden)
+		if (song == donot){
+			return;
+		} else {
+			//shitty null fix, i fucking hate it when this happens
+			//make it look sexier if possible
+			if (CoolUtil.difficulties[PlayState.storyDifficulty] != CoolUtil.defaultDifficulty) {
+				if(CoolUtil.difficulties[PlayState.storyDifficulty] == null){
+					PlayState.SONG = Song.loadFromJson(song.toLowerCase(), song.toLowerCase());
+				}else{
+					PlayState.SONG = Song.loadFromJson(song.toLowerCase() + "-" + CoolUtil.difficulties[PlayState.storyDifficulty], song.toLowerCase());
+				}
+			}else{
+			PlayState.SONG = Song.loadFromJson(song.toLowerCase(), song.toLowerCase());
+			}
+			MusicBeatState.resetState();
+		}
 	}
 
 	function autosaveSong():Void

--- a/source/editors/DialogueCharacterEditorState.hx
+++ b/source/editors/DialogueCharacterEditorState.hx
@@ -1,6 +1,5 @@
 package editors;
 
-import cpp.abi.Abi;
 #if desktop
 import Discord.DiscordClient;
 #end

--- a/source/editors/DialogueCharacterEditorState.hx
+++ b/source/editors/DialogueCharacterEditorState.hx
@@ -1,5 +1,6 @@
 package editors;
 
+import cpp.abi.Abi;
 #if desktop
 import Discord.DiscordClient;
 #end
@@ -484,6 +485,14 @@ class DialogueCharacterEditorState extends MusicBeatState
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
 		if(id == FlxUIInputText.CHANGE_EVENT && sender == imageInputText) {
+			var forbidden:Array<String> = ['AUX', 'CON', 'PRN', 'NUL']; // thanks kingyomoma
+			for (i in 1...9) {
+				forbidden.push('COM$i');
+				forbidden.push('LPT$i');
+			}
+            for(donot in forbidden) {
+				if(sender.text == donot) return;
+			}
 			character.jsonFile.image = imageInputText.text;
 		} else if(id == FlxUINumericStepper.CHANGE_EVENT && (sender is FlxUINumericStepper)) {
 			if(sender == scaleStepper) {

--- a/source/editors/DialogueEditorState.hx
+++ b/source/editors/DialogueEditorState.hx
@@ -262,9 +262,17 @@ class DialogueEditorState extends MusicBeatState
 	}
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
+		var forbidden:Array<String> = ['AUX', 'CON', 'PRN', 'NUL']; // thanks kingyomoma
+		for (i in 1...9) {
+			forbidden.push('COM$i');
+			forbidden.push('LPT$i');
+		}
 		if(id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText)) {
 			if (sender == characterInputText)
 			{
+				for (donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				character.reloadCharacterJson(characterInputText.text);
 				reloadCharacter();
 				updateTextBox();
@@ -283,11 +291,17 @@ class DialogueEditorState extends MusicBeatState
 			}
 			else if(sender == lineInputText)
 			{
+				for (donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				reloadText(0);
 				dialogueFile.dialogue[curSelected].text = lineInputText.text;
 			}
 			else if(sender == soundInputText)
 			{
+				for (donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				dialogueFile.dialogue[curSelected].sound = soundInputText.text;
 				reloadText(0);
 			}

--- a/source/editors/MenuCharacterEditorState.hx
+++ b/source/editors/MenuCharacterEditorState.hx
@@ -255,12 +255,26 @@ class MenuCharacterEditorState extends MusicBeatState
 	}
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
+		var forbidden:Array<String> = ['AUX', 'CON', 'PRN', 'NUL']; // thanks kingyomoma
+		for (i in 1...9) {
+			forbidden.push('COM$i');
+			forbidden.push('LPT$i');
+		}
 		if(id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText)) {
 			if(sender == imageInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				characterFile.image = imageInputText.text;
 			} else if(sender == idleInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				characterFile.idle_anim = idleInputText.text;
 			} else if(sender == confirmInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				characterFile.confirm_anim = confirmInputText.text;
 			}
 		} else if(id == FlxUINumericStepper.CHANGE_EVENT && (sender is FlxUINumericStepper)) {

--- a/source/editors/WeekEditorState.hx
+++ b/source/editors/WeekEditorState.hx
@@ -372,24 +372,47 @@ class WeekEditorState extends MusicBeatState
 	}
 	
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {
+		var forbidden:Array<String> = ['AUX', 'CON', 'PRN', 'NUL']; // thanks kingyomoma
+		for (i in 1...9) {
+			forbidden.push('COM$i');
+			forbidden.push('LPT$i');
+		}
 		if(id == FlxUIInputText.CHANGE_EVENT && (sender is FlxUIInputText)) {
 			if(sender == weekFileInputText) {
+				for (donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				weekFileName = weekFileInputText.text.trim();
 				reloadWeekThing();
 			} else if(sender == opponentInputText || sender == boyfriendInputText || sender == girlfriendInputText) {
+				for (fuckyou in forbidden){
+					if(sender.text == fuckyou) return;
+				}
 				weekFile.weekCharacters[0] = opponentInputText.text.trim();
 				weekFile.weekCharacters[1] = boyfriendInputText.text.trim();
 				weekFile.weekCharacters[2] = girlfriendInputText.text.trim();
 				updateText();
 			} else if(sender == backgroundInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				weekFile.weekBackground = backgroundInputText.text.trim();
 				reloadBG();
 			} else if(sender == displayNameInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				weekFile.storyName = displayNameInputText.text.trim();
 				updateText();
 			} else if(sender == weekNameInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				weekFile.weekName = weekNameInputText.text.trim();
 			} else if(sender == songsInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				var splittedText:Array<String> = songsInputText.text.trim().split(',');
 				for (i in 0...splittedText.length) {
 					splittedText[i] = splittedText[i].trim();
@@ -412,8 +435,14 @@ class WeekEditorState extends MusicBeatState
 				}
 				updateText();
 			} else if(sender == weekBeforeInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				weekFile.weekBefore = weekBeforeInputText.text.trim();
 			} else if(sender == difficultiesInputText) {
+				for(donot in forbidden){
+					if(sender.text == donot) return;
+				}
 				weekFile.difficulties = difficultiesInputText.text.trim();
 			}
 		}


### PR DESCRIPTION
Fix crash when using forbidden Windows
names in the Character Editor, referencing this issue: #9902 
If this gets closed then so be it.