### PR TITLE
include classes which not used in game

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -162,6 +162,8 @@
 	<!--Macro fixes-->
 	<haxeflag name="--macro" value="allowPackage('flash')" />
 	<haxeflag name="--macro" value="include('my.pack')" />
+	<haxeflag name="--macro" value="macros.AdditionalClasses.add()" />
+	<haxeflag name="-dce" value="no" />
 
 	<!-- _________________________________ Custom _______________________________ -->
 

--- a/source/import.hx
+++ b/source/import.hx
@@ -1,3 +1,4 @@
+#if !macro
 
 //Discord API
 #if desktop
@@ -47,3 +48,5 @@ import flixel.group.FlxSpriteGroup;
 import flixel.group.FlxGroup.FlxTypedGroup;
 
 using StringTools;
+
+#end

--- a/source/macros/AdditionalClasses.hx
+++ b/source/macros/AdditionalClasses.hx
@@ -1,0 +1,48 @@
+package macros;
+
+#if macro
+import haxe.macro.Compiler;
+
+/**
+ * Uses for adding classes even if they not used in game (for hscript goodies)
+ */
+class AdditionalClasses {
+	public static function add() {
+		var includePackages:Array<String> = [
+			#if desktop "discord_rpc", #end
+			"flixel",
+			"hscript",
+			#if VIDEOS_ALLOWED "vlc", #end
+			#if VIDEOS_ALLOWED "hxcodec", #end
+			"lime",
+			#if LUA_ALLOWED "llua", #end
+			"openfl",
+
+			"haxe",
+			#if flash "flash", #end
+			#if cpp "cpp", #end
+			#if hl "hl", #end
+			#if neko "neko", #end
+			#if sys "sys", #end
+			"DateTools",
+			"EReg",
+			"Lambda",
+			"StringBuf",
+		];
+
+		var excludePackages:Array<String> = [
+			"flixel.addons.editors.spine",
+			"flixel.addons.nape",
+			"flixel.system.macros",
+
+			"haxe.macro",
+
+			"lime._internal.backend.air",
+			"lime._internal.backend.html5",
+			"lime._internal.backend.kha",
+			"lime.tools",
+		];
+		for (pkg in includePackages) Compiler.include(pkg, true, excludePackages);
+	}
+}
+#end

--- a/source/macros/AdditionalClasses.hx
+++ b/source/macros/AdditionalClasses.hx
@@ -36,6 +36,7 @@ class AdditionalClasses {
 			"flixel.system.macros",
 
 			"haxe.macro",
+			#if (js || hxcpp) "haxe.atomic.AtomicObject", #end
 
 			"lime._internal.backend.air",
 			"lime._internal.backend.html5",


### PR DESCRIPTION
hscript: 📈

for example u cant `addHaxeLibrary('FlxGlitchEffect', 'flixel.addons.effects.chainable')` if source code not used this class

previous pr was for experimental branch: #12733