### PR TITLE
Finalisation for the new install method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ export/*
 .vscode/*
 .haxelib/
 *.code-workspace
+vs_Community.exe
 # Local history which shouldn't be shared.
 .history
 .ionide


### PR DESCRIPTION
This is just a finalisation of #13243
Since the visual studio component is now getting downloaded inside the engine folder, I just added it to gitignore:

![image](https://github.com/ShadowMario/FNF-PsychEngine/assets/87421482/1d146c3b-b55b-416d-9a6b-04c3466a089a)
