### PR TITLE
Texture "or blank" stuff for splashes

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -190,7 +190,7 @@ class FunkinLua {
 		set('lowQuality', ClientPrefs.lowQuality);
 		set("scriptName", scriptName);
 		set('isPixelStage', PlayState.isPixelStage); // BTW idrk if these will actually work properly since I don't fully know what I'm doing with haxe lmao I only have some understandings like how I had to add the "PlayState." part
-		set('isPixelStage', PlayState.curStage);
+		set('curStage', PlayState.curStage);
 
 		#if windows
 		set('buildTarget', 'windows');

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -189,7 +189,7 @@ class FunkinLua {
 		set('noResetButton', ClientPrefs.noReset);
 		set('lowQuality', ClientPrefs.lowQuality);
 		set("scriptName", scriptName);
-		set('isPixelStage', PlayState.isPixelStage); // BTW idrk if these will actually work properly since I don't fully know what I'm doing with haxe lmao
+		set('isPixelStage', PlayState.isPixelStage); // BTW idrk if these will actually work properly since I don't fully know what I'm doing with haxe lmao I only have some understandings like how I had to add the "PlayState." part
 		set('isPixelStage', PlayState.curStage);
 
 		#if windows

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -189,6 +189,8 @@ class FunkinLua {
 		set('noResetButton', ClientPrefs.noReset);
 		set('lowQuality', ClientPrefs.lowQuality);
 		set("scriptName", scriptName);
+		set('isPixelStage', PlayState.isPixelStage); // BTW idrk if these will actually work properly since I don't fully know what I'm doing with haxe lmao
+		set('isPixelStage', PlayState.curStage);
 
 		#if windows
 		set('buildTarget', 'windows');

--- a/source/NoteSplash.hx
+++ b/source/NoteSplash.hx
@@ -29,6 +29,7 @@ class NoteSplash extends FlxSprite
 		setPosition(x - Note.swagWidth * 0.95, y - Note.swagWidth);
 		alpha = 0.6;
 
+		// Checking for '' too prevent that wierd splash bug
 		if(texture == null || texture == '') {
 			texture = 'noteSplashes';
 			if((PlayState.SONG.splashSkin != null || PlayState.SONG.splashSkin != '') && PlayState.SONG.splashSkin.length > 0) texture = PlayState.SONG.splashSkin;

--- a/source/NoteSplash.hx
+++ b/source/NoteSplash.hx
@@ -14,7 +14,7 @@ class NoteSplash extends FlxSprite
 		super(x, y);
 
 		var skin:String = 'noteSplashes';
-		if(PlayState.SONG.splashSkin != null && PlayState.SONG.splashSkin.length > 0) skin = PlayState.SONG.splashSkin;
+		if((PlayState.SONG.splashSkin != null || PlayState.SONG.splashSkin != '') && PlayState.SONG.splashSkin.length > 0) skin = PlayState.SONG.splashSkin;
 
 		loadAnims(skin);
 		
@@ -29,9 +29,9 @@ class NoteSplash extends FlxSprite
 		setPosition(x - Note.swagWidth * 0.95, y - Note.swagWidth);
 		alpha = 0.6;
 
-		if(texture == null) {
+		if(texture == null || texture == '') {
 			texture = 'noteSplashes';
-			if(PlayState.SONG.splashSkin != null && PlayState.SONG.splashSkin.length > 0) texture = PlayState.SONG.splashSkin;
+			if((PlayState.SONG.splashSkin != null || PlayState.SONG.splashSkin != '') && PlayState.SONG.splashSkin.length > 0) texture = PlayState.SONG.splashSkin;
 		}
 
 		if(textureLoaded != texture) {

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4728,7 +4728,7 @@ class PlayState extends MusicBeatState
 
 	public function spawnNoteSplash(x:Float, y:Float, data:Int, ?note:Note = null) {
 		var skin:String = 'noteSplashes';
-		if(PlayState.SONG.splashSkin != null && PlayState.SONG.splashSkin.length > 0) skin = PlayState.SONG.splashSkin;
+		if((PlayState.SONG.splashSkin != null || PlayState.SONG.splashSkin != '') && PlayState.SONG.splashSkin.length > 0) skin = PlayState.SONG.splashSkin;
 
 		var hue:Float = 0;
 		var sat:Float = 0;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -4728,6 +4728,7 @@ class PlayState extends MusicBeatState
 
 	public function spawnNoteSplash(x:Float, y:Float, data:Int, ?note:Note = null) {
 		var skin:String = 'noteSplashes';
+		// Checking for '' too prevent that wierd splash bug
 		if((PlayState.SONG.splashSkin != null || PlayState.SONG.splashSkin != '') && PlayState.SONG.splashSkin.length > 0) skin = PlayState.SONG.splashSkin;
 
 		var hue:Float = 0;


### PR DESCRIPTION
Basically, it checked only for "null" before and I added "or ''"

This should also hopefully fix when you have the splashes box in the chart editor as blank!