### PR TITLE
Automatic Zoom on Beat chart option

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -5081,7 +5081,7 @@ class PlayState extends MusicBeatState
 				moveCameraSection();
 			}
 
-			if (camZooming && FlxG.camera.zoom < 1.35 && ClientPrefs.camZooms)
+			if (camZooming && FlxG.camera.zoom < 1.35 && ClientPrefs.camZooms && SONG.autoZoom)
 			{
 				FlxG.camera.zoom += 0.015 * camZoomingMult;
 				camHUD.zoom += 0.03 * camZoomingMult;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -173,6 +173,7 @@ class PlayState extends MusicBeatState
 	public var camZoomingMult:Float = 1;
 	public var camZoomingDecay:Float = 1;
 	private var curSong:String = "";
+	public var zoomOnBeat:Bool = true;
 
 	public var gfSpeed:Int = 1;
 	public var health:Float = 1;
@@ -2403,6 +2404,7 @@ class PlayState extends MusicBeatState
 		Conductor.changeBPM(songData.bpm);
 
 		curSong = songData.song;
+		zoomOnBeat = SONG.autoZoom;  // Creating a variable for this so it can be easily changed through lua or events  - Nex
 
 		if (SONG.needsVoices)
 			vocals = new FlxSound().loadEmbedded(Paths.voices(PlayState.SONG.song));
@@ -5081,7 +5083,7 @@ class PlayState extends MusicBeatState
 				moveCameraSection();
 			}
 
-			if (camZooming && FlxG.camera.zoom < 1.35 && ClientPrefs.camZooms && SONG.autoZoom)
+			if (camZooming && FlxG.camera.zoom < 1.35 && ClientPrefs.camZooms && zoomOnBeat)
 			{
 				FlxG.camera.zoom += 0.015 * camZoomingMult;
 				camHUD.zoom += 0.03 * camZoomingMult;

--- a/source/Song.hx
+++ b/source/Song.hx
@@ -29,6 +29,7 @@ typedef SwagSong =
 	var arrowSkin:String;
 	var splashSkin:String;
 	var validScore:Bool;
+	var autoZoom:Bool;
 }
 
 class Song
@@ -38,6 +39,7 @@ class Song
 	public var events:Array<Dynamic>;
 	public var bpm:Float;
 	public var needsVoices:Bool = true;
+	public var autoZoom:Bool = true;
 	public var arrowSkin:String;
 	public var splashSkin:String;
 	public var speed:Float = 1;
@@ -77,6 +79,8 @@ class Song
 				}
 			}
 		}
+
+		if(songJson.autoZoom == null) songJson.autoZoom = true; // Easier for everyone lol
 	}
 
 	public function new(song, notes, bpm)

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -220,7 +220,8 @@ class ChartingState extends MusicBeatState
 				gfVersion: 'gf',
 				speed: 1,
 				stage: 'stage',
-				validScore: false
+				validScore: false,
+				autoZoom: true  // The default value would be better if stays as true, Nex decided so but if you want you can change it (not recommended tho)
 			};
 			addSection();
 			PlayState.SONG = _song;
@@ -586,6 +587,13 @@ class ChartingState extends MusicBeatState
 		stageDropDown.selectedLabel = _song.stage;
 		blockPressWhileScrolling.push(stageDropDown);
 
+		var checkAutoZoom = new FlxUICheckBox(player2DropDown.x + 140, (player2DropDown.y + gfVersionDropDown.y) / 2, null, null, "Auto-Zoom on Beat", 100);
+		checkAutoZoom.checked = _song.autoZoom;
+		checkAutoZoom.callback = function()
+		{
+			_song.autoZoom = checkAutoZoom.checked;
+		};
+
 		var skin = PlayState.SONG.arrowSkin;
 		if(skin == null) skin = '';
 		noteSkinInputText = new FlxUIInputText(player2DropDown.x, player2DropDown.y + 50, 150, skin, 8);
@@ -616,6 +624,7 @@ class ChartingState extends MusicBeatState
 		tab_group_song.add(stepperSpeed);
 		tab_group_song.add(reloadNotesButton);
 		tab_group_song.add(noteSkinInputText);
+		tab_group_song.add(checkAutoZoom);
 		tab_group_song.add(noteSplashesInputText);
 		tab_group_song.add(new FlxText(stepperBPM.x, stepperBPM.y - 15, 0, 'Song BPM:'));
 		tab_group_song.add(new FlxText(stepperBPM.x + 100, stepperBPM.y - 15, 0, 'Song Offset:'));

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -221,7 +221,7 @@ class ChartingState extends MusicBeatState
 				speed: 1,
 				stage: 'stage',
 				validScore: false,
-				autoZoom: true  // The default value would be better if stays as true, Nex decided so but if you want you can change it (not recommended tho)
+				autoZoom: true
 			};
 			addSection();
 			PlayState.SONG = _song;


### PR DESCRIPTION
This is an option that I've added in the mod I'm working in and I've decided to share it, since I think that nobody ever added this in the engine. These changes add an option inside the chart editor: it will ask if you want the camera automatically zooming on beat or not. When the option is enabled the camera will automatically zoom on beat (as the usual), it's disabled, the camera won't automatically zoom on beat anymore. When it's disabled tho, it'll still be possible to put zoom events. This is very usefull if charters wants to have a part of a song without camera zooms.
Besides this, I've also added a part (in Song.hx, under the public function "onLoadJson") that automatically converts the json files with the old formats into the new one that has this new option (look the image)

![Screenshot_lmfao](https://user-images.githubusercontent.com/87421482/192867180-6f790514-9e4c-45d7-a4a2-5d621f401fab.png)

I don't really care about the checkbox position, you can edit it if you want to
I've also made a short video about all of this (sorry for the low quality, but github has a size limit lmfao)

https://user-images.githubusercontent.com/87421482/192864860-9db5bdd3-56ef-48b2-95d8-82abf48d0f9a.mp4

So yeah this is all, easy but cool thingie that I've done randomly lol