### PR TITLE
Character instances can be created anywhere, and bugs/crashes involving character assets can be prevented.

### DIFF
--- a/source/Character.hx
+++ b/source/Character.hx
@@ -79,7 +79,7 @@ class Character extends FlxSprite
 	public var healthColorArray:Array<Int> = [255, 0, 0];
 
 	public static var DEFAULT_CHARACTER:String = 'bf'; //In case a character is missing, it will use BF on its place
-	public function new(x:Float, y:Float, ?character:String = 'bf', ?isPlayer:Bool = false)
+	public function new(x:Float, y:Float, ?character:String = 'bf', ?isPlayer:Bool = false, ?library:String)
 	{
 		super(x, y);
 
@@ -122,19 +122,14 @@ class Character extends FlxSprite
 
 				var json:CharacterFile = cast Json.parse(rawJson);
 				var spriteType = "sparrow";
-				//sparrow
-				//packer
-				//texture
+				//sparrow, packer, texture
 				#if MODS_ALLOWED
 				var modTxtToFind:String = Paths.modsTxt(json.image);
-				var txtToFind:String = Paths.getPath('images/' + json.image + '.txt', TEXT);
-				
-				//var modTextureToFind:String = Paths.modFolders("images/"+json.image);
-				//var textureToFind:String = Paths.getPath('images/' + json.image, new AssetType();
-				
+				var txtToFind:String = Paths.getPath('images/' + json.image + '.txt', TEXT, library);
+	
 				if (FileSystem.exists(modTxtToFind) || FileSystem.exists(txtToFind) || Assets.exists(txtToFind))
 				#else
-				if (Assets.exists(Paths.getPath('images/' + json.image + '.txt', TEXT)))
+				if (Assets.exists(Paths.getPath('images/' + json.image + '.txt', TEXT, library)))
 				#end
 				{
 					spriteType = "packer";
@@ -144,12 +139,9 @@ class Character extends FlxSprite
 				var modAnimToFind:String = Paths.modFolders('images/' + json.image + '/Animation.json');
 				var animToFind:String = Paths.getPath('images/' + json.image + '/Animation.json', TEXT);
 				
-				//var modTextureToFind:String = Paths.modFolders("images/"+json.image);
-				//var textureToFind:String = Paths.getPath('images/' + json.image, new AssetType();
-				
 				if (FileSystem.exists(modAnimToFind) || FileSystem.exists(animToFind) || Assets.exists(animToFind))
 				#else
-				if (Assets.exists(Paths.getPath('images/' + json.image + '/Animation.json', TEXT)))
+				if (Assets.exists(Paths.getPath('images/' + json.image + '/Animation.json', TEXT, library)))
 				#end
 				{
 					spriteType = "texture";
@@ -158,13 +150,13 @@ class Character extends FlxSprite
 				switch (spriteType){
 					
 					case "packer":
-						frames = Paths.getPackerAtlas(json.image);
+						frames = Paths.getPackerAtlas(json.image, library);
 					
 					case "sparrow":
-						frames = Paths.getSparrowAtlas(json.image);
+						frames = Paths.getSparrowAtlas(json.image, library);
 					
 					case "texture":
-						frames = AtlasFrameMaker.construct(json.image);
+						frames = AtlasFrameMaker.construct(json.image); //too busy to bring AtlasFrameMaker changes to patch-3. yell at me if you want it!
 				}
 				imageFile = json.image;
 

--- a/source/Character.hx
+++ b/source/Character.hx
@@ -91,7 +91,7 @@ class Character extends FlxSprite
 		curCharacter = character;
 		this.isPlayer = isPlayer;
 		antialiasing = ClientPrefs.globalAntialiasing;
-		var library:String = null;
+
 		switch (curCharacter)
 		{
 			//case 'your character name in case you want to hardcode them instead':


### PR DESCRIPTION
# Overview
This pull request changes _**class character's `new()` function**_ to load character assets from any library, which prevents missing textures, null object refs, and crashes.

## The bugs:

* Paths.hx generally determines what library to load assets from based on the current FlxState. This means a character in MainMenuState can only load its texture from preload, and preloading assets while switching states can cause stuttering and crashes.

## The solutions:

Passing an optional library argument to Paths makes it load the path from the desired library rather than from a library based on what directory its set to.

# Accepting this PR means:

* modders can create new character instances wherever they please.
* preloading assets in HTML5 is more accurate and less error-prone when specified.
* Paths almost never fails to find the character files, regardless of where said files are.

lemme know if there are bugs, some of these are untested!