### PR TITLE
Re-use popupScore sprites instead of constantly destroying and re-adding.

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -2548,16 +2548,29 @@ class PlayState extends MusicBeatState
 		rating.x += ClientPrefs.data.comboOffset[0];
 		rating.y -= ClientPrefs.data.comboOffset[1];
 
-		var comboSpr:FlxSprite = new FlxSprite().loadGraphic(Paths.image(pixelShitPart1 + 'combo' + pixelShitPart2));
+		var comboSprGroup:FlxSpriteGroup = new FlxSpriteGroup();
+		var comboSpr:FlxSprite;
+		var comboSprX:Float = coolText.x;
+		var comboSprY:Float = 60;
+
+		if (comboSprGroup.countDead() > 0) {
+			comboSpr = comboSprGroup.getFirstDead();
+			comboSpr.reset(comboSprX, comboSprY);
+		} else {
+			comboSpr = new FlxSprite();
+			comboSprGroup.add(comboSpr);
+		}
+
+		comboSpr.loadGraphic(Paths.image(pixelShitPart1 + 'combo' + pixelShitPart2));
 		comboSpr.cameras = [camHUD];
 		comboSpr.screenCenter();
-		comboSpr.x = coolText.x;
+		comboSpr.x = comboSprX;
 		comboSpr.acceleration.y = FlxG.random.int(200, 300) * playbackRate * playbackRate;
 		comboSpr.velocity.y -= FlxG.random.int(140, 160) * playbackRate;
 		comboSpr.visible = (!ClientPrefs.data.hideHud && showCombo);
 		comboSpr.x += ClientPrefs.data.comboOffset[0];
 		comboSpr.y -= ClientPrefs.data.comboOffset[1];
-		comboSpr.y += 60;
+		comboSpr.y += comboSprY;
 		comboSpr.velocity.x += FlxG.random.int(1, 10) * playbackRate;
 
 		insert(members.indexOf(strumLineNotes), rating);
@@ -2689,7 +2702,8 @@ class PlayState extends MusicBeatState
 			onComplete: function(tween:FlxTween)
 			{
 				coolText.destroy();
-				comboSpr.destroy();
+				comboSpr.kill();
+				comboSpr.alpha = 1;
 			},
 			startDelay: Conductor.crochet * 0.002 / playbackRate
 		});

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -2524,11 +2524,23 @@ class PlayState extends MusicBeatState
 			pixelShitPart2 = '-pixel';
 		}
 
+		var ratingGroup:FlxSpriteGroup = new FlxSpriteGroup();
+		var ratingX:Float = coolText.x - 40;
+		var ratingY:Float = 60;
+
+		if (ratingGroup.countDead() > 0) {
+			rating = ratingGroup.getFirstDead();
+			rating.reset(ratingY, ratingY);
+		} else {
+			rating = new FlxSprite();
+			ratingGroup.add(rating);
+		}
+
 		rating.loadGraphic(Paths.image(pixelShitPart1 + daRating.image + pixelShitPart2));
 		rating.cameras = [camHUD];
 		rating.screenCenter();
-		rating.x = coolText.x - 40;
-		rating.y -= 60;
+		rating.x = ratingX;
+		rating.y -= ratingY;
 		rating.acceleration.y = 550 * playbackRate * playbackRate;
 		rating.velocity.y -= FlxG.random.int(140, 175) * playbackRate;
 		rating.velocity.x -= FlxG.random.int(0, 10) * playbackRate;
@@ -2602,11 +2614,23 @@ class PlayState extends MusicBeatState
 		}
 		for (i in seperatedScore)
 		{
-			var numScore:FlxSprite = new FlxSprite().loadGraphic(Paths.image(pixelShitPart1 + 'num' + Std.int(i) + pixelShitPart2));
+			var numScoreGroup:FlxSpriteGroup = new FlxSpriteGroup();
+			var numScore:FlxSprite;
+			var numScoreX:Float = coolText.x + (43 * daLoop) - 90;
+			var numScoreY:Float = 80;
+		
+			if (numScoreGroup.countDead() > 0) {
+				numScore = numScoreGroup.getFirstDead();
+				numScore.reset(numScoreX, numScoreY);
+			} else {
+				numScore = new FlxSprite();
+				numScoreGroup.add(numScore);
+			}
+			numScore.loadGraphic(Paths.image(pixelShitPart1 + 'num' + Std.int(i) + pixelShitPart2));
 			numScore.cameras = [camHUD];
 			numScore.screenCenter();
-			numScore.x = coolText.x + (43 * daLoop) - 90 + ClientPrefs.data.comboOffset[2];
-			numScore.y += 80 - ClientPrefs.data.comboOffset[3];
+			numScore.x = numScoreX + ClientPrefs.data.comboOffset[2];
+			numScore.y += numScoreY - ClientPrefs.data.comboOffset[3];
 			
 			if (!ClientPrefs.data.comboStacking)
 				lastScore.push(numScore);
@@ -2634,7 +2658,8 @@ class PlayState extends MusicBeatState
 			FlxTween.tween(numScore, {alpha: 0}, 0.2 / playbackRate, {
 				onComplete: function(tween:FlxTween)
 				{
-					numScore.destroy();
+					numScore.kill();
+					numScore.alpha = 1;
 				},
 				startDelay: Conductor.crochet * 0.002 / playbackRate
 			});
@@ -2652,6 +2677,11 @@ class PlayState extends MusicBeatState
 		// add(coolText);
 
 		FlxTween.tween(rating, {alpha: 0}, 0.2 / playbackRate, {
+			onComplete: function(tween:FlxTween)
+			{
+				rating.kill();
+				rating.alpha = 1;
+			},
 			startDelay: Conductor.crochet * 0.001 / playbackRate
 		});
 
@@ -2660,8 +2690,6 @@ class PlayState extends MusicBeatState
 			{
 				coolText.destroy();
 				comboSpr.destroy();
-
-				rating.destroy();
 			},
 			startDelay: Conductor.crochet * 0.002 / playbackRate
 		});


### PR DESCRIPTION
Should improve overall performance of the game, less likely to cause frame stuttering, since the game doesn't constantly have to remove and add the sprites everytime a note is hit. 

There may be a better method to do this and in that case I'm all ears, but this is atleast better than the current way the sprites are handled.
