### PR TITLE
Fix for the dumb error that was causing those annoying checks failures (Mac/Linux)

### DIFF
--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -83,7 +83,7 @@ class FunkinLua {
 				#if windows
 				lime.app.Application.current.window.alert(resultStr, 'Error on lua script!');
 				#else
-				luaTrace('$script\n$resultStr', true, false, FlxColor.RED);
+				luaTrace('$scriptName\n$resultStr', true, false, FlxColor.RED);
 				#end
 				lua = null;
 				return;


### PR DESCRIPTION
Do I even have to explain this💀
Literally the var `script` didn't exists lmfao