### PR TITLE
Playable Character check for characters other than BF

### DIFF
--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -418,6 +418,7 @@ class CharacterEditorState extends MusicBeatState
 
 		var check_player = new FlxUICheckBox(10, 60, null, null, "Playable Character", 100);
 		check_player.checked = daAnim.startsWith('bf');
+		if(!daAnim.startsWith('bf')){check_player.checked = daAnim.endsWith('-player');}
 		check_player.callback = function()
 		{
 			char.isPlayer = !char.isPlayer;
@@ -431,6 +432,7 @@ class CharacterEditorState extends MusicBeatState
 		{
 			daAnim = characterList[Std.parseInt(character)];
 			check_player.checked = daAnim.startsWith('bf');
+			if(!daAnim.startsWith('bf')){check_player.checked = daAnim.endsWith('-player');}
 			loadChar(!check_player.checked);
 			updatePresence();
 			reloadCharacterDropDown();

--- a/source/editors/CharacterEditorState.hx
+++ b/source/editors/CharacterEditorState.hx
@@ -417,8 +417,7 @@ class CharacterEditorState extends MusicBeatState
 		tab_group.name = "Settings";
 
 		var check_player = new FlxUICheckBox(10, 60, null, null, "Playable Character", 100);
-		check_player.checked = daAnim.startsWith('bf');
-		if(!daAnim.startsWith('bf')){check_player.checked = daAnim.endsWith('-player');}
+		check_player.checked = daAnim.startsWith('bf') || daAnim.endsWith('-player');
 		check_player.callback = function()
 		{
 			char.isPlayer = !char.isPlayer;
@@ -431,8 +430,7 @@ class CharacterEditorState extends MusicBeatState
 		charDropDown = new FlxUIDropDownMenuCustom(10, 30, FlxUIDropDownMenuCustom.makeStrIdLabelArray([''], true), function(character:String)
 		{
 			daAnim = characterList[Std.parseInt(character)];
-			check_player.checked = daAnim.startsWith('bf');
-			if(!daAnim.startsWith('bf')){check_player.checked = daAnim.endsWith('-player');}
+			check_player.checked = daAnim.startsWith('bf') || daAnim.endsWith('-player');
 			loadChar(!check_player.checked);
 			updatePresence();
 			reloadCharacterDropDown();


### PR DESCRIPTION
Adds an additional check for check_player in the character editor that automatically sets the variable to true if the selected character file name has the suffix "-player" as opposed to only doing that when the file name starts with BF