### PR TITLE
Fix the "true" thing for "Set Property"

### DIFF
--- a/source/psychlua/LuaUtils.hx
+++ b/source/psychlua/LuaUtils.hx
@@ -41,6 +41,8 @@ class LuaUtils
 
 	public static function setVarInArray(instance:Dynamic, variable:String, value:Dynamic, allowMaps:Bool = false):Any
 	{
+		if (value == "true") value = true;
+		
 		var splitProps:Array<String> = variable.split('[');
 		if(splitProps.length > 1)
 		{


### PR DESCRIPTION
When doing the "Set Property" event using "true" for property's that are bools, it is not read as it doesn't change it from being false, such as **camGame.visible = false;** Once set to false and trying to set it back to true doesn't work.