### PR TITLE
Make README specify Haxe Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Engine originally used on [Mind Games Mod](https://gamebanana.com/mods/301107), intended to be a fix for the vanilla version's many issues while keeping the casual play aspect of it. Also aiming to be an easier alternative to newbie coders.
 
 ## Installation:
-You must have [Haxe version 4.2.5](https://haxe.org/download/version/4.2.5/), seriously, stop using older or newer version, it won't work!
+You must have [Haxe version 4.2.5](https://haxe.org/download/version/4.2.5/), seriously, stop using older or newer versions, it won't work!
 
 open up a Command Prompt/PowerShell or Terminal, type `haxelib install hmm`
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Engine originally used on [Mind Games Mod](https://gamebanana.com/mods/301107), intended to be a fix for the vanilla version's many issues while keeping the casual play aspect of it. Also aiming to be an easier alternative to newbie coders.
 
 ## Installation:
-You must have [the most up-to-date version of Haxe](https://haxe.org/download/), seriously, stop using 4.1.5, it misses some stuff.
+You must have [Haxe version 4.2.5](https://haxe.org/download/version/4.2.5/), seriously, stop using older or newer version, it won't work!
 
 open up a Command Prompt/PowerShell or Terminal, type `haxelib install hmm`
 


### PR DESCRIPTION
It still says to use the latest version of Haxe in the README, even tho the latest one breaks stuff. Made it so that the README now specifies the only version of Haxe that works as of now.