### PR TITLE
Fix MP4Handler issue

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -48,7 +48,7 @@
     {
       "name": "hxCodec",
       "type": "haxelib",
-      "version": null
+      "version": "2.5.1"
     },
     {
       "name": "hscript",


### PR DESCRIPTION
Due to latest hxCodec updates, `MP4Handler` was renamed to `VideoHandler`, and other stuff, which was already being done in detail in #11720 

This fixes the need to reinstall hxCodec version 2.5.1 by specifically specifiying the version in `hmm.json`.

Please use the `version` json var(?) next time. Something could break without proper notice.