### PR TITLE
Camera fix for Flixel's new version

### DIFF
--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -203,7 +203,7 @@ class AchievementsMenuState extends MusicBeatState
 			}
 		}
 
-		FlxG.camera.followLerp = FlxMath.bound(elapsed * 9 / (FlxG.updateFramerate / 60), 0, 1);
+		FlxG.camera.followLerp = FlxMath.bound(elapsed * 9 * (FlxG.updateFramerate / 60), 0, 1);
 
 		if (controls.BACK) {
 			FlxG.sound.play(Paths.sound('cancelMenu'));

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -137,7 +137,7 @@ class MainMenuState extends MusicBeatState
 			FlxG.sound.music.volume += 0.5 * elapsed;
 			if(FreeplayState.vocals != null) FreeplayState.vocals.volume += 0.5 * elapsed;
 		}
-		FlxG.camera.followLerp = FlxMath.bound(elapsed * 9 / (FlxG.updateFramerate / 60), 0, 1);
+		FlxG.camera.followLerp = FlxMath.bound(elapsed * 9 * (FlxG.updateFramerate / 60), 0, 1);
 
 		if (!selectedSomethin)
 		{

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1594,7 +1594,7 @@ class PlayState extends MusicBeatState
 
 		FlxG.camera.followLerp = 0;
 		if(!inCutscene && !paused) {
-			FlxG.camera.followLerp = FlxMath.bound(elapsed * 2.4 * cameraSpeed * playbackRate / (FlxG.updateFramerate / 60), 0, 1);
+			FlxG.camera.followLerp = FlxMath.bound(elapsed * 2.4 * cameraSpeed * playbackRate * (FlxG.updateFramerate / 60), 0, 1);
 			if(!startingSong && !endingSong && boyfriend.animation.curAnim != null && boyfriend.animation.curAnim.name.startsWith('idle')) {
 				boyfriendIdleTime += elapsed;
 				if(boyfriendIdleTime >= 0.15) { // Kind of a mercy thing for making the achievement easier to get as it's apparently frustrating to some playerss

--- a/source/states/TitleState.hx
+++ b/source/states/TitleState.hx
@@ -83,7 +83,6 @@ class TitleState extends MusicBeatState
 		#end
 		Mods.loadTopMod();
 
-		FlxG.fixedTimestep = false;
 		FlxG.game.focusLostFramerate = 60;
 		FlxG.keys.preventDefaultKeys = [TAB];
 

--- a/source/substates/GameOverSubstate.hx
+++ b/source/substates/GameOverSubstate.hx
@@ -143,7 +143,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			}
 		}
 		
-		if(updateCamera) FlxG.camera.followLerp = FlxMath.bound(elapsed * 0.6 / (FlxG.updateFramerate / 60), 0, 1);
+		if(updateCamera) FlxG.camera.followLerp = FlxMath.bound(elapsed * 0.6 * (FlxG.updateFramerate / 60), 0, 1);
 		else FlxG.camera.followLerp = 0;
 
 		if (FlxG.sound.music.playing)


### PR DESCRIPTION
Yeah they changed the camera scroll method: https://github.com/HaxeFlixel/flixel/pull/2920
So now without this fix the camera is slow as fuck when on high fps since maths has changed
I also needed to set the fixed timestamp as true otherwhise sometimes the camera would have just randomly teleported