### PR TITLE
Quick Project.xml fixes, for hscript and debugging

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -130,6 +130,7 @@
 	<haxelib name="flixel-addons" />
 	<haxelib name="hscript" />
 	<define name="hscriptPos" />
+	<haxeflag name="-dce no" />
 
 	<!--In case you want to use the ui package-->
 	<haxelib name="flixel-ui" />
@@ -138,7 +139,7 @@
 	<haxelib name="faxe" if='switch'/>
 	<!--<haxelib name="polymod"/> -->
 	<haxelib name="discord_rpc" if="desktop"/>
-	<!-- <haxelib name="hxcpp-debug-server" if="desktop"/> -->
+	<haxelib name="hxcpp-debug-server" if="debug"/>
 
 	<!-- <haxelib name="markdown" /> -->
 	<!-- <haxelib name="HtmlParser" /> -->


### PR DESCRIPTION
1. Add `<haxeflag name="-dce no" />` to the Project.xml.

The purpose of this change is to disable Dead Code Elimination. For any Haxe files which are compiled for use in the game, any functions which have not been called are stripped from the codebase by default. This provides a minor savings on overall executable size. However, in the event that the `runHaxeCode` Lua function is run, and attempts to execute one of these functions which has been stripped by DCE, that line will confusingly fail. This line resolves this such that any classes that are called by the game will be fully preserved.

Keep in mind that for those classes which are not called by the game, you will need to add `<haxeflag name="--macro" value="include('funkin')" />`, replacing `funkin` with the name a package of Haxe classes to preserve for use by HScript. If you wish to do this for the engine codebase (allowing classes which are defined and unused except by HScript utilities), you will need to move the entire codebase into a package (this is relatively simple to do, just make a `funkin` folder in the `source` directory and move all the `hx` files into it)

2. Uncomment `<haxelib name="hxcpp-debug-server" />` and enable it in debug mode.

This library is important for source development which utilizes the debugger built into Visual Studio Code. Learn more by reading this guide:

# **EDIT**: Anyone reviewing this PR should click this link it's a very useful and powerful development tool that will drastically improve your coding abilities.
 https://twitter.com/EliteMasterEric/status/1535814918917734400