### PR TITLE
Make the time text accurate when playbackRate is changed

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1665,7 +1665,7 @@ class PlayState extends MusicBeatState
 			var songCalc:Float = (songLength - curTime);
 			if(ClientPrefs.data.timeBarType == 'Time Elapsed') songCalc = curTime;
 
-			var secondsTotal:Int = Math.floor(songCalc / 1000);
+			var secondsTotal:Int = Math.floor((songCalc/playbackRate) / 1000);
 			if(secondsTotal < 0) secondsTotal = 0;
 
 			if(ClientPrefs.data.timeBarType != 'Song Name')


### PR DESCRIPTION
The time bar's text isn't shown correctly if `playbackRate` is set to a number that isn't 1.0, so I fixed that.
