### PR TITLE
Adds a macro to keep classes(prevents them from beign ignored by DCE)

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -157,6 +157,7 @@
 	<!--Macro fixes-->
 	<haxeflag name="--macro" value="allowPackage('flash')" />
 	<haxeflag name="--macro" value="include('my.pack')" />
+	<haxeflag name="--macro" value="macros.Keep.keepClasses()" />
 
 	<!-- _________________________________ Custom _______________________________ -->
 

--- a/source/macros/Keep.hx
+++ b/source/macros/Keep.hx
@@ -1,0 +1,29 @@
+package macros;
+#if macro
+import haxe.macro.Compiler;
+
+using StringTools;
+
+class Keep
+{
+    // JUST WRITE THE CLASS PACKAGE AS STRING (e.g  "flixel.effects.particles.FlxParticle") IT'S AS SIMPLE AS THAT
+    public static var classesToKeep:Array<String> = [];
+    
+    public static function keepClasses(){
+        var packagesArray = [];
+        for(clas in classesToKeep){
+            var dotsSplit = clas.split('.');
+            var pack = '';
+            for(i in 0...dotsSplit.length-1)
+                pack += dotsSplit[i] + '.';
+            if(pack.endsWith('.'))
+                pack = pack.substr(0, pack.length-1);
+            packagesArray.push(pack);
+            trace(pack);
+        }
+        for(pack in packagesArray)
+            Compiler.include(pack);
+        Compiler.keep(null, classesToKeep, true);
+    }
+}
+#end

--- a/source/macros/Keep.hx
+++ b/source/macros/Keep.hx
@@ -19,7 +19,6 @@ class Keep
             if(pack.endsWith('.'))
                 pack = pack.substr(0, pack.length-1);
             packagesArray.push(pack);
-            trace(pack);
         }
         for(pack in packagesArray)
             Compiler.include(pack);


### PR DESCRIPTION
funny macro that makes you keep classes/enums without having to edit them so they can be used in runtime

i tested it on flixel.addons.plugin.screengrab.FlxScreenGrab & flixel.effects.particles.FlxParticle

FlxParticle didn't display anything when i tried using it in hscript but i didn't get any error saying that FlxParticle is null. so i think i just don't know how to use it...

later i tried it on FlxScreenGrab, and it worked except my game was crashing when i try saving the image (it's an issue from flixel-addons itself)
