### PR TITLE
Add parseJson to Lua

### DIFF
--- a/source/psychlua/ExtraFunctions.hx
+++ b/source/psychlua/ExtraFunctions.hx
@@ -143,6 +143,19 @@ class ExtraFunctions
 		});
 
 		// File management
+		Lua_helper.add_callback(lua, "parseJson", function(location:String):{}
+		{
+			var parsed:{} = {};
+
+			if (FileSystem.exists(Paths.getPath('data/$location', TEXT)))
+			{
+				parsed = tjson.TJSON.parse(File.getContent(Paths.getPath('data/$location', TEXT)));
+			}
+			else
+				parsed = tjson.TJSON.parse(location);
+
+			return parsed;
+		});
 		Lua_helper.add_callback(lua, "checkFileExists", function(filename:String, ?absolute:Bool = false) {
 			#if MODS_ALLOWED
 			if(absolute) return FileSystem.exists(filename);


### PR DESCRIPTION
## Example
Let's say we have a .json file located in mods/data/file.json, with said following contents:
```json
{	
	"parsedBool": true,

	"parsedInt": 10,
     
	"parsedString": "String"
}
```
To retrieve these variables in Lua, we can use:
```lua
local parsed = parseJson("file.json")

debugPrint(parsed.parsedBool) -- true

debugPrint(parsed.parsedInt) -- 10

debugPrint(parsed.parsedString) -- "String"
```
Alternatively, you can pass in a stringified .json instead of a file:
```lua
local parsed = parseJson([[
  {	
      "parsedBool": true,
  
      "parsedInt": 10,
       
      "parsedString": "String"
  }
]])

debugPrint(parsed.parsedBool) -- true

debugPrint(parsed.parsedInt) -- 10

debugPrint(parsed.parsedString) -- "String"
```
And that's about it!