### PR TITLE
Added sampler2D input support to FlxRuntimeShader

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -470,7 +470,7 @@ class FunkinLua {
 			}
 			#end
 			#else
-			luaTrace("setShaderFloatArray: Platform unsupported for Runtime Shaders!", false, false, FlxColor.RED);
+			luaTrace("setShaderSampler2D: Platform unsupported for Runtime Shaders!", false, false, FlxColor.RED);
 			#end
 		});
 

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -1,5 +1,6 @@
 package;
 
+import openfl.display.BitmapData;
 #if LUA_ALLOWED
 import llua.Lua;
 import llua.LuaL;
@@ -449,6 +450,25 @@ class FunkinLua {
 			if(shader == null) return;
 
 			shader.setFloatArray(prop, values);
+			#else
+			luaTrace("setShaderFloatArray: Platform unsupported for Runtime Shaders!", false, false, FlxColor.RED);
+			#end
+		});
+
+		Lua_helper.add_callback(lua, "setShaderSampler2D", function(obj:String, prop:String, bitmapdataPath:String) {
+			#if (!flash && MODS_ALLOWED && sys)
+			var shader:FlxRuntimeShader = getShader(obj);
+			if(shader == null) return;
+
+			#if MODS_ALLOWED
+			// trace('bitmapdatapath: $bitmapdataPath');
+			var value = Paths.image(bitmapdataPath);
+			if(value != null && value.bitmap != null)
+			{
+				// trace('Found bitmapdata. Width: ${value.bitmap.width} Height: ${value.bitmap.height}');
+				shader.setSampler2D(prop, value.bitmap);
+			}
+			#end
 			#else
 			luaTrace("setShaderFloatArray: Platform unsupported for Runtime Shaders!", false, false, FlxColor.RED);
 			#end

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -460,7 +460,6 @@ class FunkinLua {
 			var shader:FlxRuntimeShader = getShader(obj);
 			if(shader == null) return;
 
-			#if MODS_ALLOWED
 			// trace('bitmapdatapath: $bitmapdataPath');
 			var value = Paths.image(bitmapdataPath);
 			if(value != null && value.bitmap != null)
@@ -468,7 +467,6 @@ class FunkinLua {
 				// trace('Found bitmapdata. Width: ${value.bitmap.width} Height: ${value.bitmap.height}');
 				shader.setSampler2D(prop, value.bitmap);
 			}
-			#end
 			#else
 			luaTrace("setShaderSampler2D: Platform unsupported for Runtime Shaders!", false, false, FlxColor.RED);
 			#end

--- a/source/flixel/addons/display/FlxRuntimeShader.hx
+++ b/source/flixel/addons/display/FlxRuntimeShader.hx
@@ -616,6 +616,22 @@ class FlxRuntimeShader extends FlxShader
 	}
 
 	/**
+	 * Set or modify a sampler2D input of the shader.
+	 * @param name The name of the shader input to modify.
+	 * @param value The texture to use as the sampler2D input.
+	 */
+	public function setSampler2D(name:String, value:BitmapData)
+	{
+		var prop:ShaderInput<BitmapData> = Reflect.field(this.data, name);
+		if(prop == null)
+		{
+			trace('[WARNING] Shader sampler2D property ${name} not found.');
+			return;
+		}
+		prop.input = value;
+	}
+
+	/**
 	 * Retrieve a float parameter of the shader.
 	 * @param name The name of the parameter to retrieve.
 	 */


### PR DESCRIPTION
FlxRuntimeShader currently doesn't seem to have a method to set sampler2D inputs on the run-time shaders. This pr adds support for sampler2D inputs as well. It also adds a corresponding lua function to set/manipulate these inputs as well.
Usage in lua:
```lua
initLuaShader('your-shader-name')
setSpriteShader('your-sprite', 'your-shader-name')
setShaderSampler2D('your-sprite', 'my_tex_input', 'path-to-image-to-use-as-sampler2d')
```

In the shader:
```glsl
uniform sampler2D my_tex_input;
void main()
{
    // stuff you wanna do with the texture input
}
```
