### PR TITLE
UI Accomodation for Mac

### DIFF
--- a/assets/readme.txt
+++ b/assets/readme.txt
@@ -16,3 +16,7 @@ You can safely delete the "assets/base_game/" folder after that if you want to, 
 Q: What's the "translations" folder for?
 A: This is where I've put the Portuguese translation in, you can also set up other languages inside it easily,
 You can turn off languages by deleting the line with "TRANSLATIONS_ALLOWED" inside Project.xml
+
+NOTE:
+
+In "translations" there are two phrases that get replaced, being "MODIFIER1" and "MODIFIER2", replaced by "Control" & "Alt" if you use Mac OS, "Command" & "Option".

--- a/assets/translations/shared/data/pt-BR.lang
+++ b/assets/translations/shared/data/pt-BR.lang
@@ -46,7 +46,7 @@ storyname_week6: "simulador de confronto ft. moawling"
 
 // Freeplay
 personal_best: "MELHOR PONTUAÇÃO: {1} ({2}%)"
-freeplay_tip: "Aperte SPACE para ouvir a Música / Aperte CTRL para abrir o Menu de Modificadores / Aperte RESET para limpar sua pontuação."
+freeplay_tip: "Aperte SPACE para ouvir a Música / Aperte MODIFIER1 para abrir o Menu de Modificadores / Aperte RESET para limpar sua pontuação."
 
 musicplayer_playing: "MÚSICA: {1}"
 musicplayer_paused: "MÚSICA: {1} (PAUSADO)"

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -48,6 +48,9 @@ class Main extends Sprite
 		startFullscreen: false // if the game should start at fullscreen mode
 	};
 
+	// changes how modifier keys are shown in UI.
+	// small heads-up Control is mapped to WINDOWS in Haxeflixel, Option is curiously mapped to ALT still though.
+	public static var modifier_keys:Array<String> = #if !mac ['Control', 'Alt']; #else['Command', 'Option']; #end
 	public static var fpsVar:FPSCounter;
 
 	// You can pretty much ignore everything from here on - your code should go in your states.

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -49,7 +49,7 @@ class Main extends Sprite
 	};
 
 	// changes how modifier keys are shown in UI.
-	// small heads-up Control is mapped to WINDOWS in Haxeflixel, Option is curiously mapped to ALT still though.
+	// small heads-up Command is mapped to WINDOWS in Haxeflixel, Option is curiously mapped to ALT still though.
 	public static var modifier_keys:Array<String> = #if !mac ['Control', 'Alt']; #else['Command', 'Option']; #end
 	public static var fpsVar:FPSCounter;
 

--- a/source/backend/InputFormatter.hx
+++ b/source/backend/InputFormatter.hx
@@ -13,7 +13,7 @@ class InputFormatter {
 			case CONTROL:
 				return "Ctrl";
 			case ALT:
-				return "Alt";
+				return Main.modifier_keys[1];
 			case CAPSLOCK:
 				return "Caps";
 			case PAGEUP:

--- a/source/backend/InputFormatter.hx
+++ b/source/backend/InputFormatter.hx
@@ -88,6 +88,10 @@ class InputFormatter {
 				return "'";
 			case PRINTSCREEN:
 				return "PrtScrn";
+			#if mac
+			case WINDOWS:
+				return 'Command';
+			#end
 			case NONE:
 				return '---';
 			default:

--- a/source/backend/Language.hx
+++ b/source/backend/Language.hx
@@ -63,6 +63,11 @@ class Language
 			for (num => value in values)
 				str = str.replace('{${num+1}}', value);
 
+
+		// Multiplatform keys
+		str = str.replace('MODIFIER1', Main.modifier_keys[0]);
+		str = str.replace('MODIFIER2', Main.modifier_keys[1]);
+		
 		return str;
 	}
 

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -98,6 +98,9 @@ class FunkinLua {
 		set('startedCountdown', false);
 		set('curStage', PlayState.SONG.stage);
 
+		set('primaryModifier', Main.modifier_keys[0]); // Control or Command
+		set('secondaryModifier', Main.modifier_keys[1]); // Alt or Option
+
 		set('isStoryMode', PlayState.isStoryMode);
 		set('difficulty', PlayState.storyDifficulty);
 

--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -307,7 +307,7 @@ class FreeplayState extends MusicBeatState
 			}
 		}
 
-		if(#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end && !player.playingMusic)
+		if(#if !mac FlxG.keys.justPressed.CONTROL #else FlxG.keys.justPressed.WINDOWS #end && !player.playingMusic)
 		{
 			persistentUpdate = false;
 			openSubState(new GameplayChangersSubstate());

--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -162,7 +162,7 @@ class FreeplayState extends MusicBeatState
 		bottomBG.alpha = 0.6;
 		add(bottomBG);
 
-		var leText:String = Language.getPhrase("freeplay_tip", "Press SPACE to listen to the Song / Press CTRL to open the Gameplay Changers Menu / Press RESET to Reset your Score and Accuracy.");
+		var leText:String = Language.getPhrase("freeplay_tip", "Press SPACE to listen to the Song / Press "+Main.modifier_keys[0]+" to open the Gameplay Changers Menu / Press RESET to Reset your Score and Accuracy.");
 		bottomString = leText;
 		var size:Int = 16;
 		bottomText = new FlxText(bottomBG.x, bottomBG.y + 4, FlxG.width, leText, size);
@@ -307,7 +307,7 @@ class FreeplayState extends MusicBeatState
 			}
 		}
 
-		if(FlxG.keys.justPressed.CONTROL && !player.playingMusic)
+		if(#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end && !player.playingMusic)
 		{
 			persistentUpdate = false;
 			openSubState(new GameplayChangersSubstate());

--- a/source/states/StoryMenuState.hx
+++ b/source/states/StoryMenuState.hx
@@ -234,7 +234,7 @@ class StoryMenuState extends MusicBeatState
 			else if (changeDiff)
 				changeDifficulty();
 
-			if(FlxG.keys.justPressed.CONTROL)
+			if(#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end)
 			{
 				persistentUpdate = false;
 				openSubState(new GameplayChangersSubstate());

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -180,7 +180,7 @@ class CharacterEditorState extends MusicBeatState
 		\nOTHER
 		\nF12 - Toggle Silhouettes
 		\nHold Shift - Move Offsets 10x faster and Camera 4x faster
-		\nHold Control - Move camera 4x slower";
+		\nHold "+Main.modifier_keys[0]+" - Move camera 4x slower";
 
 		helpBg = new FlxSprite().makeGraphic(1, 1, FlxColor.BLACK);
 		helpBg.scale.set(FlxG.width, FlxG.height);
@@ -860,7 +860,7 @@ class CharacterEditorState extends MusicBeatState
 			shiftMult = 4;
 			shiftMultBig = 10;
 		}
-		if(FlxG.keys.pressed.CONTROL) ctrlMult = 0.25;
+		if(#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end) ctrlMult = 0.25;
 
 		// CAMERA CONTROLS
 		if (FlxG.keys.pressed.J) FlxG.camera.scroll.x -= elapsed * 500 * shiftMult * ctrlMult;
@@ -869,7 +869,7 @@ class CharacterEditorState extends MusicBeatState
 		if (FlxG.keys.pressed.I) FlxG.camera.scroll.y -= elapsed * 500 * shiftMult * ctrlMult;
 
 		var lastZoom = FlxG.camera.zoom;
-		if(FlxG.keys.justPressed.R && !FlxG.keys.pressed.CONTROL) FlxG.camera.zoom = 1;
+		if(FlxG.keys.justPressed.R && !#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end) FlxG.camera.zoom = 1;
 		else if (FlxG.keys.pressed.E && FlxG.camera.zoom < 3) {
 			FlxG.camera.zoom += elapsed * FlxG.camera.zoom * shiftMult * ctrlMult;
 			if(FlxG.camera.zoom > 3) FlxG.camera.zoom = 3;
@@ -931,7 +931,7 @@ class CharacterEditorState extends MusicBeatState
 			changedOffset = true;
 		}
 
-		if(FlxG.keys.pressed.CONTROL)
+		if(#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end)
 		{
 			if(FlxG.keys.justPressed.C)
 			{

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -168,10 +168,10 @@ class CharacterEditorState extends MusicBeatState
 		\nR - Reset Camera Zoom
 		\n
 		\nCHARACTER
-		\nCtrl + R - Reset Current Offset
-		\nCtrl + C - Copy Current Offset
-		\nCtrl + V - Paste Copied Offset on Current Animation
-		\nCtrl + Z - Undo Last Paste or Reset
+		\n"+Main.modifier_keys[0]+" + R - Reset Current Offset
+		\n"+Main.modifier_keys[0]+" + C - Copy Current Offset
+		\n"+Main.modifier_keys[0]+" + V - Paste Copied Offset on Current Animation
+		\n"+Main.modifier_keys[0]+" + Z - Undo Last Paste or Reset
 		\nW/S - Previous/Next Animation
 		\nSpace - Replay Animation
 		\nArrow Keys/Mouse & Right Click - Move Offset

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -329,10 +329,10 @@ class ChartingState extends MusicBeatState
 		\nUp/Down - Change Conductor's Strum Time with Snapping" +
 		#if FLX_PITCH
 		"\nLeft Bracket / Right Bracket - Change Song Playback Rate (SHIFT to go Faster)
-		\nALT + Left Bracket / Right Bracket - Reset Song Playback Rate" +
+		\n" + Main.modifier_keys[1] + " + Left Bracket / Right Bracket - Reset Song Playback Rate" +
 		#end
 		"\nHold Shift to move 4x faster
-		\nHold Control and click on an arrow to select it
+		\nHold "+Main.modifier_keys[0]+" and click on an arrow to select it
 		\nZ/X - Zoom in/out
 		\n
 		\nEsc - Test your chart inside Chart Editor
@@ -1757,7 +1757,7 @@ class ChartingState extends MusicBeatState
 				{
 					if (FlxG.mouse.overlaps(note))
 					{
-						if (FlxG.keys.pressed.CONTROL)
+						if (#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end) // WINDOWS is the command key in Mac OS
 						{
 							selectNote(note);
 						}
@@ -1879,11 +1879,11 @@ class ChartingState extends MusicBeatState
 				return;
 			}
 
-			if(FlxG.keys.justPressed.Z && FlxG.keys.pressed.CONTROL) {
+			if(FlxG.keys.justPressed.Z && #if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end) {
 				undo();
 			}
 
-			if(FlxG.keys.justPressed.Z && curZoom > 0 && !FlxG.keys.pressed.CONTROL) {
+			if(FlxG.keys.justPressed.Z && curZoom > 0 && #if !mac !FlxG.keys.pressed.CONTROL #else !FlxG.keys.pressed.WINDOWS #end) {
 				--curZoom;
 				updateZoom();
 			}
@@ -1960,7 +1960,7 @@ class ChartingState extends MusicBeatState
 				FlxG.sound.music.pause();
 
 				var holdingShift:Float = 1;
-				if (FlxG.keys.pressed.CONTROL) holdingShift = 0.25;
+				if (#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end) holdingShift = 0.25;
 				else if (FlxG.keys.pressed.SHIFT) holdingShift = 4;
 
 				var daTime:Float = 700 * FlxG.elapsed * holdingShift;

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -3034,7 +3034,7 @@ class ChartingState extends MusicBeatState
 		}
 		changeEventSelected();
 
-		if (FlxG.keys.pressed.CONTROL && noteData > -1)
+		if (#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end && noteData > -1)
 		{
 			_song.notes[curSec].sectionNotes.push([noteStrum, (noteData + 4) % 8, noteSus, curNoteTypes[daType]]);
 		}

--- a/source/states/editors/NoteSplashDebugState.hx
+++ b/source/states/editors/NoteSplashDebugState.hx
@@ -231,7 +231,7 @@ class NoteSplashDebugState extends MusicBeatState
 		}
 
 		// Copy & Paste
-		if(FlxG.keys.pressed.CONTROL)
+		if(#if !mac FlxG.keys.pressed.CONTROL #else FlxG.keys.pressed.WINDOWS #end)
 		{
 			if(FlxG.keys.justPressed.C)
 			{


### PR DESCRIPTION
![image](https://github.com/ShadowMario/FNF-PsychEngine/assets/107233412/5a7c27b8-5e16-4917-aa28-a69ff6669be6)

Changes the text relating to modifier keys to how it would be on a Mac keyboard if the compilation target is Mac OS.

Replaces all usage of Control with Command
Replaces all usage of Alt with Option