### PR TITLE
Legacy Chart Support (0.5.2h and prior, other engines)

### DIFF
--- a/source/Section.hx
+++ b/source/Section.hx
@@ -3,7 +3,8 @@ package;
 typedef SwagSection =
 {
 	var sectionNotes:Array<Dynamic>;
-	var sectionBeats:Float;
+	var lengthInSteps:Int; // legacy chart support;
+	var sectionBeats:Float; // time signatures support;
 	var typeOfSection:Int;
 	var mustHitSection:Bool;
 	var gfSection:Bool;
@@ -16,6 +17,7 @@ class Section
 {
 	public var sectionNotes:Array<Dynamic> = [];
 
+	public var lengthInSteps:Int = 16;
 	public var sectionBeats:Float = 4;
 	public var gfSection:Bool = false;
 	public var typeOfSection:Int = 0;
@@ -26,9 +28,10 @@ class Section
 	 */
 	public static var COPYCAT:Int = 0;
 
-	public function new(sectionBeats:Float = 4)
+	public function new(sectionBeats:Float = 4, lengthInSteps:Int = 16)
 	{
 		this.sectionBeats = sectionBeats;
-		trace('test created section: ' + sectionBeats);
+		this.lengthInSteps = lengthInSteps;
+		//trace('test created section: ' + sectionBeats);
 	}
 }

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1432,6 +1432,7 @@ class ChartingState extends MusicBeatState
 			if (wname == 'section_beats')
 			{
 				_song.notes[curSec].sectionBeats = nums.value;
+				_song.notes[curSec].lengthInSteps = Std.int(nums.value);
 				reloadGridLayer();
 			}
 			else if (wname == 'song_speed')
@@ -2735,10 +2736,11 @@ class ChartingState extends MusicBeatState
 		return spr;
 	}
 
-	private function addSection(sectionBeats:Float = 4):Void
+	private function addSection(sectionBeats:Float = 4, lengthInSteps:Int = 16):Void
 	{
 		var sec:SwagSection = {
 			sectionBeats: sectionBeats,
+			lengthInSteps: lengthInSteps,
 			bpm: _song.bpm,
 			changeBPM: false,
 			mustHitSection: true,


### PR DESCRIPTION
this change re-adds `lengthInSteps` in order to make legacy charts (0.5.2h and before, including alternative engines) work properly, exports both values `sectionBeats` and `lengthInSteps` upon saving the json file