### PR TITLE
Null object references involving vocals and insts are prevented, and songs without vocals can be loaded in the chart editor.

### DIFF
--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -372,6 +372,7 @@ class Paths
 	}
 
 	public static var currentTrackedSounds:Map<String, Sound> = [];
+	
 	public static function returnSound(path:String, key:String, ?library:String) {
 		#if MODS_ALLOWED
 		var file:String = modsSounds(path, key);
@@ -388,15 +389,7 @@ class Paths
 		gottenPath = gottenPath.substring(gottenPath.indexOf(':') + 1, gottenPath.length);
 		// trace(gottenPath);
 		if(!currentTrackedSounds.exists(gottenPath))
-		#if MODS_ALLOWED
-			currentTrackedSounds.set(gottenPath, Sound.fromFile('./' + gottenPath));
-		#else
-		{
-			var folder:String = '';
-			if(path == 'songs') folder = 'songs:';
-
-			currentTrackedSounds.set(gottenPath, Sound.fromFile('./' + gottenPath));
-		}
+			currentTrackedSounds.set(gottenPath, Sound.fromFile('./${gottenPath}'));
 		
 		#end
 		localTrackedAssets.push(gottenPath);

--- a/source/Paths.hx
+++ b/source/Paths.hx
@@ -395,8 +395,9 @@ class Paths
 			var folder:String = '';
 			if(path == 'songs') folder = 'songs:';
 
-			currentTrackedSounds.set(gottenPath, OpenFlAssets.getSound(folder + getPath('$path/$key.$SOUND_EXT', SOUND, library)));
+			currentTrackedSounds.set(gottenPath, Sound.fromFile('./' + gottenPath));
 		}
+		
 		#end
 		localTrackedAssets.push(gottenPath);
 		return currentTrackedSounds.get(gottenPath);

--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1352,12 +1352,14 @@ class ChartingState extends MusicBeatState
 			// vocals.stop();
 		}
 
-		var file:Dynamic = Paths.voices(currentSongName);
 		vocals = new FlxSound();
+		if  (_song.needsVoices) {
+			var file:Dynamic = Paths.voices(currentSongName);
 		if (Std.isOfType(file, Sound) || OpenFlAssets.exists(file)) {
 			vocals.loadEmbedded(file);
-			FlxG.sound.list.add(vocals);
 		}
+	}
+	FlxG.sound.list.add(vocals);
 		generateSong();
 		FlxG.sound.music.pause();
 		Conductor.songPosition = sectionStartTime();


### PR DESCRIPTION
This pull request changes **_Paths.hx_** and **_ChartingState.hx_** to properly deal with vocals, insts, and new songs that don't have those.

## Paths:
Reverted to an older filepath allocation method that still works since the graphics/memory overhaul.
## ChartingState:
Checked to see if the song actually needs voices before Paths tries to load an audio file. (The variable's file's type can't be checked if the file doesn't exist prior to the reference)
___
Both of these are untested! Lemme know if anything doesn't work as I did this in the web editor.


