### PR TITLE
Filepath tracing, custom notes in the chart editor, and XML crash prevention

### DIFF
--- a/source/Note.hx
+++ b/source/Note.hx
@@ -159,14 +159,16 @@ class Note extends FlxSprite
 				case 'GF Sing':
 					gfNote = true;
 				case '':
-
+					//normal notes retain the noteskin texture
+				case 'Hey!':
+					// hey notes retain the noteskin texture
 				default:
 					#if MODS_ALLOWED
 					luaPrefix = value.split(" ")[0].toUpperCase();
-					if (FileSystem.exists(Paths.image(luaPrefix)))
+					if (Paths.image(luaPrefix + 'NOTE_assets')!= null)
 						reloadNote(luaPrefix, 'NOTE_assets');
 					else
-						trace('Rename $value texture to ${luaPrefix}NOTE_assets');
+						trace('Suggestion: rename $value texture to ${luaPrefix}NOTE_assets');
 					#end
 			}
 			noteType = value;

--- a/source/Note.hx
+++ b/source/Note.hx
@@ -7,6 +7,10 @@ import flixel.math.FlxMath;
 import flixel.util.FlxColor;
 import flash.display.BitmapData;
 import editors.ChartingState;
+#if sys
+import sys.io.File;
+import sys.FileSystem;
+#end
 
 using StringTools;
 
@@ -95,6 +99,7 @@ class Note extends FlxSprite
 
 	public var hitsoundDisabled:Bool = false;
 
+
 	private function set_multSpeed(value:Float):Float {
 		resizeByRatio(value / multSpeed);
 		multSpeed = value;
@@ -120,6 +125,7 @@ class Note extends FlxSprite
 	}
 
 	private function set_noteType(value:String):String {
+		var luaPrefix:String = '';
 		noteSplashTexture = PlayState.SONG.splashSkin;
 		if (noteData > -1 && noteData < ClientPrefs.arrowHSV.length)
 		{
@@ -152,6 +158,16 @@ class Note extends FlxSprite
 					noMissAnimation = true;
 				case 'GF Sing':
 					gfNote = true;
+				case '':
+
+				default:
+					#if MODS_ALLOWED
+					luaPrefix = value.split(" ")[0].toUpperCase();
+					if (FileSystem.exists(Paths.image(luaPrefix)))
+						reloadNote(luaPrefix, 'NOTE_assets');
+					else
+						trace('Rename $value texture to ${luaPrefix}NOTE_assets');
+					#end
 			}
 			noteType = value;
 		}
@@ -292,13 +308,6 @@ class Note extends FlxSprite
 				offsetX += lastNoteOffsetXForPixelAutoAdjusting;
 				lastNoteOffsetXForPixelAutoAdjusting = (width - 7) * (PlayState.daPixelZoom / 2);
 				offsetX -= lastNoteOffsetXForPixelAutoAdjusting;
-
-				/*if(animName != null && !animName.endsWith('end'))
-				{
-					lastScaleY /= lastNoteScaleToo;
-					lastNoteScaleToo = (6 / height);
-					lastScaleY *= lastNoteScaleToo;
-				}*/
 			}
 		} else {
 			frames = Paths.getSparrowAtlas(blahblah);

--- a/source/Note.hx
+++ b/source/Note.hx
@@ -132,7 +132,7 @@ class Note extends FlxSprite
 			switch(value) {
 				case 'Hurt Note':
 					ignoreNote = mustPress;
-					reloadNote('HURT');
+					reloadNote('HURT', 'NOTE_assets');
 					noteSplashTexture = 'HURTnoteSplashes';
 					colorSwap.hue = 0;
 					colorSwap.saturation = 0;

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -357,7 +357,6 @@ class Paths
 		#end
 
 		var path = getPath('images/$key.png', IMAGE, library);
-		//trace(path);
 		if (OpenFlAssets.exists(path, IMAGE)) {
 			if(!currentTrackedAssets.exists(path)) {
 				var newGraphic:FlxGraphic = FlxG.bitmap.add(path, false, path);
@@ -367,7 +366,7 @@ class Paths
 			localTrackedAssets.push(path);
 			return currentTrackedAssets.get(path);
 		}
-		trace('oh no its returning null NOOOO');
+		trace('NOOOO: $path is returning null!');
 		return null;
 	}
 


### PR DESCRIPTION
# **Overview**
**_This request changes Note.hx_** so the engine attempts to reload custom notes in-game and in the chart editor with a valid texture rather than reloading with a blank string, which can be overridden by the noteskin and cause crashes.

**_It also changes Paths.hx_** to trace the expected filepath of an asset returning null.

## The bugs:

- Calling `reloadNote('HURT');` results in 'HURT' + noteskin, if argument `texture` is null. HURTGOLDNOTE_assets doesn't exist for example, causing a crash in-game.

- Custom notes don't call `reloadNote()` to reload the texture in advance, meaning it could be overridden by the noteskin.
It doesn't load the texture in the chart editor, and has the potential to crash in-game.

- It is often impossible to determine the suggested path for a missing texture by looking at the terminal logs.

## The solutions:

- Calling `reloadNote('HURT', 'NOTE_assets');` results in 'HURT' + 'NOTE_assets', which conveniently exists. 

- Setting the custom note prefix to the note's name and then `reloadNote()` results in 'LUANOTE_assets' if it exists for example, avoiding null object references and loading the texture in the chart editor.

- If it doesn't, the texture isn't loaded in the chart editor and the terminal suggests to change the texture to a more conventional name.

# **Accepting this PR** means:

- Any custom note with those arguments will appear in the chart editor with it's texture, rather than just looking like a generic note.

- Noteskins will not effect any custom notetypes like Hurt Notes in-game.

- The game doesn't crash every funkin' time you want to use a noteskin on an existing chart.

- If other bugs cause the game to crash, the terminal will display more detailed stacks that can help solve problems.