### PR TITLE
Icon workaround fix on Linux

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -167,6 +167,8 @@
 	<!-- _________________________________ Custom _______________________________ -->
 
 	<!--Place custom nodes like icons here (higher priority to override the HaxeFlixel icon)-->
+
+	<assets path='art/iconOG.png' rename='icon.png' if="linux" />
 	
 	<icon path="art/icon16.png" size='16'/>
 	<icon path="art/icon32.png" size='32'/>

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -13,6 +13,10 @@ import openfl.display.StageScaleMode;
 import lime.app.Application;
 import states.TitleState;
 
+#if linux
+import lime.graphics.Image;
+#end
+
 //crash handler stuff
 #if CRASH_HANDLER
 import openfl.events.UncaughtErrorEvent;
@@ -95,6 +99,11 @@ class Main extends Sprite
 		if(fpsVar != null) {
 			fpsVar.visible = ClientPrefs.data.showFPS;
 		}
+		#end
+
+		#if linux
+		var icon = Image.fromFile("icon.png");
+		Lib.current.stage.window.setIcon(icon);
 		#end
 
 		#if html5


### PR DESCRIPTION
linux doesn't have app icons (window/taskbar icons)

so instead, add icon.png to the main folder, and set the icon manually in Main.hx

i tried using Assets.getBitmapData too, but it would result in the icon being displayed in BGR instead of RGB