### PR TITLE
fixed beat separators in chart editor

### DIFF
--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -2244,8 +2244,8 @@ class ChartingState extends MusicBeatState
 		gridBlackLine.antialiasing = false;
 		gridLayer.add(gridBlackLine);
 
-		for (i in 1...4) {
-			var beatsep:FlxSprite = new FlxSprite(gridBG.x, (GRID_SIZE * (4 * curZoom)) * i).makeGraphic(1, 1, 0x44FF0000);
+		for (i in 1...Std.int(getSectionBeats())) {
+			var beatsep:FlxSprite = new FlxSprite(gridBG.x, (GRID_SIZE * (4 * zoomList[curZoom])) * i).makeGraphic(1, 1, 0x44FF0000);
 			beatsep.scale.x = gridBG.width;
 			beatsep.updateHitbox();
 			if(vortex) gridLayer.add(beatsep);


### PR DESCRIPTION
re implementation of #8757 but without the extra zooms (unnecessary with snapping now implemented) and with support for non 4 beat sections

https://github.com/ShadowMario/FNF-PsychEngine/assets/58795684/51c32ee1-1a91-4c46-a7c6-0c974f412d6a