### PR TITLE
WIP: better mod handling

### DIFF
--- a/source/Mods.hx
+++ b/source/Mods.hx
@@ -1,0 +1,63 @@
+import flixel.util.FlxColor;
+import sys.FileSystem;
+import sys.io.File;
+import haxe.io.Path;
+import haxe.Json;
+
+// Represent information about a mod
+class ModInfo {
+    // The directory in which the mod is store. May be absolute or relative
+    public var folder:String;
+    // The name of the last directory that contain the mod
+    public var dirName:String;
+    // The name of the mod itself, as displayer in the UI
+	public var name:String;
+	public var description:String;
+	public var color:FlxColor;
+	public var restart:Bool; //trust me. this is very important
+    
+    public function new(folder: String) {
+        this.folder = folder;
+        this.dirName = Path.withoutDirectory(Path.removeTrailingSlashes(folder));
+        this.loadPackInfo();
+    }
+
+    public function loadPackInfo() {
+        this.name = this.dirName;
+		this.description = "No description provided.";
+		this.color = ModsMenuState.defaultColor;
+		this.restart = false;
+        
+        //Try loading json
+		var path = this.folder + '/pack.json';
+		if(FileSystem.exists(path)) {
+			var rawJson:String = File.getContent(path);
+			if(rawJson != null && rawJson.length > 0) {
+				var parsedJson:Dynamic = Json.parse(rawJson);
+                var colors:Null<Array<Dynamic>> = cast(parsedJson.colors, Null<Array<Dynamic>>);
+                var description:Null<String> = cast(parsedJson.description, Null<String>);
+                var name:Null<String> = cast(parsedJson.name, Null<String>);
+                var restart:Null<Bool> = cast(parsedJson.restart, Null<Bool>);
+				
+				// default value is "Name", and some people forget (or just don’t have to) change it
+				if (name != null && name.length > 0 && name != "Name")
+				{
+					this.name = name;
+				}
+				// same, except default is "Description"
+				if (description != null && description.length > 0 && description != "Description")
+				{
+					this.description = description;
+				}
+				if (colors != null && colors.length > 2)
+				{
+                    var colorsTyped:Array<Int> = [for (c in colors) cast(c, Int)];
+					this.color = FlxColor.fromRGB(colorsTyped[0], colorsTyped[1], colorsTyped[2]);
+				}
+                if (restart != null) {
+				    this.restart = restart;
+                }
+			}
+		}
+    }
+}

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -476,7 +476,7 @@ class Paths
 				if (dat[1] == "1")
 				{
 					var folder = dat[0];
-					var path = Paths.mods(folder + '/pack.json');
+					var path = Paths.mods(folder + '/pack.json'); //TODO:marius: rewrite using ModInfo
 					if(FileSystem.exists(path)) {
 						try{
 							var rawJson:String = File.getContent(path);


### PR DESCRIPTION
I want to add better handling for mods (due to... some ideological preference for clean mods instead of source port, with some exception... But that’s not important. Also, this started due to wanting to support mod in ~/.local/share/something on Linux (and whatever the ApplicationPath is on Windows)).

It’ll probably take a few days until I have something good with that, but here is the overview of what I plan:

Adding two class, a class ModInfo, representing a mod (and the related pack.json) and a modsList, representing the list of avalaible mod, loading or not.

ModInfo will be a pure (with no static) class, but modsList will have multiple, mostly:

a static list of Path (String) indicating folders where there are one subfolder per mods (sorted by priority list)
a static list of ModInfo, indicating the list of loaded mods
It’ll also have a function to load a list of ModInfo of all known mods, whether they are enabled or not.
(I still have a few decision to take regarding API, but I’ll take them).



I made that WIP, as I will be interested in comments regarding the way it’s made, both about the implementation and the design.
Also, it’s my first contribution here (and the first code I write in haxe, althought I’m already experienced with a bunch of other languages), so if I did anything wrong, I’ll be interested to know that too.