### PR TITLE
"Pause > Options > Adjust Offsets > Exit Pause" crash fix

### DIFF
--- a/source/options/NoteOffsetState.hx
+++ b/source/options/NoteOffsetState.hx
@@ -12,7 +12,6 @@ import states.stages.StageWeek1 as BackgroundStage;
 class NoteOffsetState extends MusicBeatState
 {
 	var stageDirectory:String = 'week1';
-	private var prevStageDir:String = '';
 	var boyfriend:Character;
 	var gf:Character;
 
@@ -59,7 +58,6 @@ class NoteOffsetState extends MusicBeatState
 		FlxG.sound.pause();
 
 		// Stage
-		prevStageDir = Paths.currentLevel;
 		Paths.setCurrentLevel(stageDirectory);
 		new BackgroundStage();
 
@@ -413,8 +411,6 @@ class NoteOffsetState extends MusicBeatState
 					FlxG.sound.playMusic(Paths.music(Paths.formatToSongPath(ClientPrefs.data.pauseMusic)));
 				else
 					FlxG.sound.music.volume = 0;
-
-				Paths.setCurrentLevel(prevStageDir);
 			}
 			else FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			FlxG.mouse.visible = false;

--- a/source/options/NoteOffsetState.hx
+++ b/source/options/NoteOffsetState.hx
@@ -12,6 +12,7 @@ import states.stages.StageWeek1 as BackgroundStage;
 class NoteOffsetState extends MusicBeatState
 {
 	var stageDirectory:String = 'week1';
+	private var prevStageDir:String = '';
 	var boyfriend:Character;
 	var gf:Character;
 
@@ -58,6 +59,7 @@ class NoteOffsetState extends MusicBeatState
 		FlxG.sound.pause();
 
 		// Stage
+		prevStageDir = Paths.currentLevel;
 		Paths.setCurrentLevel(stageDirectory);
 		new BackgroundStage();
 
@@ -411,6 +413,8 @@ class NoteOffsetState extends MusicBeatState
 					FlxG.sound.playMusic(Paths.music(Paths.formatToSongPath(ClientPrefs.data.pauseMusic)));
 				else
 					FlxG.sound.music.volume = 0;
+
+				Paths.setCurrentLevel(prevStageDir);
 			}
 			else FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			FlxG.mouse.visible = false;

--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -1,6 +1,7 @@
 package options;
 
 import states.MainMenuState;
+import backend.StageData;
 
 class OptionsState extends MusicBeatState
 {
@@ -23,7 +24,7 @@ class OptionsState extends MusicBeatState
 			case 'Gameplay':
 				openSubState(new options.GameplaySettingsSubState());
 			case 'Adjust Delay and Combo':
-				LoadingState.loadAndSwitchState(new options.NoteOffsetState());
+				MusicBeatState.switchState(new options.NoteOffsetState());
 		}
 	}
 
@@ -83,7 +84,8 @@ class OptionsState extends MusicBeatState
 			FlxG.sound.play(Paths.sound('cancelMenu'));
 			if(onPlayState)
 			{
-				MusicBeatState.switchState(new PlayState());
+				StageData.loadDirectory(PlayState.SONG);
+				LoadingState.loadAndSwitchState(new PlayState());
 				FlxG.sound.music.volume = 0;
 			}
 			else MusicBeatState.switchState(new MainMenuState());


### PR DESCRIPTION
Stages weren't loading correctly if you went in the Adjust Offsets menu from pause and then go back to the song (mainly tankman stage)
This fixes that annoying ass crash

Before: 

https://github.com/ShadowMario/FNF-PsychEngine/assets/87421482/4da05692-1fbc-479c-8982-34e916c5ef82

Now:

https://github.com/ShadowMario/FNF-PsychEngine/assets/87421482/4e0bbdd4-ca67-45ae-923a-bea20a7b9146
