### PR TITLE
Lock hmm.json to specific versions to improve install process.

### DIFF
--- a/hmm.json
+++ b/hmm.json
@@ -1,78 +1,87 @@
 {
   "dependencies": [
     {
-      "name": "lime",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "openfl",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "flixel",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "flixel-addons",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "flixel-tools",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "flixel-ui",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "hxcpp",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "tjson",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "hxjsonast",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "hxCodec",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "SScript",
-      "type": "haxelib",
-      "version": null
-    },
-    {
-      "name": "hxcpp-debug-server",
-      "type": "haxelib",
-      "version": null
-    },
-    {
       "name": "discord_rpc",
       "type": "git",
       "dir": null,
       "ref": "master",
-      "url": "https://github.com/Aidan63/linc_discord-rpc"
+      "url": "https://github.com/Aidan63/linc_discord-rpc.git"
+    },
+    {
+      "name": "flixel",
+      "type": "haxelib",
+      "version": "5.2.2"
+    },
+    {
+      "name": "flixel-addons",
+      "type": "haxelib",
+      "version": "3.0.2"
+    },
+    {
+      "name": "flixel-tools",
+      "type": "haxelib",
+      "version": "1.5.1"
+    },
+    {
+      "name": "flixel-ui",
+      "type": "haxelib",
+      "version": "2.5.0"
+    },
+    {
+      "name": "hscript",
+      "type": "haxelib",
+      "version": "2.5.0"
+    },
+    {
+      "name": "https://github.com/polybiusproxy/hxCodec",
+      "type": "git",
+      "dir": null,
+      "ref": "master",
+      "url": "c8c47e706ad82a423783006ed901b6d93c89a421"
+    },
+    {
+      "name": "hxCodec",
+      "type": "git",
+      "dir": null,
+      "ref": "c8c47e706ad82a423783006ed901b6d93c89a421",
+      "url": "https://github.com/polybiusproxy/hxCodec"
+    },
+    {
+      "name": "hxcpp",
+      "type": "haxelib",
+      "version": "4.3.2"
+    },
+    {
+      "name": "hxcpp-debug-server",
+      "type": "haxelib",
+      "version": "1.2.4"
+    },
+    {
+      "name": "lime",
+      "type": "haxelib",
+      "version": "8.0.1"
     },
     {
       "name": "linc_luajit",
       "type": "git",
       "dir": null,
       "ref": "master",
-      "url": "https://github.com/superpowers04/linc_luajit"
+      "url": "https://github.com/superpowers04/linc_luajit.git"
+    },
+    {
+      "name": "openfl",
+      "type": "haxelib",
+      "version": "9.2.1"
+    },
+    {
+      "name": "sscript",
+      "type": "haxelib",
+      "version": "4.0.1"
+    },
+    {
+      "name": "tjson",
+      "type": "haxelib",
+      "version": "1.4.0"
     }
   ]
 }

--- a/hmm.json
+++ b/hmm.json
@@ -33,13 +33,6 @@
       "version": "2.5.0"
     },
     {
-      "name": "https://github.com/polybiusproxy/hxCodec",
-      "type": "git",
-      "dir": null,
-      "ref": "master",
-      "url": "c8c47e706ad82a423783006ed901b6d93c89a421"
-    },
-    {
       "name": "hxCodec",
       "type": "git",
       "dir": null,


### PR DESCRIPTION
Now you can just install Haxe 4.2.5 and do this:

```
haxelib install hmm
haxelib run hmm install
```

and it will install the correct library versions for you, automatically, into a local haxelib folder so it doesn't interfere with your other projects.