### PR TITLE
EditorPlayState: SectionTxt should say "Section" and not "Beats"

### DIFF
--- a/source/states/editors/EditorPlayState.hx
+++ b/source/states/editors/EditorPlayState.hx
@@ -496,7 +496,7 @@ class EditorPlayState extends MusicBeatState
 
 		keyShit();
 		scoreTxt.text = 'Hits: ' + songHits + ' | Misses: ' + songMisses;
-		sectionTxt.text = 'Beat: ' + curSection;
+		sectionTxt.text = 'Section: ' + curSection;
 		beatTxt.text = 'Beat: ' + curBeat;
 		stepTxt.text = 'Step: ' + curStep;
 		super.update(elapsed);


### PR DESCRIPTION
Minor text object fix.