### PR TITLE
Revert "Load pause music asynchronously"

### DIFF
--- a/source/substates/PauseSubState.hx
+++ b/source/substates/PauseSubState.hx
@@ -12,11 +12,6 @@ import states.StoryMenuState;
 import states.FreeplayState;
 import options.OptionsState;
 
-#if (target.threaded)
-import sys.thread.Thread;
-import sys.thread.Mutex;
-#end
-
 class PauseSubState extends MusicBeatSubstate
 {
 	var grpMenuShit:FlxTypedGroup<Alphabet>;
@@ -63,36 +58,8 @@ class PauseSubState extends MusicBeatSubstate
 		}
 		difficultyChoices.push('BACK');
 
+
 		pauseMusic = new FlxSound();
-
-		#if (target.threaded)
-		var mutex:Mutex = new Mutex();
-
-		Thread.create(function()
-		{
-			mutex.acquire();
-			
-			try
-			{
-				if (songName == null || songName.toLowerCase() != 'none')
-				{
-					if(songName == null)
-					{
-						var path:String = Paths.formatToSongPath(ClientPrefs.data.pauseMusic);
-						if(path.toLowerCase() != 'none')
-							pauseMusic.loadEmbedded(Paths.music(Paths.formatToSongPath(ClientPrefs.data.pauseMusic)), true, true);
-					}
-					else pauseMusic.loadEmbedded(Paths.music(songName), true, true);
-				}
-			} catch(e:Dynamic) {}
-			pauseMusic.volume = 0;
-			pauseMusic.play(false, FlxG.random.int(0, Std.int(pauseMusic.length / 2)));
-
-			FlxG.sound.list.add(pauseMusic);
-
-			mutex.release();
-		});
-		#else
 		try
 		{
 			if (songName == null || songName.toLowerCase() != 'none')
@@ -110,7 +77,6 @@ class PauseSubState extends MusicBeatSubstate
 		pauseMusic.play(false, FlxG.random.int(0, Std.int(pauseMusic.length / 2)));
 
 		FlxG.sound.list.add(pauseMusic);
-		#end
 
 		var bg:FlxSprite = new FlxSprite().makeGraphic(1, 1, FlxColor.BLACK);
 		bg.scale.set(FlxG.width, FlxG.height);
@@ -194,7 +160,7 @@ class PauseSubState extends MusicBeatSubstate
 	override function update(elapsed:Float)
 	{
 		cantUnpause -= elapsed;
-		if (pauseMusic != null && pauseMusic.volume < 0.5)
+		if (pauseMusic.volume < 0.5)
 			pauseMusic.volume += 0.01 * elapsed;
 
 		super.update(elapsed);
@@ -384,8 +350,7 @@ class PauseSubState extends MusicBeatSubstate
 
 	override function destroy()
 	{
-		if (pauseMusic != null)
-			pauseMusic.destroy();
+		pauseMusic.destroy();
 
 		super.destroy();
 	}


### PR DESCRIPTION
This implementation is a bit off. If the player somehow closes the pause menu before the song is loaded, it'll play the song during the game. From my understanding the song will only have to load once and then it'll be pre-cached, so this is kind've a problem that doesn't need fixing imo