### PR TITLE
hxCodec 3.0.0 (and beyond) fix

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -47,8 +47,9 @@ import sys.FileSystem;
 import sys.io.File;
 #end
 
-#if VIDEOS_ALLOWED 
-#if (hxCodec >= "2.6.1") import hxcodec.VideoHandler as MP4Handler;
+#if VIDEOS_ALLOWED
+#if (hxCodec >= "3.0.0") import hxcodec.flixel.FlxVideo as MP4Handler;
+#elseif (hxCodec == "2.6.1") import hxcodec.VideoHandler as MP4Handler;
 #elseif (hxCodec == "2.6.0") import VideoHandler as MP4Handler;
 #else import vlc.MP4Handler; #end
 #end
@@ -825,12 +826,23 @@ class PlayState extends MusicBeatState
 		}
 
 		var video:MP4Handler = new MP4Handler();
+		#if (hxCodec <= "2.6.1")
 		video.playVideo(filepath);
 		video.finishCallback = function()
 		{
 			startAndEnd();
 			return;
 		}
+		#else
+		video.play(filepath);
+		video.onEndReached.add(function()
+		{
+			video.dispose();
+			startAndEnd();
+			return;
+		});
+		#end
+
 		#else
 		FlxG.log.warn('Platform not supported!');
 		startAndEnd();


### PR DESCRIPTION
hxCodec had a bit of updates recently, and **a lot** has changed
This is a fix for the newest versions (3.0.0, 3.0.1 and 3.0.2 (3.0.2 is downloaded using the git command as the wiki says))
I suggest, though, locking the version to 2.6.1 at least for now in the wiki
We could say that this is an upgrade of what i did in the past here: #11905