### PR TITLE
Bugfix for Set Property event's Boolean values

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3798,11 +3798,18 @@ class PlayState extends MusicBeatState
 				}
 
 			case 'Set Property':
-				var killMe:Array<String> = value1.split('.');
+				var trueVal:Dynamic = null;
+				var killMe:Array<String> = value1.split(',');
+				if (killMe.length > 1 && killMe[1].toLowerCase().replace(" ", "") == "bool") {
+					if (value2 == "true") trueVal = true;
+					else if (value2 == "false") trueVal = false;
+				}
+
+				killMe = killMe[0].split('.');
 				if(killMe.length > 1) {
-					FunkinLua.setVarInArray(FunkinLua.getPropertyLoopThingWhatever(killMe, true, true), killMe[killMe.length-1], value2);
+					FunkinLua.setVarInArray(FunkinLua.getPropertyLoopThingWhatever(killMe, true, true), killMe[killMe.length-1], trueVal != null ? trueVal : value2);
 				} else {
-					FunkinLua.setVarInArray(this, value1, value2);
+					FunkinLua.setVarInArray(this, value1, trueVal != null ? trueVal : value2);
 				}
 		}
 		callOnLuas('onEvent', [eventName, value1, value2]);

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -91,7 +91,7 @@ class ChartingState extends MusicBeatState
 		['Screen Shake', "Value 1: Camera shake\nValue 2: HUD shake\n\nEvery value works as the following example: \"1, 0.05\".\nThe first number (1) is the duration.\nThe second number (0.05) is the intensity."],
 		['Change Character', "Value 1: Character to change (Dad, BF, GF)\nValue 2: New character's name"],
 		['Change Scroll Speed', "Value 1: Scroll Speed Multiplier (1 is default)\nValue 2: Time it takes to change fully in seconds."],
-		['Set Property', "Value 1: Variable name\nValue 2: New value"]
+		['Set Property', "Value 1: Variable name\nValue 2: New value\n\nIf the Value is boolean add ', bool' in Value 1\nExample: boyfriend.visible, bool"]
 	];
 
 	var _file:FileReference;


### PR DESCRIPTION
Welp since Reflect is not able to convert from string to bool (not even std or libraries like them oof), this stupidly fixes the boolean values bug in Set Property event

Before this fix the event used to convert every bool into null or false if I dont get wrong; cause, for example, if you tried to put as variable **boyfriend.visible** and as value **true**, bf would just disappear as if **boyfriend.visible = false**

Well anyway, now I’ve fixed this bug in a stupid way lol