### PR TITLE
Add support for command line arguments

### DIFF
--- a/source/debug/Argument.hx
+++ b/source/debug/Argument.hx
@@ -1,0 +1,185 @@
+#if sys
+package debug;
+
+import backend.Difficulty;
+import backend.Mods;
+import backend.Song;
+import backend.WeekData;
+
+import options.OptionsState;
+
+#if ACHIEVEMENTS_ALLOWED import states.AchievementsMenuState; #end
+import states.CreditsState;
+import states.FreeplayState;
+import states.MainMenuState;
+import states.ModsMenuState;
+import states.PlayState;
+import states.StoryMenuState;
+
+import states.editors.CharacterEditorState;
+import states.editors.ChartingState;
+import states.editors.MasterEditorMenu;
+
+using StringTools;
+
+class Argument
+{
+	public static function parse(args:Array<String>):Bool
+	{
+		switch (args[0])
+		{
+			default:
+			{
+				return false;
+			}
+
+			case '-h' | '--help':
+			{
+				var exePath:Array<String> = Sys.programPath().split(#if windows '\\' #else '/' #end);
+				var exeName:String = exePath[exePath.length - 1].replace('.exe', '');
+
+				Sys.println('
+Usage:
+  ${exeName} (menu | story | freeplay | mods ${#if ACHIEVEMENTS_ALLOWED '| awards' #end} | credits | options)
+  ${exeName} play "Song Name" ["Mod Folder"] [-s | --story] [-d=<val> | --diff=<val>]
+  ${exeName} chart "Song Name" ["Mod Folder"] [-d=<val> | --diff=<val>]
+  ${exeName} debug ["Mod Folder"]
+  ${exeName} character <char> ["Mod Folder"]
+  ${exeName} -h | --help
+
+Options:
+  -h       --help        Show this screen.
+  -s       --story       Enables story mode when in play state.
+  -d=<val> --diff=<val>  Sets the difficulty for the song. [default: ${Difficulty.getDefault().toLowerCase().trim()}]
+');
+
+				Sys.exit(0);
+			}
+
+			case 'menu':
+			{
+				LoadingState.loadAndSwitchState(new MainMenuState());
+			}
+
+			case 'story':
+			{
+				LoadingState.loadAndSwitchState(new StoryMenuState());
+			}
+
+			case 'freeplay':
+			{
+				LoadingState.loadAndSwitchState(new FreeplayState());
+			}
+
+			case 'mods':
+			{
+				LoadingState.loadAndSwitchState(new ModsMenuState());
+			}
+
+			#if ACHIEVEMENTS_ALLOWED
+			case 'awards':
+			{
+				LoadingState.loadAndSwitchState(new AchievementsMenuState());
+			}
+			#end
+
+			case 'credits':
+			{
+				LoadingState.loadAndSwitchState(new CreditsState());
+			}
+
+			case 'options':
+			{
+				LoadingState.loadAndSwitchState(new OptionsState());
+			}
+
+			case 'play':
+			{
+				var modFolder:String = null;
+				var diff:String = null;
+				for (i in 2...args.length)
+				{
+					if (args[i] == '-s' || args[i] == '--story')
+						PlayState.isStoryMode = true;
+
+					else if (args[i].startsWith('-d=') || args[i].startsWith('--diff='))
+						diff = (args[i].split('='))[1];
+
+					else if (modFolder != null)
+						modFolder = args[i];
+				}
+
+				setupSong(args[1], modFolder, diff);
+				LoadingState.loadAndSwitchState(new PlayState(), true);
+			}
+
+			case 'chart':
+			{
+				var modFolder:String = null;
+				var diff:String = null;
+				for (i in 2...args.length)
+				{
+					if (args[i].startsWith('-d') || args[i].startsWith('--diff'))
+						diff = (args[i].split('='))[1];
+
+					else if (modFolder != null)
+						modFolder = args[i];
+				}
+
+				setupSong(args[1], args[2], diff);
+				LoadingState.loadAndSwitchState(new ChartingState(), true);
+			}
+
+			case 'debug':
+			{
+				if (args[1] != null) Mods.currentModDirectory = args[1];
+				LoadingState.loadAndSwitchState(new MasterEditorMenu());
+			}
+
+			case 'character':
+			{
+				if (args[2] != null) Mods.currentModDirectory = args[2];
+				LoadingState.loadAndSwitchState(new CharacterEditorState(args[1]));
+			}
+		}
+
+		return true;
+	}
+
+	static function setupSong(songName:String, ?modFolder:String, ?diff:String):Void
+	{
+		WeekData.reloadWeekFiles(PlayState.isStoryMode);
+
+		if (modFolder == null)
+		{
+			var songFound:Bool = false;
+			for (weekData in WeekData.weeksList)
+			{
+				if (songFound)
+					break;
+
+				var week:WeekData = WeekData.weeksLoaded.get(weekData);
+
+				for (weekSong in week.songs)
+				{
+					if (Paths.formatToSongPath(weekSong[0]) == Paths.formatToSongPath(songName))
+					{
+						WeekData.setDirectoryFromWeek(week);
+						Difficulty.loadFromWeek(week);
+						songFound = true;
+						break;
+					}
+				}
+			}
+		}
+		else
+		{
+			Mods.currentModDirectory = modFolder;
+		}
+
+		var defaultDiff:Bool = diff == null || (diff != null && diff.toLowerCase().trim() == Difficulty.getDefault().toLowerCase().trim());
+		var jsonName:String = songName + (!defaultDiff ? '-${diff}' : '');
+		PlayState.SONG = Song.loadFromJson(jsonName, songName);
+	}
+}
+#end

--- a/source/states/TitleState.hx
+++ b/source/states/TitleState.hx
@@ -3,6 +3,10 @@ package states;
 import backend.WeekData;
 import backend.Highscore;
 
+#if sys
+import debug.Argument;
+#end
+
 import flixel.input.keyboard.FlxKey;
 import flixel.addons.transition.FlxTransitionableState;
 import flixel.graphics.frames.FlxAtlasFrames;
@@ -152,11 +156,16 @@ class TitleState extends MusicBeatState
 		}
 
 		FlxG.mouse.visible = false;
-		#if FREEPLAY
-		MusicBeatState.switchState(new FreeplayState());
-		#elseif CHARTING
-		MusicBeatState.switchState(new ChartingState());
-		#else
+
+		#if sys
+		if (!initialized && Argument.parse(Sys.args()))
+		{
+			initialized = true;
+			FlxG.sound.playMusic(Paths.music('freakyMenu'), 0);
+			return;
+		}
+		#end
+
 		if(FlxG.save.data.flashing == null && !FlashingState.leftState) {
 			FlxTransitionableState.skipNextTransIn = true;
 			FlxTransitionableState.skipNextTransOut = true;
@@ -172,7 +181,6 @@ class TitleState extends MusicBeatState
 				});
 			}
 		}
-		#end
 	}
 
 	var logoBl:FlxSprite;


### PR DESCRIPTION
This adds command line arguments to Psych Engine, allowing for much quicker mod development.

Video showcase:

https://github.com/ShadowMario/FNF-PsychEngine/assets/15317421/6033a07b-21f5-4761-b187-bddeaa4c2db2

---

To see what you can use, open the game up with `-h` or `--help`:

![2024-04-06_15-43-22_WindowsTerminal](https://github.com/ShadowMario/FNF-PsychEngine/assets/15317421/505cd299-4b26-433c-880f-0693c8d771f0)

The help message uses [docopt](http://docopt.org/) as reference.

Examples:
 - `PsychEngine freeplay`
 - `PsychEngine play ballistic "Whitty" -s -d=hard`
 - `PsychEngine chart "Satin Panties" -d=hard`
 - `PsychEngine character dside-nat "DDTO D-Sides"`

This can also be used with lime with the following: `lime test Project.xml windows -debug -args <args>`

An example of this would be: `lime test Project.xml windows -debug -args play "Sugarcoat It" -d=hard`

---

Given this was written for source mods using Psych 0.6, I have not had much time testing this to make sure it fully works with Psych 0.7+. Given that, I have set this PR as a draft. If there aren't any issues that crop up, I'll set it as ready for review.

### [Test Build](https://github.com/ActualMandM/FNF-PsychEngine/releases/tag/args) (no base game assets)