### PR TITLE
Fix layering on UI 

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -463,10 +463,10 @@ class PlayState extends MusicBeatState
 		}
 		stagesFunc(function(stage:BaseStage) stage.createPost());
 
-		comboGroup = new FlxSpriteGroup();
-		add(comboGroup);
+		// INITIALIZE UI GROUPS
 		uiGroup = new FlxSpriteGroup();
-		add(uiGroup);
+		strumLineNotes = new FlxTypedGroup<StrumNote>();
+		comboGroup = new FlxSpriteGroup();
 
 		Conductor.songPosition = -5000 / Conductor.songPosition;
 		var showTime:Bool = (ClientPrefs.data.timeBarType != 'Disabled');
@@ -487,9 +487,10 @@ class PlayState extends MusicBeatState
 		uiGroup.add(timeBar);
 		uiGroup.add(timeTxt);
 
-		strumLineNotes = new FlxTypedGroup<StrumNote>();
+		add(comboGroup);
 		add(strumLineNotes);
 		add(grpNoteSplashes);
+		add(uiGroup);
 
 		if(ClientPrefs.data.timeBarType == 'Song Name')
 		{


### PR DESCRIPTION
Solves https://github.com/ShadowMario/FNF-PsychEngine/issues/13014 by changing the layering on the UI groups when generating the UI

new order is:
- Judgements and Combo first
- Strumlines second
- Note Splashes third
- general UI last