### PR TITLE
Update OptionsState.hx

### DIFF
--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -89,7 +89,7 @@ class OptionsState extends MusicBeatState
 			if(onPlayState)
 			{
 				StageData.loadDirectory(PlayState.SONG);
-				MusicBeatState.switchState(new PlayState());
+				LoadingState.loadAndSwitchState(new PlayState());
 				FlxG.sound.music.volume = 0;
 			}
 			else MusicBeatState.switchState(new MainMenuState());


### PR DESCRIPTION
Because `MusicBeatState.switchState` automatically checks for assets in the `shared` folder, `PlayState` assets won't load if you enter "Adjust Delay and Combo" menu in Options State on the Pause menu screen. This pull request aims to fix that issue.

*In-game screenshot: Uses a modded HUD*
![image](https://github.com/ShadowMario/FNF-PsychEngine/assets/117119380/0808614e-b660-43a8-a541-fe2eb1356f2f)
