### PR TITLE
Add PsychLua "removeHScript" function

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -141,7 +141,7 @@ class Main extends Sprite
 		     if (FlxG.cameras != null) {
 			   for (cam in FlxG.cameras.list) {
 				@:privateAccess
-				if (cam != null && cam.filters != null)
+				if (cam != null && cam._filters != null)
 					resetSpriteCache(cam.flashSprite);
 			   }
 		     }

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -141,7 +141,7 @@ class Main extends Sprite
 		     if (FlxG.cameras != null) {
 			   for (cam in FlxG.cameras.list) {
 				@:privateAccess
-				if (cam != null && cam._filters != null)
+				if (cam != null && cam.filters != null)
 					resetSpriteCache(cam.flashSprite);
 			   }
 		     }

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -425,6 +425,26 @@ class FunkinLua {
 			luaTrace('removeLuaScript: Script $luaFile isn\'t running!', false, false, FlxColor.RED);
 			return false;
 		});
+		Lua_helper.add_callback(lua, "removeHScript", function(luaFile:String, ?ignoreAlreadyRunning:Bool = false) {
+			#if HSCRIPT_ALLOWED
+			var foundScript:String = findScript(luaFile, '.hx');
+			if(foundScript != null)
+			{
+				if(!ignoreAlreadyRunning)
+					for (script in game.hscriptArray)	
+						if(script.origin == foundScript)
+						{
+							trace('Closing script ' + (script.origin != null ? script.origin : luaFile));
+							script.destroy();
+							return true;
+						}
+			}
+			luaTrace('removeHScript: Script $luaFile isn\'t running!', false, false, FlxColor.RED);
+			return false;
+			#else
+			luaTrace("removeHScript: HScript is not supported on this platform!", false, false, FlxColor.RED);
+			#end
+		});
 
 		Lua_helper.add_callback(lua, "loadSong", function(?name:String = null, ?difficultyNum:Int = -1) {
 			if(name == null || name.length < 1)


### PR DESCRIPTION
following the same functionality as "**removeLuaScript**"

Scripts used for testing:
- hscript_test.lua (removeHScript event):
`function onEvent(name, value1, value2)
    if name == 'hscript_test' then
        if value1 == 'true' then
            addHScript('test')
            print('added hscript')
        elseif value1 == 'false' then
            removeHScript('test')
            print('removed hscript')
        end
    end
end`
- test.hx (HScript test):
`function onCreate() {
    trace("added");
}
function onBeatHit()
{
    if(curBeat % 2 == 0)
    {
        trace(curBeat);
    }
}`

Tested in test chart song (test script stored on Vs.Karie() mod folder):
![a_removehscripttest](https://github.com/ShadowMario/FNF-PsychEngine/assets/79620403/eb73cbe7-97f0-4796-877b-3f2b9f2441f3)

_(PR recreated due a conflict with "shader coords fix" commit)_