### PR TITLE
Fix onKeyPress and other functions failing on HScript

### DIFF
--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -151,12 +151,6 @@ class HScript extends BrewScript
 		set('parentLua', parentLua);
 		set('this', this);
 		set('game', PlayState.instance);
-		for (i in Type.getInstanceFields(PlayState))
-		{
-			var property:Dynamic = Reflect.getProperty(PlayState.instance, i);
-			if (property != null)
-				set(i, property);
-		}
 		set('buildTarget', FunkinLua.getBuildTarget());
 		set('customSubstate', CustomSubstate.instance);
 		set('customSubstateName', CustomSubstate.name);

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -151,6 +151,10 @@ class HScript extends BrewScript
 		set('parentLua', parentLua);
 		set('this', this);
 		set('game', PlayState.instance);
+		#if (BrewScript >= "6.1.80")
+		if (PlayState.instance != null)
+			setSpecialObject(PlayState.instance, false, PlayState.instance.instancesExclude);
+		#end
 		set('buildTarget', FunkinLua.getBuildTarget());
 		set('customSubstate', CustomSubstate.instance);
 		set('customSubstateName', CustomSubstate.name);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -104,6 +104,7 @@ class PlayState extends MusicBeatState
 	
 	#if HSCRIPT_ALLOWED
 	public var hscriptArray:Array<HScript> = [];
+	public var instancesExclude:Array<String> = [];
 	#end
 
 	#if LUA_ALLOWED
@@ -3265,6 +3266,8 @@ class PlayState extends MusicBeatState
 			if(exclusions.contains(script.origin))
 				continue;
 
+			if(!instancesExclude.contains(variable))
+				instancesExclude.push(variable);
 			script.set(variable, arg);
 		}
 		#end


### PR DESCRIPTION
This issue was tied to `game` getting set to scripts, it is now patched with Brew 6.1.80.