### PR TITLE
Fix leaving NoteSplashDebug

### DIFF
--- a/source/states/editors/NoteSplashDebugState.hx
+++ b/source/states/editors/NoteSplashDebugState.hx
@@ -139,6 +139,7 @@ class NoteSplashDebugState extends MusicBeatState
 		if(controls.BACK && notTyping)
 		{
 			MusicBeatState.switchState(new MasterEditorMenu());
+			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			FlxG.mouse.visible = false;
 		}
 		super.update(elapsed);


### PR DESCRIPTION
When you exited it, the music wouldn't start playing again just like the other editors but instead when you went to the main menu.
This fixes that