### PR TITLE
use splice parameter in `remove();` and remove splashes when they are killed

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1241,7 +1241,7 @@ class PlayState extends MusicBeatState
 						onComplete: function(twn:FlxTween)
 						{
 							camHUD.visible = true;
-							remove(whiteScreen);
+							remove(whiteScreen, true);
 							startCountdown();
 						}
 					});
@@ -1259,7 +1259,7 @@ class PlayState extends MusicBeatState
 					FlxTween.tween(blackScreen, {alpha: 0}, 0.7, {
 						ease: FlxEase.linear,
 						onComplete: function(twn:FlxTween) {
-							remove(blackScreen);
+							remove(blackScreen, true);
 						}
 					});
 					FlxG.sound.play(Paths.sound('Lights_Turn_On'));
@@ -1270,7 +1270,7 @@ class PlayState extends MusicBeatState
 					new FlxTimer().start(0.8, function(tmr:FlxTimer)
 					{
 						camHUD.visible = true;
-						remove(blackScreen);
+						remove(blackScreen, true);
 						FlxTween.tween(FlxG.camera, {zoom: defaultCamZoom}, 2.5, {
 							ease: FlxEase.quadInOut,
 							onComplete: function(twn:FlxTween)
@@ -1455,7 +1455,7 @@ class PlayState extends MusicBeatState
 		if(luaDebugGroup.members.length > 34) {
 			var blah = luaDebugGroup.members[34];
 			blah.destroy();
-			luaDebugGroup.remove(blah);
+			luaDebugGroup.remove(blah, true);
 		}
 		luaDebugGroup.insert(0, new DebugLuaText(text, luaDebugGroup, color));
 		#end
@@ -1653,7 +1653,7 @@ class PlayState extends MusicBeatState
 		var songName:String = Paths.formatToSongPath(SONG.song);
 		if (songName == 'roses' || songName == 'thorns')
 		{
-			remove(black);
+			remove(black, true);
 
 			if (songName == 'thorns')
 			{
@@ -1690,8 +1690,8 @@ class PlayState extends MusicBeatState
 								senpaiEvil.animation.play('idle');
 								FlxG.sound.play(Paths.sound('Senpai_Dies'), 1, false, null, true, function()
 								{
-									remove(senpaiEvil);
-									remove(red);
+									remove(senpaiEvil, true);
+									remove(red, true);
 									FlxG.camera.fade(FlxColor.WHITE, 0.01, true, function()
 									{
 										add(dialogueBox);
@@ -1713,7 +1713,7 @@ class PlayState extends MusicBeatState
 				else
 					startCountdown();
 
-				remove(black);
+				remove(black, true);
 			}
 		});
 	}
@@ -2136,7 +2136,7 @@ class PlayState extends MusicBeatState
 							ease: FlxEase.cubeInOut,
 							onComplete: function(twn:FlxTween)
 							{
-								remove(countdownReady);
+								remove(countdownReady, true);
 								countdownReady.destroy();
 							}
 						});
@@ -2156,7 +2156,7 @@ class PlayState extends MusicBeatState
 							ease: FlxEase.cubeInOut,
 							onComplete: function(twn:FlxTween)
 							{
-								remove(countdownSet);
+								remove(countdownSet, true);
 								countdownSet.destroy();
 							}
 						});
@@ -2178,7 +2178,7 @@ class PlayState extends MusicBeatState
 							ease: FlxEase.cubeInOut,
 							onComplete: function(twn:FlxTween)
 							{
-								remove(countdownGo);
+								remove(countdownGo, true);
 								countdownGo.destroy();
 							}
 						});
@@ -2820,6 +2820,13 @@ class PlayState extends MusicBeatState
 			iconP1.swapOldIcon();
 		}*/
 		callOnLuas('onUpdate', [elapsed]);
+
+		grpNoteSplashes.forEachDead(function(splash:NoteSplash) {
+			if (grpNoteSplashes.length > 1) {
+				grpNoteSplashes.remove(splash, true);
+				splash.destroy();
+			}
+		});
 
 		switch (curStage)
 		{
@@ -4215,6 +4222,7 @@ class PlayState extends MusicBeatState
 			FlxTween.tween(numScore, {alpha: 0}, 0.2 / playbackRate, {
 				onComplete: function(tween:FlxTween)
 				{
+					remove(numScore, true);
 					numScore.destroy();
 				},
 				startDelay: Conductor.crochet * 0.002 / playbackRate
@@ -4241,7 +4249,7 @@ class PlayState extends MusicBeatState
 			{
 				coolText.destroy();
 				comboSpr.destroy();
-
+				remove(rating, true);
 				rating.destroy();
 			},
 			startDelay: Conductor.crochet * 0.002 / playbackRate


### PR DESCRIPTION
probably helps with memory usage in a very slight amount somewhere and seems to not break the game at all so i think it's a reasonable thing to accept