### PR TITLE
Probably better of clearing unused memory (In my opinion)

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1370,7 +1370,6 @@ class PlayState extends MusicBeatState
 					Paths.music(key);
 			}
 		}
-		Paths.clearUnusedMemory();
 		
 		CustomFadeTransition.nextCamera = camOther;
 	}
@@ -4890,6 +4889,7 @@ class PlayState extends MusicBeatState
 		}
 	}
 
+	@:access(flixel.FlxGame)
 	override function destroy() {
 		for (lua in luaArray) {
 			lua.call('onDestroy', []);
@@ -4905,6 +4905,10 @@ class PlayState extends MusicBeatState
 		#if hscript
 		FunkinLua.haxeInterp = null;
 		#end
+
+		if(!(cast FlxG.game._requestedState is PlayState)) {
+			Paths.clearUnusedMemory();
+		}
 		super.destroy();
 	}
 


### PR DESCRIPTION
The cached assets will stay until no longer in the PlayState. I think this is useful because there would be an asset that has been cached that’ll be created after the create function has been run, or a mod could be using the same asset the song after.