### PR TITLE
changed "shader coords fix" filters var

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -141,7 +141,7 @@ class Main extends Sprite
 		     if (FlxG.cameras != null) {
 			   for (cam in FlxG.cameras.list) {
 				@:privateAccess
-				if (cam != null && cam._filters != null)
+				if (cam != null && cam.filters != null)
 					resetSpriteCache(cam.flashSprite);
 			   }
 		     }


### PR DESCRIPTION
Changed the deprecated var "_filters" to "filters".

According to the flixel source(FlxCamera), it is the same variable type, with the only difference that the default value is null.
![FlxCamera var source](https://github.com/ShadowMario/FNF-PsychEngine/assets/79620403/98775d0a-e7b0-45da-9ea5-c23bdbda8b77)
