### PR TITLE
Correct a minor spelling mistake in PlayState.hx

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -2251,8 +2251,7 @@ class PlayState extends MusicBeatState
 			return false;
 		else
 		{
-			var noMissWeek:String = WeekData.getWeekFileName() + '_nomiss';
-			var achieve:String = checkForAchievement([noMissWeek, 'r_ubad', 'ur_good', 'hype', 'two_keys', 'toastie', 'debugger']);
+			var achieve:String = checkForAchievement(['${WeekData.getWeekFileName()}_nomiss', 'ur_bad', 'ur_good', 'hype', 'two_keys', 'toastie', 'debugger']);
 			if(achieve != null) {
 				startAchievement(achieve);
 				return false;


### PR DESCRIPTION
I was looking for implementing my own achievement system (since I already had it done, I just had to port it to 0.7) and noticed that "ur_bad" achievement was misspelt as "r_ubad".