### PR TITLE
rewrite of HScript.hx (fix of runHaxeCode and etc)

### DIFF
--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -1450,7 +1450,7 @@ class FunkinLua {
 			trace(e);
 			return;
 		}
-		trace('lua file loaded succesfully:' + scriptName);
+		trace('lua file loaded successfully:' + scriptName);
 
 		call('onCreate', []);
 		#end
@@ -1485,7 +1485,7 @@ class FunkinLua {
 			// Checks if it's not successful, then show a error.
 			if (status != Lua.LUA_OK) {
 				var error:String = getErrorMessage(status);
-				luaTrace("ERROR (" + func + "): " + error, false, false, FlxColor.RED);
+				luaTrace("ERROR (" + func + ") - " + error, false, false, FlxColor.RED);
 				return Function_Continue;
 			}
 

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -5,6 +5,11 @@ import objects.Character;
 import psychlua.FunkinLua;
 import psychlua.CustomSubstate;
 
+#if sys
+import sys.FileSystem;
+import sys.io.File;
+#end
+
 #if (HSCRIPT_ALLOWED && SScript >= "3.0.0")
 import tea.SScript;
 class HScript extends SScript
@@ -36,10 +41,21 @@ class HScript extends SScript
 	public var origin:String;
 	override public function new(?parent:FunkinLua, ?file:String)
 	{
+		var usesClasses = false;
+
 		if (file == null)
 			file = '';
-	
-		super(file, false, false);
+		#if sys
+		else if (FileSystem.exists(file)) {
+			var fileWithoutComments = ~/(\/[*](?:[^*]|[\r\n]|([*]+([^*\/]|[\r\n])))*[*]+\/|\/\/.*)/gm.replace(File.getContent(file), '');
+			usesClasses = ~/class\s.*\s*{/.match(fileWithoutComments);
+		}
+		#end
+
+		super(null, false, false);
+		classSupport = usesClasses;
+		doFile(file);
+
 		parentLua = parent;
 		if (parent != null)
 			origin = parent.scriptName;

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -76,21 +76,13 @@ class HScript extends SScript
 		});
 		set('getVar', function(name:String)
 		{
-			var result:Dynamic = null;
-			if(PlayState.instance.variables.exists(name)) result = PlayState.instance.variables.get(name);
-			return result;
+			return PlayState.instance.variables.get(name);
 		});
 		set('removeVar', function(name:String)
 		{
-			if(PlayState.instance.variables.exists(name))
-			{
-				PlayState.instance.variables.remove(name);
-				return true;
-			}
-			return false;
+			return PlayState.instance.variables.remove(name);
 		});
-		set('debugPrint', function(text:String, ?color:FlxColor = null) {
-			if(color == null) color = FlxColor.WHITE;
+		set('debugPrint', function(text:String, ?color:FlxColor = FlxColor.WHITE) {
 			PlayState.instance.addTextToDebug(text, color);
 		});
 
@@ -117,26 +109,11 @@ class HScript extends SScript
 		});
 
 		set('addHaxeLibrary', function(libName:String, ?libPackage:String = '') {
-			try {
-				var str:String = '';
-				if(libPackage.length > 0)
-					str = libPackage + '.';
+			var str:String = '';
+			if(libPackage.length > 0)
+				str = libPackage + '.' + libName;
 
-				var c:Dynamic = Type.resolveClass(str + libName);
-				if (c == null)
-					c = Type.resolveEnum(str + libName);
-				set(libName, c);
-			}
-			catch (e:Dynamic) {
-				var msg:String = e.message.substr(0, e.message.indexOf('\n'));
-				if(parentLua != null)
-				{
-					FunkinLua.lastCalledScript = parentLua;
-					msg = origin + ":" + parentLua.lastCalledFunction + " - " + msg;
-				}
-				else msg = '$origin - $msg';
-				FunkinLua.luaTrace(msg, parentLua == null, false, FlxColor.RED);
-			}
+			set(libName, resolveClassOrEnum(str + libName));
 		});
 		set('parentLua', parentLua);
 		set('this', this);
@@ -159,109 +136,60 @@ class HScript extends SScript
 		set('remove', function(obj:FlxBasic, splice:Bool = false) PlayState.instance.remove(obj, splice));
 	}
 
-	public function executeCode(?funcToRun:String = null, ?funcArgs:Array<Dynamic> = null):SCall
-	{
-		if (funcToRun == null) return null;
-
-		if(!exists(funcToRun))
-		{
-			FunkinLua.luaTrace(origin + ' - No HScript function named: $funcToRun', false, false, FlxColor.RED);
-			return null;
-		}
-
-		var callValue = call(funcToRun, funcArgs);
-		if (!callValue.succeeded)
-		{
-			var e = callValue.exceptions[0];
-			if (e != null)
-			{
-				var msg:String = e.toString();
-				if(parentLua != null) msg = origin + ":" + parentLua.lastCalledFunction + " - " + msg;
-				else msg = '$origin - $msg';
-				FunkinLua.luaTrace(msg, parentLua == null, false, FlxColor.RED);
-			}
-			return null;
-		}
-		return callValue;
+	function resolveClassOrEnum(name:String):Dynamic {
+		var c:Dynamic = Type.resolveClass(name);
+		if (c == null)
+			c = Type.resolveEnum(name);
+		return c;
 	}
 
-	public function executeFunction(funcToRun:String = null, funcArgs:Array<Dynamic>):SCall
-	{
-		if (funcToRun == null)
-			return null;
+	// its like deprecated, it doing the same as executeFunction
+	public function executeCode(?funcToRun:String, ?funcArgs:Array<Dynamic>):SCall {
+		return executeFunction(funcToRun, funcArgs);
+	}
 
-		return call(funcToRun, funcArgs);
+	public function executeFunction(?funcToRun:String, ?funcArgs:Array<Dynamic>):SCall {
+		var callValue:SCall = call(funcToRun, funcArgs);
+		if (!callValue.succeeded) {
+			var e = callValue.exceptions[0];
+			if (e != null)
+				FunkinLua.luaTrace('ERROR (${callValue.calledFunction}) - $e', false, false, FlxColor.RED);
+		}
+		return callValue;
 	}
 
 	public static function implement(funk:FunkinLua)
 	{
 		#if LUA_ALLOWED
-		funk.addLocalCallback("runHaxeCode", function(codeToRun:String, ?varsToBring:Any = null, ?funcToRun:String = null, ?funcArgs:Array<Dynamic> = null):Dynamic {
+		funk.addLocalCallback("runHaxeCode", function(codeToRun:String, ?varsToBring:Any, ?funcToRun:String, ?funcArgs:Array<Dynamic>):Dynamic {
 			var retVal:SCall = null;
-			initHaxeModuleCode(funk, codeToRun);
-			if(varsToBring != null)
-			{
-				for (key in Reflect.fields(varsToBring))
-				{
-					//trace('Key $key: ' + Reflect.field(varsToBring, key));
-					funk.hscript.set(key, Reflect.field(varsToBring, key));
-				}
-			}
-			retVal = funk.hscript.executeCode(funcToRun, funcArgs);
-			if (retVal != null)
-			{
-				if(retVal.succeeded)
-					return (retVal.returnValue == null || LuaUtils.isOfTypes(retVal.returnValue, [Bool, Int, Float, String, Array])) ? retVal.returnValue : null;
+			initHaxeModule(funk);
 
-				var e = retVal.exceptions[0];
-				if (e != null)
-					FunkinLua.luaTrace('ERROR (${funk.lastCalledFunction} - $e', false, false, FlxColor.RED);
-				return null;
+			if(varsToBring != null) {
+				for (key in Reflect.fields(varsToBring))
+					funk.hscript.set(key, Reflect.field(varsToBring, key));
 			}
-			else if (funk.hscript.returnValue != null)
-				return funk.hscript.returnValue;
-			return null;
+			funk.hscript.doString(codeToRun);
+
+			if (funcToRun != null) {
+				retVal = funk.hscript.executeFunction(funcToRun, funcArgs);
+				if (retVal.returnValue != null)
+					return retVal.returnValue;
+			}
+			return funk.hscript.returnValue;
 		});
-		
-		funk.addLocalCallback("runHaxeFunction", function(funcToRun:String, ?funcArgs:Array<Dynamic> = null) {
-			var callValue = funk.hscript.executeFunction(funcToRun, funcArgs);
-			if (!callValue.succeeded)
-			{
-				var e = callValue.exceptions[0];
-				if (e != null)
-					FunkinLua.luaTrace('ERROR (${callValue.calledFunction}) - $e', false, false, FlxColor.RED);
-				return null;
-			}
-			else
-				return callValue.returnValue;
+		funk.addLocalCallback("runHaxeFunction", function(funcToRun:String, ?funcArgs:Array<Dynamic>):Dynamic {
+			initHaxeModule(funk);
+			return funk.hscript.executeFunction(funcToRun, funcArgs).returnValue;
 		});
 		// This function is unnecessary because import already exists in SScript as a native feature
-		funk.addLocalCallback("addHaxeLibrary", function(libName:String, ?libPackage:String = '') {
+		funk.addLocalCallback("addHaxeLibrary", function(?libName:String = '', ?libPackage:String = '') {
 			var str:String = '';
 			if(libPackage.length > 0)
-				str = libPackage + '.';
-			else if(libName == null)
-				libName = '';
+				str = libPackage + '.' + libName;
 
-			var c:Dynamic = Type.resolveClass(str + libName);
-			if (c == null)
-				c = Type.resolveEnum(str + libName);
-
-			#if (SScript >= "3.0.3")
-			if (c != null)
-				SScript.globalVariables[libName] = c;
-			#end
-
-			if (funk.hscript != null)
-			{
-				try {
-					if (c != null)
-						funk.hscript.set(libName, c);
-				}
-				catch (e:Dynamic) {
-					FunkinLua.luaTrace('ERROR (${funk.lastCalledFunction}) - $e', false, false, FlxColor.RED);
-				}
-			}
+			initHaxeModule(funk);
+			funk.hscript.set(libName, funk.hscript.resolveClassOrEnum(str + libName));
 		});
 		#end
 	}

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -205,7 +205,8 @@ class HScript extends SScript
 		funk.addLocalCallback("runHaxeCode", function(codeToRun:String, ?varsToBring:Any = null, ?funcToRun:String = null, ?funcArgs:Array<Dynamic> = null):Dynamic {
 			var retVal:SCall = null;
 			#if (SScript >= "3.0.0")
-			initHaxeModuleCode(funk, codeToRun);
+			initHaxeModule(funk);
+			funk.hscript.doString(codeToRun);
 			if(varsToBring != null)
 			{
 				for (key in Reflect.fields(varsToBring))

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -5,11 +5,6 @@ import objects.Character;
 import psychlua.FunkinLua;
 import psychlua.CustomSubstate;
 
-#if sys
-import sys.FileSystem;
-import sys.io.File;
-#end
-
 #if (HSCRIPT_ALLOWED && SScript >= "3.0.0")
 import tea.SScript;
 class HScript extends SScript
@@ -41,21 +36,10 @@ class HScript extends SScript
 	public var origin:String;
 	override public function new(?parent:FunkinLua, ?file:String)
 	{
-		var usesClasses = false;
-
 		if (file == null)
 			file = '';
-		#if sys
-		else if (FileSystem.exists(file)) {
-			var fileWithoutComments = ~/(\/[*](?:[^*]|[\r\n]|([*]+([^*\/]|[\r\n])))*[*]+\/|\/\/.*)/gm.replace(File.getContent(file), '');
-			usesClasses = ~/class\s.*\s*{/.match(fileWithoutComments);
-		}
-		#end
 
-		super(null, false, false);
-		classSupport = usesClasses;
-		doFile(file);
-
+		super(file, false, false);
 		parentLua = parent;
 		if (parent != null)
 			origin = parent.scriptName;

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -215,7 +215,7 @@ class HScript extends SScript
 
 				var e = retVal.exceptions[0];
 				if (e != null)
-					FunkinLua.luaTrace(funk.hscript.origin + ":" + funk.lastCalledFunction + " - " + e, false, false, FlxColor.RED);
+					FunkinLua.luaTrace('ERROR (${funk.lastCalledFunction} - $e', false, false, FlxColor.RED);
 				return null;
 			}
 			else if (funk.hscript.returnValue != null)
@@ -229,7 +229,7 @@ class HScript extends SScript
 			{
 				var e = callValue.exceptions[0];
 				if (e != null)
-					FunkinLua.luaTrace('ERROR (${funk.hscript.origin}: ${callValue.calledFunction}) - ' + e.message.substr(0, e.message.indexOf('\n')), false, false, FlxColor.RED);
+					FunkinLua.luaTrace('ERROR (${callValue.calledFunction}) - $e', false, false, FlxColor.RED);
 				return null;
 			}
 			else
@@ -259,7 +259,7 @@ class HScript extends SScript
 						funk.hscript.set(libName, c);
 				}
 				catch (e:Dynamic) {
-					FunkinLua.luaTrace(funk.hscript.origin + ":" + funk.lastCalledFunction + " - " + e, false, false, FlxColor.RED);
+					FunkinLua.luaTrace('ERROR (${funk.lastCalledFunction}) - $e', false, false, FlxColor.RED);
 				}
 			}
 		});

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -166,8 +166,18 @@ class HScript extends SScript
 			initHaxeModule(funk);
 
 			if(varsToBring != null) {
-				for (key in Reflect.fields(varsToBring))
-					funk.hscript.set(key, Reflect.field(varsToBring, key));
+				if (varsToBring is Array) {
+					for (vars in cast(varsToBring, Array<Dynamic>)) if (vars is String) {
+						funk.hscript.doString('function bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA() { return $vars; this.unset("bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA"); }');
+						var obj = funk.hscript.call('bmV2ZXIgZ29ubmEgZ2l2ZSB5b3UgdXA').returnValue;
+						var fields = (obj is Class) ? Type.getClassFields(obj) : Reflect.fields(obj);
+						for (key in fields)
+							funk.hscript.set(key, Reflect.field(obj, key));
+					}
+				}
+				else
+					for (key in Reflect.fields(varsToBring))
+						funk.hscript.set(key, Reflect.field(varsToBring, key));
 			}
 			funk.hscript.doString(codeToRun);
 

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -146,7 +146,7 @@ class HScript extends SScript
 				if(libPackage.length > 0)
 					str = libPackage + '.';
 
-				var c = Type.resolveClass(str + libName);
+				var c:Dynamic = Type.resolveClass(str + libName);
 				if (c == null)
 					c = Type.resolveEnum(str + libName);
 				set(libName, c);
@@ -277,7 +277,7 @@ class HScript extends SScript
 			else if(libName == null)
 				libName = '';
 
-			var c = Type.resolveClass(str + libName);
+			var c:Dynamic = Type.resolveClass(str + libName);
 			if (c == null)
 				c = Type.resolveEnum(str + libName);
 

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -13,24 +13,17 @@ class HScript extends SScript
 	
 	public static function initHaxeModule(parent:FunkinLua)
 	{
-		#if (SScript >= "3.0.0")
-		if(parent.hscript == null)
-		{
+		if(parent.hscript == null) {
 			trace('initializing haxe interp for: ${parent.scriptName}');
 			parent.hscript = new HScript(parent);
 		}
-		#end
 	}
 
 	public static function initHaxeModuleCode(parent:FunkinLua, code:String)
 	{
-		#if (SScript >= "3.0.0")
-		if(parent.hscript == null)
-		{
-			trace('initializing haxe interp for: ${parent.scriptName}');
-			parent.hscript = new HScript(parent, code);
-		}
-		#end
+		initHaxeModule(parent);
+		if (parent.hscript != null)
+			parent.hscript.doString(code);
 	}
 
 	public var origin:String;
@@ -51,7 +44,6 @@ class HScript extends SScript
 
 	override function preset()
 	{
-		#if (SScript >= "3.0.0")
 		super.preset();
 
 		// Some very commonly used classes
@@ -165,7 +157,6 @@ class HScript extends SScript
 		set('addBehindBF', function(obj:FlxBasic) PlayState.instance.addBehindBF(obj));
 		set('insert', function(pos:Int, obj:FlxBasic) PlayState.instance.insert(pos, obj));
 		set('remove', function(obj:FlxBasic, splice:Bool = false) PlayState.instance.remove(obj, splice));
-		#end
 	}
 
 	public function executeCode(?funcToRun:String = null, ?funcArgs:Array<Dynamic> = null):SCall
@@ -207,9 +198,7 @@ class HScript extends SScript
 		#if LUA_ALLOWED
 		funk.addLocalCallback("runHaxeCode", function(codeToRun:String, ?varsToBring:Any = null, ?funcToRun:String = null, ?funcArgs:Array<Dynamic> = null):Dynamic {
 			var retVal:SCall = null;
-			#if (SScript >= "3.0.0")
-			initHaxeModule(funk);
-			funk.hscript.doString(codeToRun);
+			initHaxeModuleCode(funk, codeToRun);
 			if(varsToBring != null)
 			{
 				for (key in Reflect.fields(varsToBring))
@@ -231,14 +220,10 @@ class HScript extends SScript
 			}
 			else if (funk.hscript.returnValue != null)
 				return funk.hscript.returnValue;
-			#else
-			FunkinLua.luaTrace("runHaxeCode: HScript isn't supported on this platform!", false, false, FlxColor.RED);
-			#end
 			return null;
 		});
 		
 		funk.addLocalCallback("runHaxeFunction", function(funcToRun:String, ?funcArgs:Array<Dynamic> = null) {
-			#if (SScript >= "3.0.0")
 			var callValue = funk.hscript.executeFunction(funcToRun, funcArgs);
 			if (!callValue.succeeded)
 			{
@@ -249,9 +234,6 @@ class HScript extends SScript
 			}
 			else
 				return callValue.returnValue;
-			#else
-			FunkinLua.luaTrace("runHaxeFunction: HScript isn't supported on this platform!", false, false, FlxColor.RED);
-			#end
 		});
 		// This function is unnecessary because import already exists in SScript as a native feature
 		funk.addLocalCallback("addHaxeLibrary", function(libName:String, ?libPackage:String = '') {
@@ -270,7 +252,6 @@ class HScript extends SScript
 				SScript.globalVariables[libName] = c;
 			#end
 
-			#if (SScript >= "3.0.0")
 			if (funk.hscript != null)
 			{
 				try {
@@ -281,14 +262,10 @@ class HScript extends SScript
 					FunkinLua.luaTrace(funk.hscript.origin + ":" + funk.lastCalledFunction + " - " + e, false, false, FlxColor.RED);
 				}
 			}
-			#else
-			FunkinLua.luaTrace("addHaxeLibrary: HScript isn't supported on this platform!", false, false, FlxColor.RED);
-			#end
 		});
 		#end
 	}
 
-	#if (SScript >= "3.0.3")
 	override public function destroy()
 	{
 		origin = null;
@@ -296,12 +273,6 @@ class HScript extends SScript
 
 		super.destroy();
 	}
-	#else
-	public function destroy()
-	{
-		active = false;
-	}
-	#end
 }
 
 class CustomFlxColor

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -130,7 +130,10 @@ class HScript extends SScript
 				if(libPackage.length > 0)
 					str = libPackage + '.';
 
-				set(libName, Type.resolveClass(str + libName));
+				var c = Type.resolveClass(str + libName);
+				if (c == null)
+					c = Type.resolveEnum(str + libName);
+				set(libName, c);
 			}
 			catch (e:Dynamic) {
 				var msg:String = e.message.substr(0, e.message.indexOf('\n'));

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -259,6 +259,8 @@ class HScript extends SScript
 				libName = '';
 
 			var c = Type.resolveClass(str + libName);
+			if (c == null)
+				c = Type.resolveEnum(str + libName);
 
 			#if (SScript >= "3.0.3")
 			if (c != null)

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -2135,7 +2135,7 @@ class PlayState extends MusicBeatState
 				}
 				catch(e:Dynamic)
 				{
-					addTextToDebug('ERROR ("Set Property" Event) - ' + e.message.substr(0, e.message.indexOf('\n')), FlxColor.RED);
+					addTextToDebug('ERROR ("Set Property" Event) - $e', FlxColor.RED);
 				}
 			
 			case 'Play Sound':
@@ -3154,6 +3154,10 @@ class PlayState extends MusicBeatState
 
 	public function initHScript(file:String)
 	{
+		function doerror(m:String) {
+			addTextToDebug(m, FlxColor.RED);
+			trace(m);
+		}
 		try
 		{
 			var newScript:HScript = new HScript(null, file);
@@ -3163,7 +3167,7 @@ class PlayState extends MusicBeatState
 				@:privateAccess
 				for (e in newScript.parsingExceptions)
 					if(e != null)
-						addTextToDebug('ERROR ON LOADING ($file): ${e.message.substr(0, e.message.indexOf('\n'))}', FlxColor.RED);
+						doerror('ERROR ON LOADING - $e');
 				newScript.destroy();
 				return;
 			}
@@ -3176,19 +3180,19 @@ class PlayState extends MusicBeatState
 				{
 					for (e in callValue.exceptions)
 						if (e != null)
-							addTextToDebug('ERROR ($file: onCreate) - ${e.message.substr(0, e.message.indexOf('\n'))}', FlxColor.RED);
+							doerror('ERROR (onCreate) - $e');
 
 					newScript.destroy();
 					hscriptArray.remove(newScript);
-					trace('failed to initialize sscript interp!!! ($file)');
+					return;
 				}
-				else trace('initialized sscript interp successfully: $file');
 			}
-			
+
+			trace('initialized sscript interp successfully: $file');
 		}
 		catch(e)
 		{
-			addTextToDebug('ERROR ($file) - ' + e.message.substr(0, e.message.indexOf('\n')), FlxColor.RED);
+			doerror('ERROR - $e');
 			var newScript:HScript = cast (SScript.global.get(file), HScript);
 			if(newScript != null)
 			{
@@ -3270,7 +3274,7 @@ class PlayState extends MusicBeatState
 				{
 					var e = callValue.exceptions[0];
 					if(e != null)
-						FunkinLua.luaTrace('ERROR (${script.origin}: ${callValue.calledFunction}) - ' + e.message.substr(0, e.message.indexOf('\n')), true, false, FlxColor.RED);
+						FunkinLua.luaTrace('ERROR (${callValue.calledFunction}) - $e', true, false, FlxColor.RED);
 				}
 				else
 				{

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -408,6 +408,10 @@ class PlayState extends MusicBeatState
 		add(luaDebugGroup);
 		#end
 
+		#if (SScript >= "4.1.0")
+		SScript.defaultClassSupport = null;
+		#end
+
 		// "GLOBAL" SCRIPTS
 		#if LUA_ALLOWED
 		var foldersToCheck:Array<String> = Mods.directoriesWithFile(Paths.getPreloadPath(), 'scripts/');

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -408,10 +408,6 @@ class PlayState extends MusicBeatState
 		add(luaDebugGroup);
 		#end
 
-		#if (SScript >= "4.1.0")
-		SScript.defaultClassSupport = null;
-		#end
-
 		// "GLOBAL" SCRIPTS
 		#if LUA_ALLOWED
 		var foldersToCheck:Array<String> = Mods.directoriesWithFile(Paths.getPreloadPath(), 'scripts/');


### PR DESCRIPTION
code in runHaxeCode runs only if you did it one time, if call it again, it ignores code, this pr fixes that problem
resolves #13012, #12954
u need use `public var examplevar = 0;` to use `examplevar` in another calls of runHaxeCode tho

- **addHaxeLibrary can add enums now**
- **rewrited some error messages**

1. for example (new):
```
ERROR ON LOADING - mods/scripts/sdf.hx:2: Unknown variable: pig
ERROR (onCreate) - mods/scripts/sdf.hx:2: Unknown variable: pig
```
2. also "initialized sscript interp successfully" now traces even if onCreate function doesnt exist
3. also error messages from hscript now traces to console

- **rewrited some code in HScript.hx (optimization?!??!?)**
- **added new coolie feature for 2nd argument of runHaxeCode**
1. for example (new feature):
```lua
runHaxeCode("debugPrint(songPercent);", {'game'})
```
2. the same as:
```lua
runHaxeCode("debugPrint(game.songPercent);")
```