### PR TITLE
Fix PsychLua getRandomType functions never being able to return 0

### DIFF
--- a/source/psychlua/ExtraFunctions.hx
+++ b/source/psychlua/ExtraFunctions.hx
@@ -243,6 +243,7 @@ class ExtraFunctions
 			var toExclude:Array<Int> = [];
 			for (i in 0...excludeArray.length)
 			{
+				if (exclude == '') break;
 				toExclude.push(Std.parseInt(excludeArray[i].trim()));
 			}
 			return FlxG.random.int(min, max, toExclude);
@@ -252,6 +253,7 @@ class ExtraFunctions
 			var toExclude:Array<Float> = [];
 			for (i in 0...excludeArray.length)
 			{
+				if (exclude == '') break;
 				toExclude.push(Std.parseFloat(excludeArray[i].trim()));
 			}
 			return FlxG.random.float(min, max, toExclude);


### PR DESCRIPTION
ok so short answer
psych random functions never return 0
so i fixed it

long answer
since the `exclude` variable is usually null (no one ever sets it anyways) the number that gets pushed to the exlcude array is always 0
because it runsa for loop based on the length of the exclude array
which is 0
because it's null

and because the only number that's pushed to the exclude array is 0 the random functions aren't able to ever return 0

![](https://github.com/ShadowMario/FNF-PsychEngine/assets/73214127/6adf1477-4bd3-4123-829b-d74a8e429f01)


