### PR TITLE
Add helpful trace information to `Paths.image`

### DIFF
--- a/source/backend/Paths.hx
+++ b/source/backend/Paths.hx
@@ -253,7 +253,8 @@ class Paths
 			if(retVal != null) return retVal;
 		}
 
-		trace('oh no its returning null NOOOO ($file) (' + posInfos.fileName + ', ' + posInfos.lineNumber + ')');
+		trace('Image with key "$key" could not be found' + (library == null ? '' : ' in the library "$library"') + '! ' + '(${posInfos.fileName}, ${posInfos.lineNumber})');
+		
 		return null;
 	}
 

--- a/source/backend/Paths.hx
+++ b/source/backend/Paths.hx
@@ -220,7 +220,7 @@ class Paths
 	}
 
 	public static var currentTrackedAssets:Map<String, FlxGraphic> = [];
-	static public function image(key:String, ?library:String = null, ?allowGPU:Bool = true):FlxGraphic
+	static public function image(key:String, ?library:String = null, ?allowGPU:Bool = true, ?posInfos:haxe.PosInfos):FlxGraphic
 	{
 		var bitmap:BitmapData = null;
 		var file:String = null;
@@ -253,7 +253,7 @@ class Paths
 			if(retVal != null) return retVal;
 		}
 
-		trace('oh no its returning null NOOOO ($file)');
+		trace('oh no its returning null NOOOO ($file) (' + posInfos.fileName + ', ' + posInfos.lineNumber + ')');
 		return null;
 	}
 


### PR DESCRIPTION
`Paths.image` currently does not output much useful information when an image you are trying to load is missing. It only tells you what image couldn't be found, and no other information.

This PR adds a new parameter to Paths.image, `posInfos`. This parameter is not meant to be filled in and is recommended to be left empty as much as possible. However, you SHOULD be able to insert your own data without much trouble.

The trace has been extended to display the class name you are calling the function from, as well as the line number, here's a quick sample.
![image](https://github.com/ShadowMario/FNF-PsychEngine/assets/86160807/a0132db7-9edd-4994-a323-ae9c2163cb0e)