### PR TITLE
Added parseJson for Lua

### DIFF
--- a/source/psychlua/ExtraFunctions.hx
+++ b/source/psychlua/ExtraFunctions.hx
@@ -249,7 +249,7 @@ class ExtraFunctions
 			return list;
 		});
 		
-		Lua_helper.add_callback(lua, "parseJsonData", function(jsonStr:String, varName:String) {
+		Lua_helper.add_callback(lua, "parseJson", function(jsonStr:String, varName:String) {
 			var json = Paths.modFolders('data/' + jsonStr + '.json');
 			var foundJson:Bool;
 			
@@ -259,7 +259,7 @@ class ExtraFunctions
 				if (FileSystem.exists(json)) {
 					foundJson = true;
 				} else {
-					luaTrace('parseJsonData: Invalid json file path!', false, false, FlxColor.RED);
+					luaTrace('parseJson: Invalid json file path!', false, false, FlxColor.RED);
 					foundJson = false;
 					return;	
 				}
@@ -267,7 +267,7 @@ class ExtraFunctions
 				if (Assets.exists(json)) {
 					foundJson = true;
 				} else {
-					luaTrace('parseJsonData: Invalid json file path!', false, false, FlxColor.RED);
+					luaTrace('parseJson: Invalid json file path!', false, false, FlxColor.RED);
 					foundJson = false;
 					return;	
 				}

--- a/source/psychlua/ExtraFunctions.hx
+++ b/source/psychlua/ExtraFunctions.hx
@@ -248,6 +248,36 @@ class ExtraFunctions
 			#end
 			return list;
 		});
+		
+		Lua_helper.add_callback(lua, "parseJsonData", function(jsonStr:String, varName:String) {
+			var json = Paths.modFolders('data/' + jsonStr + '.json');
+			var foundJson:Bool;
+			
+			trace(Assets.exists(json));
+
+			#if sys
+				if (FileSystem.exists(json)) {
+					foundJson = true;
+				} else {
+					luaTrace('parseJsonData: Invalid json file path!', false, false, FlxColor.RED);
+					foundJson = false;
+					return;	
+				}
+			#else
+				if (Assets.exists(json)) {
+					foundJson = true;
+				} else {
+					luaTrace('parseJsonData: Invalid json file path!', false, false, FlxColor.RED);
+					foundJson = false;
+					return;	
+				}
+			#end
+			
+			if (foundJson) {
+				var parsedJson = haxe.Json.parse(File.getContent(json));				
+				PlayState.instance.variables.set(varName, parsedJson);
+			}
+		});
 
 		// String tools
 		Lua_helper.add_callback(lua, "stringStartsWith", function(str:String, start:String) {

--- a/source/psychlua/ExtraFunctions.hx
+++ b/source/psychlua/ExtraFunctions.hx
@@ -253,8 +253,6 @@ class ExtraFunctions
 			var json = Paths.modFolders('data/' + jsonStr + '.json');
 			var foundJson:Bool;
 			
-			trace(Assets.exists(json));
-
 			#if sys
 				if (FileSystem.exists(json)) {
 					foundJson = true;


### PR DESCRIPTION
Quite a few people have asked on how to retrieve data from a .json file, and there's no super easy method for it, so this PR adds `parseJson`, a function which retrieves data from a specified json file from the mod's data folder, then sets a modchart variable with a specified name so you can easily access the json's data via `getProperty`.

**Example**
Let's say we have a .json file located in `mods/data/testJson.json`, with said file containing
```
{	
	"parsedBool":true,
	"parsedInt":10,
	"parsedString":"String"
}
```

In order to access these properties via a Lua script and output them using `debugPrint`, your code would have to look something like
```
function onCreatePost()
	parseJson('testJson', 'json')
	debugPrint(getProperty('json.parsedBool'))
	debugPrint(getProperty('json.parsedInt'))
	debugPrint(getProperty('json.parsedString'))
end
```
And that's about it.
Keep in mind trying to parse a json that does not exist will throw an error, and parsing a broken json will throw and error and stop further code from running.