### PR TITLE
Fix Philly Glow Particles not being Destroyed

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -2848,7 +2848,7 @@ class PlayState extends MusicBeatState
 					while (i > 0)
 					{
 						var particle = phillyGlowParticles.members[i];
-						if(particle.alpha < 0)
+						if(particle.alpha == 0)
 						{
 							particle.kill();
 							phillyGlowParticles.remove(particle, true);


### PR DESCRIPTION
Philly glow particles continually build up due to an error on whoever coded this, as alpha is bound between 0 and 1, and can never be less than 0.
This PR changes the < 0 to == 0, which actually makes the conditional able to happen, instead of always being false.
BTW, without this fix, there can reach up to 1400 objects updating per frame, which is not even close to ideal, especially on low end PCs.