### PR TITLE
Instakill on Miss Improvements

### DIFF
--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -65,6 +65,7 @@ class Note extends FlxSprite
 	public var sustainLength:Float = 0;
 	public var isSustainNote:Bool = false;
 	public var noteType(default, set):String = null;
+	public var isHideableNote:Bool = false;
 
 	public var eventName:String = '';
 	public var eventLength:Int = 0;
@@ -188,6 +189,7 @@ class Note extends FlxSprite
 					lowPriority = true;
 					missHealth = isSustainNote ? 0.25 : 0.1;
 					hitCausesMiss = true;
+					isHideableNote = true;
 					hitsound = 'cancelMenu';
 					hitsoundChartEditor = false;
 				case 'Alt Animation':

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -536,21 +536,24 @@ class PlayState extends MusicBeatState
 		healthBar.visible = !ClientPrefs.data.hideHud;
 		healthBar.alpha = ClientPrefs.data.healthBarAlpha;
 		reloadHealthBarColors();
-		uiGroup.add(healthBar);
+		if (!instakillOnMiss)
+			uiGroup.add(healthBar);
 
 		iconP1 = new HealthIcon(boyfriend.healthIcon, true);
 		iconP1.y = healthBar.y - 75;
 		iconP1.visible = !ClientPrefs.data.hideHud;
 		iconP1.alpha = ClientPrefs.data.healthBarAlpha;
-		uiGroup.add(iconP1);
+		if (!instakillOnMiss)
+			uiGroup.add(iconP1);
 
 		iconP2 = new HealthIcon(dad.healthIcon, false);
 		iconP2.y = healthBar.y - 75;
 		iconP2.visible = !ClientPrefs.data.hideHud;
 		iconP2.alpha = ClientPrefs.data.healthBarAlpha;
-		uiGroup.add(iconP2);
+		if (!instakillOnMiss)
+			uiGroup.add(iconP2);
 
-		scoreTxt = new FlxText(0, healthBar.y + 40, FlxG.width, "", 20);
+		scoreTxt = new FlxText(0, healthBar.y + (!instakillOnMiss ? 40 : 0), FlxG.width, "", 20);
 		scoreTxt.setFormat(Paths.font("vcr.ttf"), 20, FlxColor.WHITE, CENTER, FlxTextBorderStyle.OUTLINE, FlxColor.BLACK);
 		scoreTxt.scrollFactor.set();
 		scoreTxt.borderSize = 1.25;
@@ -1340,6 +1343,8 @@ class PlayState extends MusicBeatState
 				if(!Std.isOfType(songNotes[3], String)) swagNote.noteType = ChartingState.noteTypeList[songNotes[3]]; //Backward compatibility + compatibility with Week 7 charts
 
 				swagNote.scrollFactor.set();
+
+				if (instakillOnMiss && swagNote.isHideableNote) continue;
 
 				unspawnNotes.push(swagNote);
 


### PR DESCRIPTION
Health Bar and Hurting note was shown when Instakill is enabled, so here the small change for Instakill mode:
- Health bar won't show when Instakill is enabled.
- 2 new Bool titled "isHideableNote" and "isNormalNote" (Not implemented yet).
  - isHideableNote can only hides note types, while isNormalNote can only turns any note types into normal notes.