### PR TITLE
Fix strum centering

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -81,7 +81,7 @@ using StringTools;
 
 class PlayState extends MusicBeatState
 {
-	public static var STRUM_X = 42;
+	public static var STRUM_X = 48.5;
 	public static var STRUM_X_MIDDLESCROLL = -278;
 
 	public static var ratingStuff:Array<Dynamic> = [


### PR DESCRIPTION
The strums are not actually centered, and can be properly centered by increasing STRUM_X by 6.5.

![image](https://user-images.githubusercontent.com/101066547/226149185-542fb892-2e95-4e60-87a6-f5e0e4d70422.png)

As you can see in this image, before the change, the innermost notes where offset by 13. By dividing that by 2 to get 6.5, we can add that to STRUM_X to offset the strums by 6.5 units, which results in the following:

![image](https://user-images.githubusercontent.com/101066547/226149231-a4811e85-0acc-4044-9b7a-f7a9fa314497.png)

Perfectly centered strums!

The method used to find this was simply to create a sprite in the center of the HUD, that is 10 pixels wide and 720 pixels tall, then do a bit of math to get the distance each note is from the sprite's edges (i.e. its x and its x + width). The code for the trace is below:

![image](https://user-images.githubusercontent.com/101066547/226149305-196cd2bf-3d13-4618-b771-6111646ba9a3.png)