### PR TITLE
Wrong term fix in Visuals & UI Menu

### DIFF
--- a/source/options/VisualsUISubState.hx
+++ b/source/options/VisualsUISubState.hx
@@ -50,8 +50,8 @@ class VisualsUISubState extends BaseOptionsMenu
 			true);
 		addOption(option);
 
-		var option:Option = new Option('Health Bar Transparency',
-			'How much transparent should the health bar and icons be.',
+		var option:Option = new Option('Health Bar Visibility',
+			'How much visible should the health bar and icons be.',
 			'healthBarAlpha',
 			'percent',
 			1);

--- a/source/options/VisualsUISubState.hx
+++ b/source/options/VisualsUISubState.hx
@@ -51,7 +51,7 @@ class VisualsUISubState extends BaseOptionsMenu
 		addOption(option);
 
 		var option:Option = new Option('Health Bar Visibility',
-			'How much visible should the health bar and icons be.',
+			'How visible the health bar and icons should be.',
 			'healthBarAlpha',
 			'percent',
 			1);


### PR DESCRIPTION
I know that in this period Ive been uploading a lot of prs, but fr did no one ever notice this before??
![istg](https://user-images.githubusercontent.com/87421482/230474553-b87ed4b9-5eaf-458d-8848-5f37b8beea2f.png)

Fully transparent means invisible, while in this option the more the number is high, the more the objects are visible
Why the heck did nobody notice this before!!1!
![bruh](https://user-images.githubusercontent.com/87421482/230473325-4a001f31-6aaf-46d3-b3de-146f76679a85.png)

So I changed this from `transparent` / `transparency` to `visible` / `visibility`


Im uploading this on the experimental branch cause its getting worked on overriding the old one but Id recommend to edit also the main one
I hope nobody got confused because of this (or didnt just care lmfao)
I mean correct me if Im wrong