### PR TITLE
make normal difficulty not look for `song-normal` if the difficulty is lowercase

### DIFF
--- a/source/backend/Difficulty.hx
+++ b/source/backend/Difficulty.hx
@@ -14,8 +14,8 @@ class Difficulty
 	{
 		if(num == null) num = PlayState.storyDifficulty;
 
-		var fileSuffix:String = list[num];
-		if(fileSuffix != defaultDifficulty)
+		var fileSuffix:String = list[num].toLowerCase();
+		if(fileSuffix != defaultDifficulty.toLowerCase())
 		{
 			fileSuffix = '-' + fileSuffix;
 		}


### PR DESCRIPTION
i realized this when playing some songs
![](https://github.com/ShadowMario/FNF-PsychEngine/assets/73214127/bc7b32f6-bd5a-4429-be43-d4d202f83df4)
after i realized it tries looking for `song-difficulty` if the difficulty isn't exactly `Normal`
so even if it's `normal` it'll try looking for `song-difficulty` instead of just `song`

and i found it really irritating