### PR TITLE
fix createCallback 3rd argument (?)

### DIFF
--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -247,7 +247,7 @@ class HScript extends SScript
 		{
 			if(funk == null) funk = parentLua;
 			
-			if(parentLua != null) funk.addLocalCallback(name, func);
+			if(funk != null) funk.addLocalCallback(name, func);
 			else FunkinLua.luaTrace('createCallback ($name): 3rd argument is null', false, false, FlxColor.RED);
 		});
 		#end


### PR DESCRIPTION
not sure if this was intentional but basically
createCallback only works if the parentLua variable gets assigned?
which means that this function basically only works inside of runHaxeCode or if you manually do new HScript and you can't choose the script that you wanna put the function in