### PR TITLE
Fix a small oversight in BaseStage.hx

### DIFF
--- a/source/backend/BaseStage.hx
+++ b/source/backend/BaseStage.hx
@@ -118,8 +118,8 @@ class BaseStage extends FlxBasic
 	// overrides
 	function startCountdown() if(onPlayState) return PlayState.instance.startCountdown(); else return false;
 	function endSong() if(onPlayState)return PlayState.instance.endSong(); else return false;
-	function moveCameraSection() if(onPlayState) moveCameraSection();
-	function moveCamera(isDad:Bool) if(onPlayState) moveCamera(isDad);
+	function moveCameraSection() if(onPlayState) PlayState.instance.moveCameraSection();
+	function moveCamera(isDad:Bool) if(onPlayState) PlayState.instance.moveCamera(isDad);
 	inline private function get_paused() return game.paused;
 	inline private function get_songName() return game.songName;
 	inline private function get_isStoryMode() return PlayState.isStoryMode;


### PR DESCRIPTION
`moveCamera` and `moveCameraSection` actually called themselves, rather than calling the functions in `PlayState`