### PR TITLE
Basic Improvements to Lua's setHealthBarColors

### DIFF
--- a/source/FunkinLua.hx
+++ b/source/FunkinLua.hx
@@ -1983,9 +1983,22 @@ class FunkinLua {
 
 		Lua_helper.add_callback(lua, "setHealthBarColors", function(leftHex:String, rightHex:String) {
 			var left:FlxColor = Std.parseInt(leftHex);
-			if(!leftHex.startsWith('0x')) left = Std.parseInt('0xff' + leftHex);
 			var right:FlxColor = Std.parseInt(rightHex);
-			if(!rightHex.startsWith('0x')) right = Std.parseInt('0xff' + rightHex);
+
+			if (leftHex != null && leftHex != '') {				
+				if (!leftHex.startsWith('0x')) {
+					left = Std.parseInt('0xff' + leftHex);
+				}
+			} else {
+				left = FlxColor.fromRGB(PlayState.instance.dad.healthColorArray[0], PlayState.instance.dad.healthColorArray[1], PlayState.instance.dad.healthColorArray[2]);
+			}
+			if (rightHex != null && rightHex != '') {
+				if (!rightHex.startsWith('0x')) {
+					right = Std.parseInt('0xff' + rightHex);
+				}
+			} else {
+				right = FlxColor.fromRGB(PlayState.instance.boyfriend.healthColorArray[0], PlayState.instance.boyfriend.healthColorArray[1], PlayState.instance.boyfriend.healthColorArray[2]);
+			}
 
 			PlayState.instance.healthBar.createFilledBar(left, right);
 			PlayState.instance.healthBar.updateBar();


### PR DESCRIPTION
Currently, `setHealthBarColors` is sufficient enough, however if you are trying to change one side of the healthbar's colors, it's not too great at that.
Currently, running the code `setHealthBarColors(nil, 'FF0000')` in your Lua script presents you with this.

![before](https://user-images.githubusercontent.com/86160807/224519472-82d2f836-8900-4653-bce2-97ded122ca96.png)
Due to the way this function is coded, trying to change one side of the healthbar's colors with it isn't ideal.

This PR fixes that, if one argument of the function is nil/empty, it will simply use the current health bar color for the switch.
Now, running the same example mentioned above provides you with this.

![after](https://user-images.githubusercontent.com/86160807/224519551-d18da8ca-a1e3-473a-a64c-065a0f00a391.png)
Thus making changing one half of the health bar's colors much simpler.
