### PR TITLE
Fix fadeIn for Week 7 Gameover

### DIFF
--- a/source/substates/GameOverSubstate.hx
+++ b/source/substates/GameOverSubstate.hx
@@ -82,9 +82,7 @@ class GameOverSubstate extends MusicBeatSubstate
 		PlayState.instance.callOnScripts('onUpdate', [elapsed]);
 
 		if (controls.ACCEPT)
-		{
 			endBullshit();
-		}
 
 		if (controls.BACK)
 		{
@@ -103,7 +101,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			PlayState.instance.callOnScripts('onGameOverConfirm', [false]);
 		}
-		
+
 		if (boyfriend.animation.curAnim != null)
 		{
 			if (boyfriend.animation.curAnim.name == 'firstDeath' && boyfriend.animation.curAnim.finished && startedDeath)
@@ -124,26 +122,23 @@ class GameOverSubstate extends MusicBeatSubstate
 					{
 						playingDeathSound = true;
 						coolStartDeath(0.2);
-						
+
 						var exclude:Array<Int> = [];
 						//if(!ClientPrefs.cursing) exclude = [1, 3, 8, 13, 17, 21];
 
 						FlxG.sound.play(Paths.sound('jeffGameover/jeffGameover-' + FlxG.random.int(1, 25, exclude)), 1, false, null, true, function() {
 							if(!isEnding)
-							{
-								FlxG.sound.music.fadeIn(0.2, 1, 4);
-							}
+								FlxG.sound.music.fadeIn(4, 0.2, 1);
 						});
 					}
 					else coolStartDeath();
 				}
 			}
 		}
-		
+
 		if (FlxG.sound.music.playing)
-		{
 			Conductor.songPosition = FlxG.sound.music.time;
-		}
+
 		PlayState.instance.callOnScripts('onUpdatePost', [elapsed]);
 	}
 


### PR DESCRIPTION
The current fadeIn value for Week 7's Gameover causes the music to fade in abruptly, this fixes that by using the actual values from Week 7's source code

https://github.com/ShadowMario/FNF-PsychEngine/assets/48515908/bda24882-b964-4ba3-8fa6-40849060cd5b

