### PR TITLE
Another fix for hxCodec's new update

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -72,7 +72,8 @@ import sys.io.File;
 #end
 
 #if VIDEOS_ALLOWED
-import vlc.MP4Handler;
+#if (hxCodec >= "2.6.1") import hxcodec.VideoHandler as MP4Handler;
+#else import vlc.MP4Handler; #end
 #end
 
 using StringTools;

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -73,6 +73,7 @@ import sys.io.File;
 
 #if VIDEOS_ALLOWED
 #if (hxCodec >= "2.6.1") import hxcodec.VideoHandler as MP4Handler;
+#elseif (hxCodec == "2.6.0") import VideoHandler as MP4Handler;
 #else import vlc.MP4Handler; #end
 #end
 


### PR DESCRIPTION
For all the stinky people that updated hxCodec
This should fix the problems with hxCodec's new update checking the version that is installed (So it will work for everyone without depending on their version)

Edit: Now it also fixes the 2.6.0 version: so now it's possible to use 2.5.1, 2.6.0 or 2.6.1