### PR TITLE
make icons in freeplay centered properly

### DIFF
--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -494,6 +494,8 @@ class FreeplayState extends MusicBeatState
 
 		updateTexts(elapsed);
 		super.update(elapsed);
+
+		for (icon in iconArray) icon.y = icon.sprTracker.y - 36;
 	}
 
 	public static function destroyFreeplayVocals() {


### PR DESCRIPTION
icons in freeplay are off center
this fixes that

# without fix
![](https://github.com/ShadowMario/FNF-PsychEngine/assets/73214127/610dc097-d112-4a8e-b146-9676d8ecffc4)

# with fix
![](https://github.com/ShadowMario/FNF-PsychEngine/assets/73214127/905eb612-4411-4b80-8e53-511480bc2e22)

icons are also both 300x150

this might also be a shit way of fixing it but im sure someone will make a better method down the road lmao

