### PR TITLE
Alphabet Offset Scale Fix

### DIFF
--- a/source/objects/Alphabet.hx
+++ b/source/objects/Alphabet.hx
@@ -242,7 +242,7 @@ class Alphabet extends FlxSpriteGroup
 
 		for (letter in letters)
 		{
-			letter.rowWidth = rowData[letter.row];
+			letter.rowWidth = rowData[letter.row] / scale.x;
 		}
 
 		if(letters.length > 0) rows++;


### PR DESCRIPTION
This missing maths was causing a weird bug with the letters offsets with edited scale; for example I tested with scaleX and scaleY = 0.6 and with aligment = RIGHT

Before this fix:
![image](https://github.com/ShadowMario/FNF-PsychEngine/assets/87421482/68618560-4a7c-414a-83b2-32c1d9235de3)

After this fix:
![image](https://github.com/ShadowMario/FNF-PsychEngine/assets/87421482/9688b08a-c6ee-4ad6-b616-09d86819d3d7)
