### PR TITLE
Basic Improvements to Lua's setHealthBarColors

### DIFF
--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -1857,24 +1857,16 @@ class FunkinLua {
 		});
 
 		Lua_helper.add_callback(lua, "setHealthBarColors", function(leftHex:String, rightHex:String) {
-			var left:FlxColor = Std.parseInt(leftHex);
-			var right:FlxColor = Std.parseInt(rightHex);
+			var left = Std.parseInt('0xFF' + leftHex);
+			var right = Std.parseInt('0xFF' + rightHex);
 
-			if (leftHex != null && leftHex != '') {				
-				if (!leftHex.startsWith('0x')) {
-					left = Std.parseInt('0xff' + leftHex);
-				}
-			} else {
+			if (leftHex == null || leftHex == '') {
 				left = FlxColor.fromRGB(PlayState.instance.dad.healthColorArray[0], PlayState.instance.dad.healthColorArray[1], PlayState.instance.dad.healthColorArray[2]);
-			}
-			if (rightHex != null && rightHex != '') {
-				if (!rightHex.startsWith('0x')) {
-					right = Std.parseInt('0xff' + rightHex);
-				}
-			} else {
+			}		
+			if (rightHex == null || rightHex == '') {
 				right = FlxColor.fromRGB(PlayState.instance.boyfriend.healthColorArray[0], PlayState.instance.boyfriend.healthColorArray[1], PlayState.instance.boyfriend.healthColorArray[2]);
 			}
-
+			
 			PlayState.instance.healthBar.createFilledBar(left, right);
 			PlayState.instance.healthBar.updateBar();
 		});

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -1858,9 +1858,22 @@ class FunkinLua {
 
 		Lua_helper.add_callback(lua, "setHealthBarColors", function(leftHex:String, rightHex:String) {
 			var left:FlxColor = Std.parseInt(leftHex);
-			if(!leftHex.startsWith('0x')) left = Std.parseInt('0xff' + leftHex);
 			var right:FlxColor = Std.parseInt(rightHex);
-			if(!rightHex.startsWith('0x')) right = Std.parseInt('0xff' + rightHex);
+
+			if (leftHex != null && leftHex != '') {				
+				if (!leftHex.startsWith('0x')) {
+					left = Std.parseInt('0xff' + leftHex);
+				}
+			} else {
+				left = FlxColor.fromRGB(PlayState.instance.dad.healthColorArray[0], PlayState.instance.dad.healthColorArray[1], PlayState.instance.dad.healthColorArray[2]);
+			}
+			if (rightHex != null && rightHex != '') {
+				if (!rightHex.startsWith('0x')) {
+					right = Std.parseInt('0xff' + rightHex);
+				}
+			} else {
+				right = FlxColor.fromRGB(PlayState.instance.boyfriend.healthColorArray[0], PlayState.instance.boyfriend.healthColorArray[1], PlayState.instance.boyfriend.healthColorArray[2]);
+			}
 
 			PlayState.instance.healthBar.createFilledBar(left, right);
 			PlayState.instance.healthBar.updateBar();


### PR DESCRIPTION
Currently, `setHealthBarColors` is sufficient enough, however if you are trying to change one side of the healthbar's colors, it's not too great at that.
Currently, running the code `setHealthBarColors(nil, 'FF0000')` in your Lua script presents you with this.

![before](https://user-images.githubusercontent.com/86160807/224538528-a0b5e944-0375-487e-8085-7ec8c87b8a20.png)
Due to the way this function is coded, trying to change one side of the healthbar's colors with it isn't ideal.

This PR fixes that, if one argument of the function is nil/empty, it will simply use the current health bar color for the switch.
Now, running the same example mentioned above provides you with this.

![after](https://user-images.githubusercontent.com/86160807/224538538-a8b14865-d615-4a16-bb82-da9976287d66.png)
Thus making changing one half of the health bar's colors much simpler.

Reopen of #12074