### PR TITLE
adjust HMM requested library versions

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -13,12 +13,12 @@
     {
       "name": "flixel",
       "type": "haxelib",
-      "version": null
+      "version": "4.11.0"
     },
     {
       "name": "flixel-addons",
       "type": "haxelib",
-      "version": null
+      "version": "2.12.1"
     },
     {
       "name": "flixel-tools",
@@ -48,7 +48,7 @@
     {
       "name": "hxCodec",
       "type": "haxelib",
-      "version": "2.5.1"
+      "version": "2.6.1"
     },
     {
       "name": "hscript",


### PR DESCRIPTION
Hi there!

I struggled with installing PsychEngine until I manually adjusted some library versions that HMM was installing. In particular, it seemed to pull newer versions of _flixel_ and _flixel-addons_ that were not supported, but stuck to an old version of _hxcodec_, which resulted in
```Error: Could not find include file "C:/HaxeToolkit/haxe/lib/hxCodec/2,6,1/vlc/lib/LibVLCBuild.xml"```

I think the versions in this PR are the correct ones.

Hope that helps!