### PR TITLE
Custom UIs per Stage

### DIFF
--- a/source/backend/StageData.hx
+++ b/source/backend/StageData.hx
@@ -13,6 +13,7 @@ typedef StageFile = {
 	var directory:String;
 	var defaultZoom:Float;
 	var isPixelStage:Bool;
+	var stageUI:String;
 
 	var boyfriend:Array<Dynamic>;
 	var girlfriend:Array<Dynamic>;
@@ -32,6 +33,7 @@ class StageData {
 			directory: "",
 			defaultZoom: 0.9,
 			isPixelStage: false,
+			stageUI: "normal",
 
 			boyfriend: [770, 100],
 			girlfriend: [400, 130],

--- a/source/options/NotesSubState.hx
+++ b/source/options/NotesSubState.hx
@@ -572,7 +572,7 @@ class NotesSubState extends MusicBeatSubstate
 	public function spawnNotes()
 	{
 		dataArray = !onPixel ? ClientPrefs.data.arrowRGB : ClientPrefs.data.arrowRGBPixel;
-		PlayState.isPixelStage = onPixel;
+		if (onPixel) PlayState.stageUI = "pixel";
 
 		// clear groups
 		modeNotes.forEachAlive(function(note:FlxSprite) {
@@ -644,7 +644,7 @@ class NotesSubState extends MusicBeatSubstate
 		}
 		insert(members.indexOf(myNotes) + 1, bigNote);
 		_storedColor = getShaderColor();
-		PlayState.isPixelStage = false;
+		PlayState.stageUI = "normal";
 	}
 
 	function updateNotes(?instant:Bool = false)

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -858,14 +858,13 @@ class PlayState extends MusicBeatState
 	function cacheCountdown()
 	{
 		var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-
-		var introUIPrefix:String = "";
-		var introUISuffix:String = "";
-		if (stageUI != "normal") {
-			introUIPrefix = '${stageUI}UI/';
-			if (PlayState.isPixelStage) introUISuffix = "-pixel";
+		var introImagesArray:Array<String> = ["ready", "set" ,"go"];
+		introImagesArray = switch(stageUI) {
+			case "pixel": ['${stageUI}/ready-pixel', '${stageUI}/set-pixel', '${stageUI}/date-pixel'];
+			case "normal": ["ready", "set" ,"go"];
+			default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go']
 		}
-		introAssets.set(stageUI, ['${introUIPrefix}ready${introUISuffix}', '${introUIPrefix}set${introUISuffix}', '${introUIPrefix}go${introUISuffix}']);
+		introAssets.set(stageUI, introImagesArray);
 		var introAlts:Array<String> = introAssets.get(stageUI);
 		for (asset in introAlts) Paths.image(asset);
 		
@@ -928,13 +927,13 @@ class PlayState extends MusicBeatState
 					dad.dance();
 
 				var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-				var introUIPrefix:String = "";
-				var introUISuffix:String = "";
-				if (stageUI != "normal") {
-					introUIPrefix = '${stageUI}UI/';
-					if (PlayState.isPixelStage) introUISuffix = "-pixel";
+				var introImagesArray:Array<String> = ["ready", "set" ,"go"];
+				introImagesArray = switch(stageUI) {
+					case "pixel": ['${stageUI}/ready-pixel', '${stageUI}/set-pixel', '${stageUI}/date-pixel'];
+					case "normal": ["ready", "set" ,"go"];
+					default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go']
 				}
-				introAssets.set(stageUI, ['${introUIPrefix}ready${introUISuffix}', '${introUIPrefix}set${introUISuffix}', '${introUIPrefix}go${introUISuffix}']);
+				introAssets.set(stageUI, introImagesArray);
 
 				var introAlts:Array<String> = introAssets.get(stageUI);
 				var antialias:Bool = (ClientPrefs.data.antialiasing && !isPixelStage);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -862,7 +862,7 @@ class PlayState extends MusicBeatState
 		introImagesArray = switch(stageUI) {
 			case "pixel": ['${stageUI}/ready-pixel', '${stageUI}/set-pixel', '${stageUI}/date-pixel'];
 			case "normal": ["ready", "set" ,"go"];
-			default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go']
+			default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go'];
 		}
 		introAssets.set(stageUI, introImagesArray);
 		var introAlts:Array<String> = introAssets.get(stageUI);
@@ -931,7 +931,7 @@ class PlayState extends MusicBeatState
 				introImagesArray = switch(stageUI) {
 					case "pixel": ['${stageUI}/ready-pixel', '${stageUI}/set-pixel', '${stageUI}/date-pixel'];
 					case "normal": ["ready", "set" ,"go"];
-					default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go']
+					default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go'];
 				}
 				introAssets.set(stageUI, introImagesArray);
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -338,6 +338,7 @@ class PlayState extends MusicBeatState
 
 		defaultCamZoom = stageData.defaultZoom;
 
+		stageUI = "normal";
 		if (stageData.stageUI != null)
 			stageUI = stageData.stageUI;
 		else {

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -858,8 +858,7 @@ class PlayState extends MusicBeatState
 	function cacheCountdown()
 	{
 		var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-		var introImagesArray:Array<String> = ["ready", "set" ,"go"];
-		introImagesArray = switch(stageUI) {
+		var introImagesArray:Array<String> = switch(stageUI) {
 			case "pixel": ['${stageUI}UI/ready-pixel', '${stageUI}UI/set-pixel', '${stageUI}UI/date-pixel'];
 			case "normal": ["ready", "set" ,"go"];
 			default: ['${stageUI}UI/ready', '${stageUI}UI/set', '${stageUI}UI/go'];
@@ -927,8 +926,7 @@ class PlayState extends MusicBeatState
 					dad.dance();
 
 				var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-				var introImagesArray:Array<String> = ["ready", "set" ,"go"];
-				introImagesArray = switch(stageUI) {
+				var introImagesArray:Array<String> = switch(stageUI) {
 					case "pixel": ['${stageUI}UI/ready-pixel', '${stageUI}UI/set-pixel', '${stageUI}UI/date-pixel'];
 					case "normal": ["ready", "set" ,"go"];
 					default: ['${stageUI}UI/ready', '${stageUI}UI/set', '${stageUI}UI/go'];

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -860,9 +860,9 @@ class PlayState extends MusicBeatState
 		var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
 		var introImagesArray:Array<String> = ["ready", "set" ,"go"];
 		introImagesArray = switch(stageUI) {
-			case "pixel": ['${stageUI}/ready-pixel', '${stageUI}/set-pixel', '${stageUI}/date-pixel'];
+			case "pixel": ['${stageUI}UI/ready-pixel', '${stageUI}UI/set-pixel', '${stageUI}UI/date-pixel'];
 			case "normal": ["ready", "set" ,"go"];
-			default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go'];
+			default: ['${stageUI}UI/ready', '${stageUI}UI/set', '${stageUI}UI/go'];
 		}
 		introAssets.set(stageUI, introImagesArray);
 		var introAlts:Array<String> = introAssets.get(stageUI);
@@ -929,9 +929,9 @@ class PlayState extends MusicBeatState
 				var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
 				var introImagesArray:Array<String> = ["ready", "set" ,"go"];
 				introImagesArray = switch(stageUI) {
-					case "pixel": ['${stageUI}/ready-pixel', '${stageUI}/set-pixel', '${stageUI}/date-pixel'];
+					case "pixel": ['${stageUI}UI/ready-pixel', '${stageUI}UI/set-pixel', '${stageUI}UI/date-pixel'];
 					case "normal": ["ready", "set" ,"go"];
-					default: ['${stageUI}/ready', '${stageUI}/set', '${stageUI}/go'];
+					default: ['${stageUI}UI/ready', '${stageUI}UI/set', '${stageUI}UI/go'];
 				}
 				introAssets.set(stageUI, introImagesArray);
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -129,7 +129,7 @@ class PlayState extends MusicBeatState
 	public static var isPixelStage(get, never):Bool;
 
 	@:noCompletion
-	function get_isPixelStage():Bool
+	static function get_isPixelStage():Bool
 		return stageUI == "pixel";
 
 	public static var SONG:SwagSong = null;

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -858,9 +858,14 @@ class PlayState extends MusicBeatState
 	function cacheCountdown()
 	{
 		var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-		introAssets.set(stage, ['ready', 'set', 'go']);
-		introAssets.set('pixel', ['pixelUI/ready-pixel', 'pixelUI/set-pixel', 'pixelUI/date-pixel']);
 
+		var introUIPrefix:String = "";
+		var introUISuffix:String = "";
+		if (stageUI != "normal") {
+			introUIPrefix = '${stageUI}UI/';
+			if (PlayState.isPixelStage) introUISuffix = "-pixel";
+		}
+		introAssets.set(stageUI, ['${introUIPrefix}ready${introUISuffix}', '${introUIPrefix}set${introUISuffix}', '${introUIPrefix}go${introUISuffix}']);
 		var introAlts:Array<String> = introAssets.get(stageUI);
 		for (asset in introAlts) Paths.image(asset);
 		
@@ -923,8 +928,13 @@ class PlayState extends MusicBeatState
 					dad.dance();
 
 				var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-				introAssets.set(stageUI, ['ready', 'set', 'go']);
-				introAssets.set('pixel', ['pixelUI/ready-pixel', 'pixelUI/set-pixel', 'pixelUI/date-pixel']);
+				var introUIPrefix:String = "";
+				var introUISuffix:String = "";
+				if (stageUI != "normal") {
+					introUIPrefix = '${stageUI}UI/';
+					if (PlayState.isPixelStage) introUISuffix = "-pixel";
+				}
+				introAssets.set(stageUI, ['${introUIPrefix}ready${introUISuffix}', '${introUIPrefix}set${introUISuffix}', '${introUIPrefix}go${introUISuffix}']);
 
 				var introAlts:Array<String> = introAssets.get(stageUI);
 				var antialias:Bool = (ClientPrefs.data.antialiasing && !isPixelStage);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -858,14 +858,11 @@ class PlayState extends MusicBeatState
 	function cacheCountdown()
 	{
 		var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-		introAssets.set('default', ['ready', 'set', 'go']);
+		introAssets.set(stage, ['ready', 'set', 'go']);
 		introAssets.set('pixel', ['pixelUI/ready-pixel', 'pixelUI/set-pixel', 'pixelUI/date-pixel']);
 
-		var introAlts:Array<String> = introAssets.get('default');
-		if (isPixelStage) introAlts = introAssets.get('pixel');
-		
-		for (asset in introAlts)
-			Paths.image(asset);
+		var introAlts:Array<String> = introAssets.get(stageUI);
+		for (asset in introAlts) Paths.image(asset);
 		
 		Paths.sound('intro3' + introSoundsSuffix);
 		Paths.sound('intro2' + introSoundsSuffix);
@@ -926,17 +923,13 @@ class PlayState extends MusicBeatState
 					dad.dance();
 
 				var introAssets:Map<String, Array<String>> = new Map<String, Array<String>>();
-				introAssets.set('default', ['ready', 'set', 'go']);
+				introAssets.set(stageUI, ['ready', 'set', 'go']);
 				introAssets.set('pixel', ['pixelUI/ready-pixel', 'pixelUI/set-pixel', 'pixelUI/date-pixel']);
 
-				var introAlts:Array<String> = introAssets.get('default');
-				var antialias:Bool = ClientPrefs.data.antialiasing;
-				if(isPixelStage) {
-					introAlts = introAssets.get('pixel');
-					antialias = false;
-				}
-
+				var introAlts:Array<String> = introAssets.get(stageUI);
+				var antialias:Bool = (ClientPrefs.data.antialiasing && !isPixelStage);
 				var tick:Countdown = THREE;
+
 				switch (swagCounter)
 				{
 					case 0:


### PR DESCRIPTION
## Overview
This allows you to give each stage JSON a different UI style, no longer limiting developers to just normal and pixel, you can now make your own custom UI styles by changing a single string on your stage file

## How to
go into your Mods directory and create a new folder, the folder needs to be named after your stage UI parameter, with the "UI" suffix

example: my stage file has the `stageUI` parameter as "ourple"
now, I can just create a folder named "ourpleUI" and drop my custom assets there

**[THIS INFORMATION BELOW DOES NOT APPLY TO UIS NAMED AS "PIXEL", AS I KEPT THEM AS THEY WERE BEFORE FOR COMPATIBILITY REASONS!!!]**

the assets themselves must be named as they are on the "shared" folder, for example, the "sick" rating is named "sick.png", the "ready" sprite is named "ready.png", thus your custom assets should follow this name scheme