### PR TITLE
Better hxCodec versions compatibility

### DIFF
--- a/source/backend/VideoHandler.hx
+++ b/source/backend/VideoHandler.hx
@@ -1,0 +1,71 @@
+package backend;
+
+#if VIDEOS_ALLOWED 
+#if (hxCodec >= "3.0.0") import hxcodec.flixel.FlxVideo as BaseVideoHandler;
+#elseif (hxCodec >= "2.6.1") import hxcodec.VideoHandler as BaseVideoHandler;
+#elseif (hxCodec == "2.6.0") import VideoHandler as BaseVideoHandler;
+#else import vlc.MP4Handler as BaseVideoHandler; #end
+#end
+
+/*A class made to handle Video functions from diffrent hxCodec versions*/
+class VideoHandler extends BaseVideoHandler {
+    public function new() {
+        super();
+    }
+    #if VIDEOS_ALLOWED
+    #if (hxCodec >= "3.0.0")
+    /**
+	 * Native video support for Flixel & OpenFL
+	 * @param Path Example: `your/video/here.mp4`
+	 * @param Loop Loop the video.
+	 */
+     #else
+    /**
+	 * Native video support for Flixel & OpenFL
+	 * @param Path Example: `your/video/here.mp4`
+	 * @param Loop Loop the video.
+	 * @param PauseMusic Pause music until the video ends.
+	 */
+     #end
+    public function startVideo(path:String, loop:Bool = false #if (hxCodec < "3.0.0") , pauseDaMusic:Bool = false #end) {
+        #if (hxCodec >= "3.0.0")
+        super.play(path, loop);
+        #else
+        super.playVideo(path, loop, pauseDaMusic);
+        #end
+    }
+
+    /**
+	 * Adds a function that is called when the Video ends.
+	 * @param func Example: `function() { //code to run}`
+	 */
+    public function setFinishCallBack(func:Dynamic){
+        #if (hxCodec >= "3.0.0")
+        super.onEndReached.add(function() {
+            super.dispose();
+            if(func != null)
+            func();
+        }, true);
+        #else
+        if(func != null)
+        super.finishCallback = func;
+        #end
+    }
+
+    /**
+	 * Adds a function which is called when the Codec is opend(video starts).
+	 * @param func Example: `function() { //code to run}`
+	 */
+    public function setStartCallBack(func:Dynamic){
+        #if (hxCodec >= "3.0.0")
+        if(func != null)
+        super.onOpening.add(func, true);
+        #else
+        if(func != null)
+        super.openingCallback = func;
+        #end
+    }
+
+    //if you want do smth such as pausing the video just do this -> yourVideo.pause();, , same thing for resume but call resume(); instead
+    #end
+}

--- a/source/backend/VideoSpriteHandler.hx
+++ b/source/backend/VideoSpriteHandler.hx
@@ -1,0 +1,72 @@
+package backend;
+#if VIDEOS_ALLOWED 
+#if (hxCodec >= "3.0.0") import hxcodec.flixel.FlxVideoSprite as BaseVideoSprite;
+#elseif (hxCodec >= "2.6.1") import hxcodec.VideoSprite as BaseVideoSprite;
+#elseif (hxCodec == "2.6.0") import VideoSprite as BaseVideoSprite;
+#else import vlc.MP4Sprite as BaseVideoSprite; #end
+#end
+
+/*A class made to handle VideoSprite from diffrent hxCodec versions*/
+class VideoSpriteHandler extends BaseVideoSprite {
+    public function new(x:Float, y:Float #if (hxCodec < "2.6.0"),width:Float = 1280, height:Float = 720, autoScale:Bool = true #end){
+        super(x, y);
+    }
+    #if VIDEOS_ALLOWED
+
+    #if (hxCodec >= "3.0.0")
+    /**
+	 * Native video support for Flixel & OpenFL
+	 * @param Path Example: `your/video/here.mp4`
+	 * @param Loop Loop the video.
+	 */
+     #else
+    /**
+	 * Native video support for Flixel & OpenFL
+	 * @param Path Example: `your/video/here.mp4`
+	 * @param Loop Loop the video.
+	 * @param PauseMusic Pause music until the video ends.
+	 */
+     #end
+    public function startVideo(path:String, loop:Bool = false #if (hxCodec < "3.0.0") , pauseDaMusic:Bool = false #end) {
+        #if (hxCodec >= "3.0.0")
+        super.play(path, loop);
+        #else
+        super.playVideo(path, loop, pauseDaMusic);
+        #end
+    }
+
+     /**
+	 * Adds a function that is called when the Video ends.
+	 * @param func Example: `function() { //code to run }`
+	 */
+    public function setFinishCallBack(func:Dynamic){
+        #if (hxCodec >= "3.0.0")
+        super.bitmap.onEndReached.add(function() {
+            //super.bitmap.dispose(); //i'm not sure about this...
+            if(func != null)
+                func();
+        }, true);
+        #else
+        if(func != null)
+        super.bitmap.finishCallback = func;
+        #end
+    }
+
+     /**
+	 * Adds a function which is called when the Codec is opend(video starts).
+	 * @param func Example: `function() { //code to run }`
+	 */
+    public function setStartCallBack(func:Dynamic){
+        #if (hxCodec >= "3.0.0")
+        if(func != null)
+        super.bitmap.onOpening.add(func, true);
+        #else
+        if(func != null)
+        super.bitmap.openingCallback = func;
+        #end
+    }
+    /*if you want do smth such as pausing the video just do this -> yourVideo.bitmap.pause();
+     same thing for resume but call resume(); instead*/
+
+    #end
+}

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -76,6 +76,10 @@ class HScript extends SScript
 		#end
 		set('ShaderFilter', openfl.filters.ShaderFilter);
 		set('StringTools', StringTools);
+		#if VIDEOS_ALLOWED
+		set('VideoSpriteHandler', backend.VideoSpriteHandler);
+		set('VideoHandler', backend.VideoHandler);
+		#end
 
 		// Functions & Variables
 		set('setVar', function(name:String, value:Dynamic)

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -55,10 +55,7 @@ import sys.io.File;
 #end
 
 #if VIDEOS_ALLOWED 
-#if (hxCodec >= "3.0.0") import hxcodec.flixel.FlxVideo as VideoHandler;
-#elseif (hxCodec >= "2.6.1") import hxcodec.VideoHandler as VideoHandler;
-#elseif (hxCodec == "2.6.0") import VideoHandler;
-#else import vlc.MP4Handler as VideoHandler; #end
+import backend.VideoHandler;
 #end
 
 import objects.Note.EventNote;
@@ -833,6 +830,7 @@ class PlayState extends MusicBeatState
 	}
 
 	public function startVideo(name:String)
+	{public function startVideo(name:String)
 	{
 		#if VIDEOS_ALLOWED
 		inCutscene = true;
@@ -841,7 +839,7 @@ class PlayState extends MusicBeatState
 		#if sys
 		if(!FileSystem.exists(filepath))
 		#else
-		if(!OpenFlAssets.exists(filepath))
+		if(!Assets.exists(filepath))
 		#end
 		{
 			FlxG.log.warn('Couldnt find video file: ' + name);
@@ -850,24 +848,11 @@ class PlayState extends MusicBeatState
 		}
 
 		var video:VideoHandler = new VideoHandler();
-			#if (hxCodec >= "3.0.0")
-			// Recent versions
-			video.play(filepath);
-			video.onEndReached.add(function()
-			{
-				video.dispose();
+			video.startVideo(filepath);
+			video.setFinishCallBack(function(){
 				startAndEnd();
 				return;
-			}, true);
-			#else
-			// Older versions
-			video.playVideo(filepath);
-			video.finishCallback = function()
-			{
-				startAndEnd();
-				return;
-			}
-			#end
+			});
 		#else
 		FlxG.log.warn('Platform not supported!');
 		startAndEnd();


### PR DESCRIPTION
This mainly helps any hxcodec scripts work on any psych build with different hxcodec versions easily

And it allows you to use VideoSprite just fine with hscript and runHaxeCode (beffor i made i couldn't call the playVideo function so ig this fixed it)

I tested this with 2.6.0 I'm not sure about 3.0 and above...