### PR TITLE
Little lag fix for note splashes!

### DIFF
--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -38,7 +38,7 @@ class NoteSplash extends FlxSprite
 		precacheConfig(skin);
 		_configLoaded = skin;
 		scrollFactor.set();
-		//setupNoteSplash(x, y, 0);
+		setupNoteSplash(x, y, 0);
 	}
 
 	override function destroy()


### PR DESCRIPTION
So when you press a "sick!" note for the first time, the game lags for a milisecond and thats no cool.
I realized that shadowMario commented a line that preloads the notesplashes when they create.
idk why shadowMario commented that line 😭

anyways its just a simple thing that was happening from psych 0.7

The issue: https://github.com/ShadowMario/FNF-PsychEngine/issues/14184