### PR TITLE
Update Paths.hx to show which asset is missing / giving an error

### DIFF
--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -367,7 +367,7 @@ class Paths
 			localTrackedAssets.push(path);
 			return currentTrackedAssets.get(path);
 		}
-		trace('oh no its returning null NOOOO');
+		trace('oh no ' + key + ' returning null NOOOO');
 		return null;
 	}
 


### PR DESCRIPTION
this has been in the pinned messages on the psych server for months why is it not added in 
![image](https://user-images.githubusercontent.com/85320064/215356420-137770a9-064a-4b8c-b9c0-4da4e2f925f9.png)
