### PR TITLE
Gameplay changer support by mod

### DIFF
--- a/example_mods/custom_gamechangers/readme.txt
+++ b/example_mods/custom_gamechangers/readme.txt
@@ -1,0 +1,5 @@
+Add custom game play changers
+
+The file name will be the name of the configuration
+Enter type and tag name separated by commas
+Example: "bool,dadReduceHP"

--- a/example_mods/custom_gamechangers/readme.txt
+++ b/example_mods/custom_gamechangers/readme.txt
@@ -5,9 +5,12 @@ Supported types: "int, float, percent, string"
 
 Please write it in a text file:
 int, float, percent:
-	 type,  tag, 		scrollSpeed, minValue, maxValue, changeValue, displayFormat, decimals
-Example:"float, healthDecrease, 1, 	     0.1,      2,	 0.1,	      %vX,	     1	     "
+	 type,  tag, 		defaultValue, scrollSpeed, minValue, maxValue, changeValue, displayFormat, decimals
+Example:"float, healthDecrease, 1,	      1, 	   0.1,      2,	       0.1,	    %vX,	   1	   "
 
 string:
 	 type,   tag,  choices
 Example:"string, test, test1, test2, test3, bruh"
+
+bool:	 type, tag,	    defaultValue
+Example:"bool, dadReduceHP, false	"

--- a/example_mods/custom_gamechangers/readme.txt
+++ b/example_mods/custom_gamechangers/readme.txt
@@ -1,5 +1,13 @@
 Add custom game play changers
 
-The file name will be the name of the configuration
-Enter type and tag name separated by commas
-Example: "bool,dadReduceHP"
+The file name becomes the name of the configuration
+Supported types: "int, float, percent, string"
+
+Please write it in a text file:
+int, float, percent:
+	 type,  tag, 		scrollSpeed, minValue, maxValue, changeValue, displayFormat, decimals
+Example:"float, healthDecrease, 1, 	     0.1,      2,	 0.1,	      %vX,	     1	     "
+
+string:
+	 type,   tag,  choices
+Example:"string, test, test1, test2, test3, bruh"

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2769,7 +2769,7 @@ class FunkinLua {
 			return list;
 		});
 
-		Lua_helper.add_callback(lua, "getGameplayChangerBool", function(tag:String) {
+		Lua_helper.add_callback(lua, "getGameplayChangerValue", function(tag:String) {
 			return ClientPrefs.getGameplaySetting(tag, false);
 		});
 

--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -2769,6 +2769,10 @@ class FunkinLua {
 			return list;
 		});
 
+		Lua_helper.add_callback(lua, "getGameplayChangerBool", function(tag:String) {
+			return ClientPrefs.getGameplaySetting(tag, false);
+		});
+
 		call('onCreate', []);
 		#end
 	}

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -140,6 +140,10 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 								case 'string':
 									var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, contentArray[0], contentArray);
 									optionsArray.push(option);
+
+								case 'bool':
+									var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, contentArray[0]);
+									optionsArray.push(option);
 							}
 						}
 					}

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -117,10 +117,12 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 					var path = haxe.io.Path.join([directory, file]);
 					if (!FileSystem.isDirectory(path) && file != 'readme.txt' && file.endsWith('.txt')) {
 						var fileToCheck:String = file.substr(0, file.length - 4);
-						var tag:String = File.getContent(path);
+						var contentArray:Array<String> = File.getContent(path).split(",");
+						var type:String = contentArray[0];
+						var tag:String = contentArray[1];
 						if(!customGameplayChangers.exists(tag)) {
 							customGameplayChangers.set(tag, false);
-							var option:GameplayOption = new GameplayOption(fileToCheck, tag, 'bool', false);
+							var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, false);
 							optionsArray.push(option);
 						}
 					}

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -118,6 +118,10 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 					if (!FileSystem.isDirectory(path) && file != 'readme.txt' && file.endsWith('.txt')) {
 						var fileToCheck:String = file.substr(0, file.length - 4);
 						var contentArray:Array<String> = File.getContent(path).split(",");
+						for(i in 0...contentArray.length)
+							if(contentArray[i].isSpace(0))
+								contentArray[i] = contentArray[i].substr(1, contentArray[i].length); // Remove space
+
 						var type:String = contentArray[0];
 						var tag:String = contentArray[1];
 						

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -120,7 +120,7 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 						var contentArray:Array<String> = File.getContent(path).split(",");
 						for(i in 0...contentArray.length)
 							if(contentArray[i].isSpace(0))
-								contentArray[i] = contentArray[i].substr(1, contentArray[i].length); // Remove space
+								contentArray[i] = contentArray[i].trim(); // Remove space
 
 						var type:String = contentArray[0];
 						var tag:String = contentArray[1];
@@ -134,9 +134,9 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 								case 'int' | 'float' | 'percent':
 									var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, contentArray[0]);
 									option.scrollSpeed = Std.parseFloat(contentArray[1]);
-									option.minValue = contentArray[2];
-									option.maxValue = contentArray[3];
-									option.changeValue = contentArray[4];
+									option.minValue = Std.parseFloat(contentArray[2]);
+									option.maxValue = Std.parseFloat(contentArray[3]);
+									option.changeValue = Std.parseFloat(contentArray[4]);
 									option.displayFormat = contentArray[5];
 									option.decimals = Std.parseInt(contentArray[6]);
 									optionsArray.push(option);

--- a/source/GameplayChangersSubstate.hx
+++ b/source/GameplayChangersSubstate.hx
@@ -120,10 +120,27 @@ class GameplayChangersSubstate extends MusicBeatSubstate
 						var contentArray:Array<String> = File.getContent(path).split(",");
 						var type:String = contentArray[0];
 						var tag:String = contentArray[1];
+						
 						if(!customGameplayChangers.exists(tag)) {
 							customGameplayChangers.set(tag, false);
-							var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, false);
-							optionsArray.push(option);
+							contentArray.remove(type);
+							contentArray.remove(tag);
+							switch(type)
+							{
+								case 'int' | 'float' | 'percent':
+									var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, contentArray[0]);
+									option.scrollSpeed = Std.parseFloat(contentArray[1]);
+									option.minValue = contentArray[2];
+									option.maxValue = contentArray[3];
+									option.changeValue = contentArray[4];
+									option.displayFormat = contentArray[5];
+									option.decimals = Std.parseInt(contentArray[6]);
+									optionsArray.push(option);
+
+								case 'string':
+									var option:GameplayOption = new GameplayOption(fileToCheck, tag, type, contentArray[0], contentArray);
+									optionsArray.push(option);
+							}
 						}
 					}
 				}

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -35,6 +35,7 @@ class Paths
 		'characters',
 		'custom_events',
 		'custom_notetypes',
+		'custom_gamechangers',
 		'data',
 		'songs',
 		'music',


### PR DESCRIPTION
I am using a translation site, so I apologize if my English is not correct.

## Description

With this support, it is possible to add gameplay changers by adding files to custom_gamechangers folder in the mods folder.

You can also retrieve its value from lua. (getGameplayChangerValue)

The filename of the .txt file added to custom_gamechangers becomes the title on the settings screen, and the contents of the file become the value type and the tags inside the game and the property of the value.

Custom game changer selections are saved in the save data.

## Examples to add

For example, to add a gameplay changer that reduces health when dad hits a note, add a file named "dad note hits reduce health.txt" with contents like "bool, dadReduceHP, false" and add code to reduce health by making a conditional decision using
"if getGameplayChangerValue( 'dadReduceHP' ) then" in the lua file.

HP reduction settings can also be added by float.

![image](https://user-images.githubusercontent.com/90076182/201365519-54f2942e-bef5-4809-9477-e59e6ba06922.png)

----------------------------------------------------------------------------------------------------------------------------------------

This is what it looks like when you actually add it:

https://user-images.githubusercontent.com/90076182/201365697-1396556b-f8bc-420d-9cb5-51b082a05fef.mp4

