### PR TITLE
Fix for hold note behaviour when strum direction is changed

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -3205,6 +3205,10 @@ class PlayState extends MusicBeatState
 					}
 
 					var angleDir = strumDirection * Math.PI / 180;
+					
+					if(daNote.isSustainNote)
+						daNote.angle = strumDirection - 90;
+					
 					if (daNote.copyAngle)
 						daNote.angle = strumDirection - 90 + strumAngle;
 


### PR DESCRIPTION
When the strum line direction is changed using lua like so:
```lua
setPropertyFromGroup('strumLineNotes.members', 0, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 1, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 2, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 3, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 4, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 5, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 6, 'direction', 100)
setPropertyFromGroup('strumLineNotes.members', 7, 'direction', 100)
```
It causes the hold notes to break apart as they remain vertical even when the direction is changed.
This pr should resolve that

Before:
![brokenholds](https://user-images.githubusercontent.com/83609901/199761937-12cb4468-fa94-41cf-8f8d-9107ae0f102c.gif)

After:
![fixedholds](https://user-images.githubusercontent.com/83609901/199761985-0851d8b7-69d9-4633-9c5d-302e0a81b7b6.gif)
