### PR TITLE
Use current monitor refresh rate for default framerate

### DIFF
--- a/source/backend/ClientPrefs.hx
+++ b/source/backend/ClientPrefs.hx
@@ -180,6 +180,11 @@ class ClientPrefs {
 
 		#if (!html5 && !switch)
 		FlxG.autoPause = ClientPrefs.data.autoPause;
+
+		if(FlxG.save.data.framerate == null) {
+			final refreshRate:Int = FlxG.stage.application.window.displayMode.refreshRate;
+			data.framerate = Std.int(FlxMath.bound(refreshRate, 60, 240));
+		}
 		#end
 
 		if(data.framerate > FlxG.drawFramerate)

--- a/source/options/GraphicsSettingsSubState.hx
+++ b/source/options/GraphicsSettingsSubState.hx
@@ -52,8 +52,10 @@ class GraphicsSettingsSubState extends BaseOptionsMenu
 			'int');
 		addOption(option);
 
+		final refreshRate:Int = FlxG.stage.application.window.displayMode.refreshRate;
 		option.minValue = 60;
 		option.maxValue = 240;
+		option.defaultValue = Std.int(FlxMath.bound(refreshRate, option.minValue, option.maxValue));
 		option.displayFormat = '%v FPS';
 		option.onChange = onChangeFramerate;
 		#end


### PR DESCRIPTION
Revamped version of #8341

This PR makes it so any save created for the first time will have Psych automatically grab the monitor's current refresh rate and set its framerate cap to that, saving the hassle of the user going into options to set it themselves.

If the monitor's refresh rate is outside the FPS cap range (60-240), Psych Engine will cap it.

This will also apply when you reset framerate back to its default in options.