### PR TITLE
formatToSongPath fix

### DIFF
--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -324,8 +324,8 @@ class Paths
 	}
 
 	inline static public function formatToSongPath(path:String) {
-		var invalidChars = ~/[~&\\;:<>#]/;
-		var hideChars = ~/[.,'"%?!]/;
+		var invalidChars = ~/[~&\\;:<>#]+/g;
+		var hideChars = ~/[.,'"%?!]+/g;
 
 		var path = invalidChars.split(path.replace(' ', '-')).join("-");
 		return hideChars.split(path).join("").toLowerCase();


### PR DESCRIPTION
make it so EReg now actually replaces the matched characters that are in the string instead of once.

before: "s.o.n.g\~t\~est" -> "so.n.g-t est"
after: "s.o.n.g t est" -> "song-t-est"

a pretty annoying bug fixed when it comes to songname having multiple dots