### PR TITLE
Improved Discord Rich Presence - Experimental Branch

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -24,6 +24,7 @@
 	<define name="LUA_ALLOWED" if="desktop" />
 	<define name="ACHIEVEMENTS_ALLOWED" />
 	<define name="VIDEOS_ALLOWED" if="desktop" unless="32bits"/>
+	<define name="DISCORD_ALLOWED" if="desktop"/> <!-- DELETE THIS TO REMOVE THE DISCORD RICH PRESENCE CONNECTION -->
 	<define name="PSYCH_WATERMARKS"/> <!-- DELETE THIS TO REMOVE WATERMARKS/DEV NAMES ON TITLE SCREEN -->
 	<define name="TITLE_SCREEN_EASTER_EGG" if="officialBuild"/> <!-- DELETE THE if="officialBuild" for enabling this on an unofficial build -->
 
@@ -108,7 +109,7 @@
 	<!--Psych stuff needed-->
 	<haxelib name="linc_luajit" if="LUA_ALLOWED"/>
 	<haxelib name="hxCodec" if="VIDEOS_ALLOWED"/>
-	<haxelib name="discord_rpc" if="desktop"/>
+	<haxelib name="discord_rpc" if="DISCORD_ALLOWED"/>
 	<haxelib name="hscript" />
 	<define name="hscriptPos" />
 

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -105,7 +105,7 @@ class Main extends Sprite
 		Lib.current.loaderInfo.uncaughtErrorEvents.addEventListener(UncaughtErrorEvent.UNCAUGHT_ERROR, onCrash);
 		#end
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		if (!DiscordClient.isInitialized) {
 			DiscordClient.initialize();
 			Application.current.window.onClose.add(function() {
@@ -152,7 +152,9 @@ class Main extends Sprite
 		Sys.println("Crash dump saved in " + Path.normalize(path));
 
 		Application.current.window.alert(errMsg, "Error!");
+		#if DISCORD_ALLOWED
 		DiscordClient.shutdown();
+		#end
 		Sys.exit(1);
 	}
 	#end

--- a/source/backend/ClientPrefs.hx
+++ b/source/backend/ClientPrefs.hx
@@ -158,7 +158,7 @@ class ClientPrefs {
 		FlxG.save.data.henchmenDeath = Achievements.henchmenDeath;
 		FlxG.save.flush();
 
-		#if desktop  // Putting this here so the game does it only when saved and not on as onChange (Giving proper time to the rpc to shutdown)  - Nex
+		#if DISCORD_ALLOWED  // Putting this here so the game does it only when saved and not on as onChange (Giving proper time to the rpc to shutdown)  - Nex
 		if (data.discordRPC == 'Deactivated' && DiscordClient.isInitialized) DiscordClient.shutdown();
 		else if (data.discordRPC != 'Deactivated' && !DiscordClient.isInitialized) DiscordClient.initialize();
 		#end

--- a/source/backend/ClientPrefs.hx
+++ b/source/backend/ClientPrefs.hx
@@ -34,6 +34,7 @@ class SaveVariables {
 	public var pauseMusic:String = 'Tea Time';
 	public var checkForUpdates:Bool = true;
 	public var comboStacking:Bool = true;
+	public var discordRPC:String = 'Normal';
 	public var gameplaySettings:Map<String, Dynamic> = [
 		'scrollspeed' => 1.0,
 		'scrolltype' => 'multiplicative', 
@@ -156,6 +157,11 @@ class ClientPrefs {
 		FlxG.save.data.achievementsMap = Achievements.achievementsMap;
 		FlxG.save.data.henchmenDeath = Achievements.henchmenDeath;
 		FlxG.save.flush();
+
+		#if desktop  // Putting this here so the game does it only when saved and not on as onChange (Giving proper time to the rpc to shutdown)  - Nex
+		if (data.discordRPC == 'Deactivated' && DiscordClient.isInitialized) DiscordClient.shutdown();
+		else if (data.discordRPC != 'Deactivated' && !DiscordClient.isInitialized) DiscordClient.initialize();
+		#end
 
 		//Placing this in a separate save so that it can be manually deleted without removing your Score and stuff
 		var save:FlxSave = new FlxSave();

--- a/source/backend/Discord.hx
+++ b/source/backend/Discord.hx
@@ -1,7 +1,9 @@
 package backend;
 
 import Sys.sleep;
+#if DISCORD_ALLOWED
 import discord_rpc.DiscordRpc;
+#end
 
 #if LUA_ALLOWED
 import llua.Lua;
@@ -11,8 +13,18 @@ import llua.State;
 class DiscordClient
 {
 	public static var isInitialized:Bool = false;
+	#if DISCORD_ALLOWED
+	public static var queue:DiscordPresenceOptions = {
+		details: "In the Menus",
+		state: null,
+		largeImageKey: 'icon',
+		largeImageText: "Psych Engine"
+	}
+	#end
+
 	public function new()
 	{
+		#if DISCORD_ALLOWED
 		trace("Discord Client starting...");
 		DiscordRpc.start({
 			clientID: "863222024192262205",
@@ -30,21 +42,26 @@ class DiscordClient
 		}
 
 		DiscordRpc.shutdown();
+		#end
 	}
 	
 	public static function shutdown()
 	{
+		#if DISCORD_ALLOWED
 		DiscordRpc.shutdown();
+		isInitialized = false;
+		#end
 	}
 	
 	static function onReady()
 	{
-		DiscordRpc.presence({
-			details: "In the Menus",
-			state: null,
-			largeImageKey: 'icon',
-			largeImageText: "Psych Engine"
-		});
+		#if DISCORD_ALLOWED
+		changePresence(
+			queue.details, queue.state, queue.smallImageKey,
+			queue.startTimestamp == 1 ? true : false,
+			queue.endTimestamp
+		);
+		#end
 	}
 
 	static function onError(_code:Int, _message:String)
@@ -59,16 +76,22 @@ class DiscordClient
 
 	public static function initialize()
 	{
-		var DiscordDaemon = sys.thread.Thread.create(() ->
+		#if DISCORD_ALLOWED
+		if (ClientPrefs.data.discordRPC != 'Deactivated')
 		{
-			new DiscordClient();
-		});
-		trace("Discord Client initialized");
-		isInitialized = true;
+			var DiscordDaemon = sys.thread.Thread.create(() ->
+			{
+				new DiscordClient();
+			});
+			trace("Discord Client initialized");
+			isInitialized = true;
+		}
+		#end
 	}
 
 	public static function changePresence(details:String, state:Null<String>, ?smallImageKey : String, ?hasStartTimestamp : Bool, ?endTimestamp: Float)
 	{
+		#if DISCORD_ALLOWED
 		var startTimestamp:Float = 0;
 		if(hasStartTimestamp) startTimestamp = Date.now().getTime();
 
@@ -77,7 +100,7 @@ class DiscordClient
 			endTimestamp = startTimestamp + endTimestamp;
 		}
 
-		DiscordRpc.presence({
+		var presence:DiscordPresenceOptions = {
 			details: details,
 			state: state,
 			largeImageKey: 'icon',
@@ -86,9 +109,24 @@ class DiscordClient
 			// Obtained times are in milliseconds so they are divided so Discord can use it
 			startTimestamp : Std.int(startTimestamp / 1000),
             endTimestamp : Std.int(endTimestamp / 1000)
-		});
+		};
 
-		//trace('Discord RPC Updated. Arguments: $details, $state, $smallImageKey, $hasStartTimestamp, $endTimestamp');
+		if (ClientPrefs.data.discordRPC == 'Deactivated' || !isInitialized) {
+			presence.startTimestamp = if (hasStartTimestamp) 1 else 0;
+			presence.endTimestamp = Std.int(endTimestamp);  // It wont be perfectly accurated anymore, whatever, theyre just milliseconds afterall  - Nex
+			queue = presence;
+		} else {
+			if (ClientPrefs.data.discordRPC == 'Hide Infos') {
+				presence.details = null;
+				presence.state = null;
+				presence.smallImageKey = null;
+				presence.startTimestamp = 0;
+				presence.endTimestamp = 0;
+			}
+			DiscordRpc.presence(presence);
+			//trace('Discord RPC Updated. Arguments: $details, $state, $smallImageKey, $hasStartTimestamp, $endTimestamp');
+		}
+		#end
 	}
 
 	#if LUA_ALLOWED

--- a/source/backend/Discord.hx
+++ b/source/backend/Discord.hx
@@ -89,7 +89,7 @@ class DiscordClient
 		#end
 	}
 
-	public static function changePresence(details:String, state:Null<String>, ?smallImageKey : String, ?hasStartTimestamp : Bool, ?endTimestamp: Float)
+	#if !DISCORD_ALLOWED inline #end public static function changePresence(details:String, state:Null<String>, ?smallImageKey : String, ?hasStartTimestamp : Bool, ?endTimestamp: Float)
 	{
 		#if DISCORD_ALLOWED
 		var startTimestamp:Float = 0;
@@ -132,9 +132,7 @@ class DiscordClient
 	#if LUA_ALLOWED
 	public static function addLuaCallbacks(lua:State) {
 		Lua_helper.add_callback(lua, "changePresence", function(details:String, state:Null<String>, ?smallImageKey:String, ?hasStartTimestamp:Bool, ?endTimestamp:Float) {
-			#if DISCORD_ALLOWED
 			changePresence(details, state, smallImageKey, hasStartTimestamp, endTimestamp);
-			#end
 		});
 	}
 	#end

--- a/source/backend/Discord.hx
+++ b/source/backend/Discord.hx
@@ -132,7 +132,9 @@ class DiscordClient
 	#if LUA_ALLOWED
 	public static function addLuaCallbacks(lua:State) {
 		Lua_helper.add_callback(lua, "changePresence", function(details:String, state:Null<String>, ?smallImageKey:String, ?hasStartTimestamp:Bool, ?endTimestamp:Float) {
+			#if DISCORD_ALLOWED
 			changePresence(details, state, smallImageKey, hasStartTimestamp, endTimestamp);
+			#end
 		});
 	}
 	#end

--- a/source/import.hx
+++ b/source/import.hx
@@ -1,5 +1,5 @@
 
-#if desktop
+#if DISCORD_ALLOWED
 import backend.Discord;
 #end
 import backend.MusicBeatState;

--- a/source/import.hx
+++ b/source/import.hx
@@ -1,7 +1,5 @@
 
-#if DISCORD_ALLOWED
 import backend.Discord;
-#end
 import backend.MusicBeatState;
 import backend.MusicBeatSubstate;
 import backend.CustomFadeTransition;

--- a/source/options/BaseOptionsMenu.hx
+++ b/source/options/BaseOptionsMenu.hx
@@ -29,9 +29,7 @@ class BaseOptionsMenu extends MusicBeatSubstate
 		if(title == null) title = 'Options';
 		if(rpcTitle == null) rpcTitle = 'Options Menu';
 		
-		#if DISCORD_ALLOWED
 		DiscordClient.changePresence(rpcTitle, null);
-		#end
 		
 		var bg:FlxSprite = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
 		bg.color = 0xFFea71fd;

--- a/source/options/BaseOptionsMenu.hx
+++ b/source/options/BaseOptionsMenu.hx
@@ -29,7 +29,7 @@ class BaseOptionsMenu extends MusicBeatSubstate
 		if(title == null) title = 'Options';
 		if(rpcTitle == null) rpcTitle = 'Options Menu';
 		
-		#if desktop
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence(rpcTitle, null);
 		#end
 		

--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -30,9 +30,7 @@ class OptionsState extends MusicBeatState
 	var selectorRight:Alphabet;
 
 	override function create() {
-		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("Options Menu", null);
-		#end
 
 		var bg:FlxSprite = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
 		bg.color = 0xFFea71fd;

--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -30,7 +30,7 @@ class OptionsState extends MusicBeatState
 	var selectorRight:Alphabet;
 
 	override function create() {
-		#if desktop
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("Options Menu", null);
 		#end
 

--- a/source/options/VisualsUISubState.hx
+++ b/source/options/VisualsUISubState.hx
@@ -80,6 +80,17 @@ class VisualsUISubState extends BaseOptionsMenu
 			['None', 'Breakfast', 'Tea Time']);
 		addOption(option);
 		option.onChange = onChangePauseMusic;
+
+		#if DISCORD_ALLOWED
+		var option:Option = new Option('Discord RPC:',
+			'Change Discord Rich Presence',
+			'discordRPC',
+			'string',
+			'Normal',
+			['Deactivated', 'Normal', 'Hide Infos']);
+		addOption(option);
+		option.onChange = onChangeDiscord;
+		#end
 		
 		#if CHECK_FOR_UPDATES
 		var option:Option = new Option('Check for Updates',
@@ -122,6 +133,12 @@ class VisualsUISubState extends BaseOptionsMenu
 	{
 		if(Main.fpsVar != null)
 			Main.fpsVar.visible = ClientPrefs.data.showFPS;
+	}
+	#end
+
+	#if DISCORD_ALLOWED
+	function onChangeDiscord() {
+		DiscordClient.changePresence(rpcTitle, null);
 	}
 	#end
 }

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -2108,9 +2108,7 @@ class FunkinLua {
 		});
 
 		Lua_helper.add_callback(lua, "changePresence", function(details:String, state:Null<String>, ?smallImageKey:String, ?hasStartTimestamp:Bool, ?endTimestamp:Float) {
-			#if DISCORD_ALLOWED
 			DiscordClient.changePresence(details, state, smallImageKey, hasStartTimestamp, endTimestamp);
-			#end
 		});
 
 

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -2108,7 +2108,7 @@ class FunkinLua {
 		});
 
 		Lua_helper.add_callback(lua, "changePresence", function(details:String, state:Null<String>, ?smallImageKey:String, ?hasStartTimestamp:Bool, ?endTimestamp:Float) {
-			#if desktop
+			#if DISCORD_ALLOWED
 			DiscordClient.changePresence(details, state, smallImageKey, hasStartTimestamp, endTimestamp);
 			#end
 		});

--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -14,7 +14,7 @@ class AchievementsMenuState extends MusicBeatState
 	private var descText:FlxText;
 
 	override function create() {
-		#if desktop
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("Achievements Menu", null);
 		#end
 

--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -14,9 +14,7 @@ class AchievementsMenuState extends MusicBeatState
 	private var descText:FlxText;
 
 	override function create() {
-		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("Achievements Menu", null);
-		#end
 
 		var menuBG:FlxSprite = new FlxSprite().loadGraphic(Paths.image('menuBGBlue'));
 		menuBG.setGraphicSize(Std.int(menuBG.width * 1.1));

--- a/source/states/CreditsState.hx
+++ b/source/states/CreditsState.hx
@@ -25,7 +25,7 @@ class CreditsState extends MusicBeatState
 
 	override function create()
 	{
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/states/CreditsState.hx
+++ b/source/states/CreditsState.hx
@@ -25,10 +25,8 @@ class CreditsState extends MusicBeatState
 
 	override function create()
 	{
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
-		#end
 
 		persistentUpdate = true;
 		bg = new FlxSprite().loadGraphic(Paths.image('menuDesat'));

--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -54,7 +54,7 @@ class FreeplayState extends MusicBeatState
 		PlayState.isStoryMode = false;
 		WeekData.reloadWeekFiles(false);
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -54,10 +54,8 @@ class FreeplayState extends MusicBeatState
 		PlayState.isStoryMode = false;
 		WeekData.reloadWeekFiles(false);
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
-		#end
 
 		for (i in 0...WeekData.weeksList.length) {
 			if(weekIsLocked(WeekData.weeksList[i])) continue;

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -46,8 +46,6 @@ class MainMenuState extends MusicBeatState
 
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
-		
-		debugKeys = ClientPrefs.keyBinds.get('debug_1').copy();
 
 		camGame = new FlxCamera();
 		camAchievement = new FlxCamera();

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -44,7 +44,7 @@ class MainMenuState extends MusicBeatState
 		#end
 		WeekData.loadTheFirstEnabledMod();
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -44,10 +44,10 @@ class MainMenuState extends MusicBeatState
 		#end
 		WeekData.loadTheFirstEnabledMod();
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
-		#end
+		
+		debugKeys = ClientPrefs.keyBinds.get('debug_1').copy();
 
 		camGame = new FlxCamera();
 		camAchievement = new FlxCamera();

--- a/source/states/ModsMenuState.hx
+++ b/source/states/ModsMenuState.hx
@@ -58,10 +58,8 @@ class ModsMenuState extends MusicBeatState
 		Paths.clearUnusedMemory();
 		WeekData.setDirectoryFromWeek();
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
-		#end
 
 		bg = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
 		bg.antialiasing = ClientPrefs.data.antialiasing;

--- a/source/states/ModsMenuState.hx
+++ b/source/states/ModsMenuState.hx
@@ -58,7 +58,7 @@ class ModsMenuState extends MusicBeatState
 		Paths.clearUnusedMemory();
 		WeekData.setDirectoryFromWeek();
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -215,7 +215,7 @@ class PlayState extends MusicBeatState
 	public var opponentCameraOffset:Array<Float> = null;
 	public var girlfriendCameraOffset:Array<Float> = null;
 
-	#if desktop
+	#if DISCORD_ALLOWED
 	// Discord RPC variables
 	var storyDifficultyText:String = "";
 	var detailsText:String = "";
@@ -325,7 +325,7 @@ class PlayState extends MusicBeatState
 		Conductor.mapBPMChanges(SONG);
 		Conductor.changeBPM(SONG.bpm);
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		storyDifficultyText = Difficulty.getString();
 
 		// String that contains the mode defined here so it isn't necessary to call changePresence for each mode
@@ -1211,7 +1211,7 @@ class PlayState extends MusicBeatState
 		FlxTween.tween(timeBar, {alpha: 1}, 0.5, {ease: FlxEase.circOut});
 		FlxTween.tween(timeTxt, {alpha: 1}, 0.5, {ease: FlxEase.circOut});
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence (with Time Left)
 		DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter(), true, songLength);
 		#end
@@ -1538,7 +1538,7 @@ class PlayState extends MusicBeatState
 
 	override public function onFocusLost():Void
 	{
-		#if desktop
+		#if DISCORD_ALLOWED
 		if (health > 0 && !paused) DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
 		#end
 
@@ -1548,7 +1548,7 @@ class PlayState extends MusicBeatState
 	// Updating Discord Rich Presence.
 	function resetRPC(?cond:Bool = false)
 	{
-		#if desktop
+		#if DISCORD_ALLOWED
 		if (cond)
 			DiscordClient.changePresence(detailsText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter(), true, songLength - Conductor.songPosition - ClientPrefs.data.noteOffset);
 		else
@@ -1909,7 +1909,7 @@ class PlayState extends MusicBeatState
 		openSubState(new PauseSubState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 		//}
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
 		#end
 	}
@@ -1922,7 +1922,7 @@ class PlayState extends MusicBeatState
 		MusicBeatState.switchState(new ChartingState());
 		chartingMode = true;
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		DiscordClient.changePresence("Chart Editor", null, null, true);
 		#end
 	}
@@ -1955,7 +1955,7 @@ class PlayState extends MusicBeatState
 
 				// MusicBeatState.switchState(new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
-				#if desktop
+				#if DISCORD_ALLOWED
 				// Game Over doesn't get his own variable because it's only used here
 				DiscordClient.changePresence("Game Over - " + detailsText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
 				#end

--- a/source/states/StoryMenuState.hx
+++ b/source/states/StoryMenuState.hx
@@ -80,10 +80,8 @@ class StoryMenuState extends MusicBeatState
 		grpLocks = new FlxTypedGroup<FlxSprite>();
 		add(grpLocks);
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
-		#end
 
 		var num:Int = 0;
 		for (i in 0...WeekData.weeksList.length)

--- a/source/states/StoryMenuState.hx
+++ b/source/states/StoryMenuState.hx
@@ -80,7 +80,7 @@ class StoryMenuState extends MusicBeatState
 		grpLocks = new FlxTypedGroup<FlxSprite>();
 		add(grpLocks);
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("In the Menus", null);
 		#end

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -1057,10 +1057,8 @@ class CharacterEditorState extends MusicBeatState
 	}
 
 	function updatePresence() {
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Character Editor", "Character: " + daAnim, leHealthIcon.getCharacter());
-		#end
 	}
 
 	override function update(elapsed:Float)

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -1057,7 +1057,7 @@ class CharacterEditorState extends MusicBeatState
 	}
 
 	function updatePresence() {
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Character Editor", "Character: " + daAnim, leHealthIcon.getCharacter());
 		#end

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -221,7 +221,7 @@ class ChartingState extends MusicBeatState
 
 		// Paths.clearMemory();
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Chart Editor", StringTools.replace(_song.song, '-', ' '));
 		#end

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -221,10 +221,8 @@ class ChartingState extends MusicBeatState
 
 		// Paths.clearMemory();
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Chart Editor", StringTools.replace(_song.song, '-', ' '));
-		#end
 
 		vortex = FlxG.save.data.chart_vortex;
 		ignoreWarnings = FlxG.save.data.ignoreWarnings;

--- a/source/states/editors/DialogueCharacterEditorState.hx
+++ b/source/states/editors/DialogueCharacterEditorState.hx
@@ -442,10 +442,8 @@ class DialogueCharacterEditorState extends MusicBeatState
 		curAnim = 0;
 		animText.text = 'Animation: ' + character.jsonFile.animations[curAnim].anim + ' (' + (curAnim + 1) +' / ' + character.jsonFile.animations.length + ') - Press W or S to scroll';
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Dialogue Character Editor", "Editting: " + character.jsonFile.image);
-		#end
 	}
 
 	function updateTextBox() {

--- a/source/states/editors/DialogueCharacterEditorState.hx
+++ b/source/states/editors/DialogueCharacterEditorState.hx
@@ -442,7 +442,7 @@ class DialogueCharacterEditorState extends MusicBeatState
 		curAnim = 0;
 		animText.text = 'Animation: ' + character.jsonFile.animations[curAnim].anim + ' (' + (curAnim + 1) +' / ' + character.jsonFile.animations.length + ') - Press W or S to scroll';
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Dialogue Character Editor", "Editting: " + character.jsonFile.image);
 		#end

--- a/source/states/editors/DialogueEditorState.hx
+++ b/source/states/editors/DialogueEditorState.hx
@@ -240,7 +240,7 @@ class DialogueEditorState extends MusicBeatState
 		daText.y = DialogueBoxPsych.DEFAULT_TEXT_Y;
 		if(daText.rows > 2) daText.y -= DialogueBoxPsych.LONG_TEXT_ADD;
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		var rpcText:String = lineInputText.text;
 		if(rpcText == null || rpcText.length < 1) rpcText = '(Empty)';

--- a/source/states/editors/EditorLua.hx
+++ b/source/states/editors/EditorLua.hx
@@ -157,9 +157,7 @@ class EditorLua {
 			}
 		});
 
-		#if DISCORD_ALLOWED
 		backend.Discord.DiscordClient.addLuaCallbacks(lua);
-		#end
 
 		call('onCreate', []);
 		#end

--- a/source/states/editors/EditorLua.hx
+++ b/source/states/editors/EditorLua.hx
@@ -157,7 +157,9 @@ class EditorLua {
 			}
 		});
 
+		#if DISCORD_ALLOWED
 		backend.Discord.DiscordClient.addLuaCallbacks(lua);
+		#end
 
 		call('onCreate', []);
 		#end

--- a/source/states/editors/MasterEditorMenu.hx
+++ b/source/states/editors/MasterEditorMenu.hx
@@ -31,7 +31,7 @@ class MasterEditorMenu extends MusicBeatState
 	override function create()
 	{
 		FlxG.camera.bgColor = FlxColor.BLACK;
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Editors Main Menu", null);
 		#end

--- a/source/states/editors/MasterEditorMenu.hx
+++ b/source/states/editors/MasterEditorMenu.hx
@@ -31,10 +31,9 @@ class MasterEditorMenu extends MusicBeatState
 	override function create()
 	{
 		FlxG.camera.bgColor = FlxColor.BLACK;
-		#if DISCORD_ALLOWED
+		
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Editors Main Menu", null);
-		#end
 
 		var bg:FlxSprite = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
 		bg.scrollFactor.set();

--- a/source/states/editors/MenuCharacterEditorState.hx
+++ b/source/states/editors/MenuCharacterEditorState.hx
@@ -33,7 +33,7 @@ class MenuCharacterEditorState extends MusicBeatState
 			confirm_anim: 'M Dad Idle',
 			flipX: false
 		};
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Menu Character Editor", "Editting: " + characterFile.image);
 		#end
@@ -229,7 +229,7 @@ class MenuCharacterEditorState extends MusicBeatState
 		char.animation.play('idle');
 		updateOffset();
 		
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Menu Character Editor", "Editting: " + characterFile.image);
 		#end

--- a/source/states/editors/MenuCharacterEditorState.hx
+++ b/source/states/editors/MenuCharacterEditorState.hx
@@ -33,10 +33,9 @@ class MenuCharacterEditorState extends MusicBeatState
 			confirm_anim: 'M Dad Idle',
 			flipX: false
 		};
-		#if DISCORD_ALLOWED
+		
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Menu Character Editor", "Editting: " + characterFile.image);
-		#end
 
 		grpWeekCharacters = new FlxTypedGroup<MenuCharacter>();
 		for (char in 0...3)
@@ -229,10 +228,8 @@ class MenuCharacterEditorState extends MusicBeatState
 		char.animation.play('idle');
 		updateOffset();
 		
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Menu Character Editor", "Editting: " + characterFile.image);
-		#end
 	}
 
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {

--- a/source/states/editors/WeekEditorState.hx
+++ b/source/states/editors/WeekEditorState.hx
@@ -360,7 +360,7 @@ class WeekEditorState extends MusicBeatState
 		}
 		recalculateStuffPosition();
 
-		#if desktop
+		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Week Editor", "Editting: " + weekFileName);
 		#end

--- a/source/states/editors/WeekEditorState.hx
+++ b/source/states/editors/WeekEditorState.hx
@@ -360,10 +360,8 @@ class WeekEditorState extends MusicBeatState
 		}
 		recalculateStuffPosition();
 
-		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence
 		DiscordClient.changePresence("Week Editor", "Editting: " + weekFileName);
-		#end
 	}
 	
 	override function getEvent(id:String, sender:Dynamic, data:Dynamic, ?params:Array<Dynamic>) {


### PR DESCRIPTION
Basically the work in #12190 but for v0.7b (experimental branch)
Though, renaming `Discord.hx` to `DiscordClient.hx` here was useless because of `import.hx`, and finally I'd say lmfao

Imma add the description here too just in case:
Made this cause I was tired of the discord rich presence always showing up when on desktop
This update adds:
- An option in Visuals and UI asking for what kind of presence do you want (**Deactivated**, **Normal**, **Hide Infos**)
- A new define (**DISCORD_ALLOWED**) so its easier to remove the presence when people make their own mods
- A queue var when you change the presence while its deactivated so it will resume from that and it also should be usable on lua too
- A condition that uses **DISCORD_ALLOWED** when adding the **discord_rpc** lib into the game

I added the option in Visuals and UI cause i thought it was the best place where to put, if you think i should change the position just suggest it lmfao

If this gets added, crediting would be cool

Edit: Added the possibility to NOT add the **desktop** or the **DISCORD_ALLOWED** check when calling the changePresence function, it wont even get called when no discord (because of `inline` on the function when no discord and for the fact that the function and class will be empty if no discord)