### PR TITLE
add mod folders to lua require paths

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -87,6 +87,10 @@ class FunkinLua {
 
 		//LuaL.dostring(lua, CLENSE);
 		try{
+			Lua.getglobal(lua, "package");
+			Lua.pushstring(lua, Paths.getLuaPackagePath());
+			Lua.setfield(lua, -2, "path");
+			Lua.pop(lua, 1);
 			var result:Dynamic = LuaL.dofile(lua, script);
 			var resultStr:String = Lua.tostring(lua, result);
 			if(resultStr != null && result != 0) {

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -527,8 +527,8 @@ class Paths
 			#if sys
 			path = FileSystem.absolutePath(path);
 			#end
-			paths.push(haxe.io.Path.join([path, '?.lua']));
-			paths.push(haxe.io.Path.join([path, '?', 'init.lua']));
+			paths.push(Path.join([path, '?.lua']));
+			paths.push(Path.join([path, '?', 'init.lua']));
 		}
 		return paths.join(';');
 	}

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -20,6 +20,7 @@ import sys.FileSystem;
 import flixel.graphics.FlxGraphic;
 import openfl.display.BitmapData;
 import haxe.Json;
+import haxe.io.Path;
 
 import flash.media.Sound;
 
@@ -500,13 +501,36 @@ class Paths
 		var modsFolder:String = mods();
 		if(FileSystem.exists(modsFolder)) {
 			for (folder in FileSystem.readDirectory(modsFolder)) {
-				var path = haxe.io.Path.join([modsFolder, folder]);
+				var path = Path.join([modsFolder, folder]);
 				if (sys.FileSystem.isDirectory(path) && !ignoreModFolders.contains(folder) && !list.contains(folder)) {
 					list.push(folder);
 				}
 			}
 		}
 		return list;
+	}
+	#end
+
+	#if LUA_ALLOWED
+	static public function getLuaPackagePath():String {
+		var toAdd:Array<String> = ['.'];
+		#if MODS_ALLOWED
+		toAdd.push('./mods');
+		if (currentModDirectory != null && currentModDirectory.length > 0)
+			toAdd.push('./mods/$currentModDirectory');
+		for (mod in getGlobalMods())
+			toAdd.push('./mods/$mod');
+		#end
+		toAdd.push('./assets');
+		var paths:Array<String> = [];
+		for (path in toAdd) {
+			#if sys
+			path = FileSystem.absolutePath(path);
+			#end
+			paths.push(haxe.io.Path.join([path, '?.lua']));
+			paths.push(haxe.io.Path.join([path, '?', 'init.lua']));
+		}
+		return paths.join(';');
 	}
 	#end
 }


### PR DESCRIPTION
adds mods/, mods/$currentModDirectory, all the mods that run globally and the assets cause why not to luas package.path before the script is ran so all you have to do to use lua libs in your mod is slap it in your mods directory and require it at the top of your scripts