### PR TITLE
fix infinite loop when VIDEOS_ALLOWED is false in lua

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2200,11 +2200,13 @@ class FunkinLua {
 			return false;
 
 			#else
-			if(PlayState.instance.endingSong) {
-				PlayState.instance.endSong();
-			} else {
-				PlayState.instance.startCountdown();
-			}
+			new FlxTimer().start(0.05, function(tmr:FlxTimer) {
+				if(PlayState.instance.endingSong) {
+					PlayState.instance.endSong();
+				} else {
+					PlayState.instance.startCountdown();
+				}
+			});
 			return true;
 			#end
 		});


### PR DESCRIPTION
so basically when videos are disabled and you run startVideo inside of the onStartCountdown callback it instantly recalls onStartCountdown causing an infinite loop. fixed it by using a flxtimer