### PR TITLE
Autosave when pressing BACKSPACE to exit Chart Editor.

### DIFF
--- a/source/editors/ChartingState.hx
+++ b/source/editors/ChartingState.hx
@@ -1695,6 +1695,9 @@ class ChartingState extends MusicBeatState
 
 
 			if (FlxG.keys.justPressed.BACKSPACE) {
+				// Protect against lost data when quickly leaving the chart editor.
+				autosaveSong();
+				
 				PlayState.chartingMode = false;
 				MusicBeatState.switchState(new editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));


### PR DESCRIPTION
This can help prevent data loss if a chart is edited without pressing ENTER or ESC.