### PR TITLE
Mouse wheel support in more menus + remove dumb vars

### DIFF
--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -69,7 +69,7 @@ class AchievementsMenuState extends MusicBeatState
 		if (controls.UI_DOWN_P) {
 			changeSelection(1);
 		}
-		if(FlxG.mouse.wheel != 0){
+		if(FlxG.mouse.wheel != 0) {
 			FlxG.sound.play(Paths.sound('scrollMenu'), 0.2);
 			changeSelection(-FlxG.mouse.wheel);
 		}

--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -69,6 +69,10 @@ class AchievementsMenuState extends MusicBeatState
 		if (controls.UI_DOWN_P) {
 			changeSelection(1);
 		}
+		if(FlxG.mouse.wheel != 0){
+			FlxG.sound.play(Paths.sound('scrollMenu'), 0.2);
+			changeSelection(-FlxG.mouse.wheel);
+		}
 
 		if (controls.BACK) {
 			FlxG.sound.play(Paths.sound('cancelMenu'));

--- a/source/states/CreditsState.hx
+++ b/source/states/CreditsState.hx
@@ -155,6 +155,11 @@ class CreditsState extends MusicBeatState
 					changeSelection(shiftMult);
 					holdTime = 0;
 				}
+				if(FlxG.mouse.wheel != 0)
+				{
+					FlxG.sound.play(Paths.sound('scrollMenu'), 0.2);
+					changeSelection(-shiftMult * FlxG.mouse.wheel);
+				}
 
 				if(controls.UI_DOWN || controls.UI_UP)
 				{

--- a/source/states/CreditsState.hx
+++ b/source/states/CreditsState.hx
@@ -142,15 +142,12 @@ class CreditsState extends MusicBeatState
 				var shiftMult:Int = 1;
 				if(FlxG.keys.pressed.SHIFT) shiftMult = 3;
 
-				var upP = controls.UI_UP_P;
-				var downP = controls.UI_DOWN_P;
-
-				if (upP)
+				if (controls.UI_UP_P)
 				{
 					changeSelection(-shiftMult);
 					holdTime = 0;
 				}
-				if (downP)
+				if (controls.UI_DOWN_P)
 				{
 					changeSelection(shiftMult);
 					holdTime = 0;

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -179,6 +179,12 @@ class MainMenuState extends MusicBeatState
 				changeItem(1);
 			}
 
+			if(FlxG.mouse.wheel != 0)
+			{
+				FlxG.sound.play(Paths.sound('scrollMenu'), 0.4);
+				changeItem(-FlxG.mouse.wheel);
+			}
+
 			if (controls.BACK)
 			{
 				selectedSomethin = true;

--- a/source/states/ModsMenuState.hx
+++ b/source/states/ModsMenuState.hx
@@ -454,6 +454,11 @@ class ModsMenuState extends MusicBeatState
 			changeSelection(1);
 			FlxG.sound.play(Paths.sound('scrollMenu'));
 		}
+		if(FlxG.mouse.wheel != 0)
+		{
+			FlxG.sound.play(Paths.sound('scrollMenu'), 0.2);
+			changeSelection(-FlxG.mouse.wheel);
+		}
 		updatePosition(elapsed);
 		super.update(elapsed);
 	}


### PR DESCRIPTION
Added the support for mouse wheel scrolling in more menus so that using mouse feels more consistent.
Also removed two vars that were very much not needed to be made (Because they only were used once).

This PR adds support for mouse scrolling in:
* Main Menu
* Mods Menu
* Awards
* Credits

And removes 2 vars in:
* CreditsState.hx
