### PR TITLE
Flixel's 5.6.0+ NextState implementation (or switchState but good)

### DIFF
--- a/source/backend/BaseStage.hx
+++ b/source/backend/BaseStage.hx
@@ -19,7 +19,7 @@ enum Countdown
 
 class BaseStage extends FlxBasic
 {
-	private var game(default, set):Dynamic = PlayState.instance;
+	private var game(default, set):Dynamic;
 	public var onPlayState:Bool = false;
 
 	// some variables for convenience
@@ -47,17 +47,17 @@ class BaseStage extends FlxBasic
 
 	public function new()
 	{
-		this.game = MusicBeatState.getState();
-		if(this.game == null)
+		if (FlxG.state is MusicBeatState)
 		{
-			FlxG.log.warn('Invalid state for the stage added!');
-			destroy();
-		}
-		else 
-		{
+			this.game = cast (FlxG.state, MusicBeatState);
 			this.game.stages.push(this);
 			super();
 			create();
+		}
+		else 
+		{
+			FlxG.log.warn('Invalid state for the stage added!');
+			destroy();
 		}
 	}
 

--- a/source/options/NoteOffsetState.hx
+++ b/source/options/NoteOffsetState.hx
@@ -405,7 +405,7 @@ class NoteOffsetState extends MusicBeatState
 			if(beatTween != null) beatTween.cancel();
 
 			persistentUpdate = false;
-			MusicBeatState.switchState(new options.OptionsState());
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new options.OptionsState());
 			if(OptionsState.onPlayState)
 			{
 				if(ClientPrefs.data.pauseMusic != 'None')

--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -24,7 +24,7 @@ class OptionsState extends MusicBeatState
 			case 'Gameplay':
 				openSubState(new options.GameplaySettingsSubState());
 			case 'Adjust Delay and Combo':
-				MusicBeatState.switchState(new options.NoteOffsetState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new options.NoteOffsetState());
 		}
 	}
 
@@ -89,10 +89,10 @@ class OptionsState extends MusicBeatState
 			if(onPlayState)
 			{
 				StageData.loadDirectory(PlayState.SONG);
-				LoadingState.loadAndSwitchState(new PlayState());
+				LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState());
 				FlxG.sound.music.volume = 0;
 			}
-			else MusicBeatState.switchState(new MainMenuState());
+			else MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 		}
 		else if (controls.ACCEPT) openSelectedSubstate(options[curSelected]);
 	}

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -456,7 +456,7 @@ class FunkinLua {
 			PlayState.SONG = Song.loadFromJson(poop, name);
 			PlayState.storyDifficulty = difficultyNum;
 			game.persistentUpdate = false;
-			LoadingState.loadAndSwitchState(new PlayState());
+			LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState());
 
 			FlxG.sound.music.pause();
 			FlxG.sound.music.volume = 0;
@@ -823,9 +823,9 @@ class FunkinLua {
 			}
 
 			if(PlayState.isStoryMode)
-				MusicBeatState.switchState(new StoryMenuState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new StoryMenuState());
 			else
-				MusicBeatState.switchState(new FreeplayState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FreeplayState());
 
 			#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
 

--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -206,7 +206,7 @@ class AchievementsMenuState extends MusicBeatState
 
 		if (controls.BACK) {
 			FlxG.sound.play(Paths.sound('cancelMenu'));
-			MusicBeatState.switchState(new MainMenuState());
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 			goingBack = true;
 		}
 		super.update(elapsed);

--- a/source/states/CreditsState.hx
+++ b/source/states/CreditsState.hx
@@ -182,7 +182,7 @@ class CreditsState extends MusicBeatState
 					colorTween.cancel();
 				}
 				FlxG.sound.play(Paths.sound('cancelMenu'));
-				MusicBeatState.switchState(new MainMenuState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 				quitting = true;
 			}
 		}

--- a/source/states/FlashingState.hx
+++ b/source/states/FlashingState.hx
@@ -44,14 +44,14 @@ class FlashingState extends MusicBeatState
 					FlxG.sound.play(Paths.sound('confirmMenu'));
 					FlxFlicker.flicker(warnText, 1, 0.1, false, true, function(flk:FlxFlicker) {
 						new FlxTimer().start(0.5, function (tmr:FlxTimer) {
-							MusicBeatState.switchState(new TitleState());
+							MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new TitleState());
 						});
 					});
 				} else {
 					FlxG.sound.play(Paths.sound('cancelMenu'));
 					FlxTween.tween(warnText, {alpha: 0}, 1, {
 						onComplete: function (twn:FlxTween) {
-							MusicBeatState.switchState(new TitleState());
+							MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new TitleState());
 						}
 					});
 				}

--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -302,7 +302,7 @@ class FreeplayState extends MusicBeatState
 					colorTween.cancel();
 				}
 				FlxG.sound.play(Paths.sound('cancelMenu'));
-				MusicBeatState.switchState(new MainMenuState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 			}
 		}
 
@@ -395,7 +395,7 @@ class FreeplayState extends MusicBeatState
 				super.update(elapsed);
 				return;
 			}
-			LoadingState.loadAndSwitchState(new PlayState());
+			LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState());
 
 			FlxG.sound.music.volume = 0;
 					

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -3,7 +3,6 @@ package states;
 import lime.app.Promise;
 import lime.app.Future;
 
-import flixel.FlxState;
 
 import openfl.utils.Assets;
 import lime.utils.Assets as LimeAssets;
@@ -13,6 +12,12 @@ import lime.utils.AssetManifest;
 import backend.StageData;
 
 import haxe.io.Path;
+
+#if (flixel < version("5.6.0"))
+typedef NextState = flixel.FlxState;
+#else
+import flixel.util.typeLimit.NextState;
+#end
 
 class LoadingState extends MusicBeatState
 {
@@ -24,13 +29,13 @@ class LoadingState extends MusicBeatState
 	
 	// TO DO: Make this easier
 	
-	var target:FlxState;
+	var target:NextState;
 	var stopMusic = false;
 	var directory:String;
 	var callbacks:MultiCallback;
 	var targetShit:Float = 0;
 
-	function new(target:FlxState, stopMusic:Bool, directory:String)
+	function new(target:NextState, stopMusic:Bool, directory:String)
 	{
 		super();
 		this.target = target;
@@ -142,12 +147,12 @@ class LoadingState extends MusicBeatState
 		return Paths.voices(PlayState.SONG.song);
 	}
 	
-	inline static public function loadAndSwitchState(target:FlxState, stopMusic = false)
+	inline static public function loadAndSwitchState(target:NextState, stopMusic = false)
 	{
 		MusicBeatState.switchState(getNextState(target, stopMusic));
 	}
 	
-	static function getNextState(target:FlxState, stopMusic = false):FlxState
+	static function getNextState(target:NextState, stopMusic = false):NextState
 	{
 		var directory:String = 'shared';
 		var weekDir:String = StageData.forceNextDirectory;

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -136,7 +136,7 @@ class MainMenuState extends MusicBeatState
 			{
 				selectedSomethin = true;
 				FlxG.sound.play(Paths.sound('cancelMenu'));
-				MusicBeatState.switchState(new TitleState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new TitleState());
 			}
 
 			if (controls.ACCEPT)
@@ -158,24 +158,24 @@ class MainMenuState extends MusicBeatState
 						switch (optionShit[curSelected])
 						{
 							case 'story_mode':
-								MusicBeatState.switchState(new StoryMenuState());
+								MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new StoryMenuState());
 							case 'freeplay':
-								MusicBeatState.switchState(new FreeplayState());
+								MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FreeplayState());
 
 							#if MODS_ALLOWED
 							case 'mods':
-								MusicBeatState.switchState(new ModsMenuState());
+								MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new ModsMenuState());
 							#end
 
 							#if ACHIEVEMENTS_ALLOWED
 							case 'awards':
-								MusicBeatState.switchState(new AchievementsMenuState());
+								MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new AchievementsMenuState());
 							#end
 
 							case 'credits':
-								MusicBeatState.switchState(new CreditsState());
+								MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new CreditsState());
 							case 'options':
-								MusicBeatState.switchState(new OptionsState());
+								MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new OptionsState());
 								OptionsState.onPlayState = false;
 								if (PlayState.SONG != null)
 								{
@@ -204,7 +204,7 @@ class MainMenuState extends MusicBeatState
 			if (controls.justPressed('debug_1'))
 			{
 				selectedSomethin = true;
-				MusicBeatState.switchState(new MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MasterEditorMenu());
 			}
 			#end
 		}

--- a/source/states/ModsMenuState.hx
+++ b/source/states/ModsMenuState.hx
@@ -317,7 +317,7 @@ class ModsMenuState extends MusicBeatState
 			FlxG.sound.play(Paths.sound('cancelMenu'));
 			if(waitingToRestart)
 			{
-				//MusicBeatState.switchState(new TitleState());
+				//MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new TitleState());
 				TitleState.initialized = false;
 				TitleState.closedState = false;
 				FlxG.sound.music.fadeOut(0.3);
@@ -328,7 +328,7 @@ class ModsMenuState extends MusicBeatState
 				}
 				FlxG.camera.fade(FlxColor.BLACK, 0.5, false, FlxG.resetGame, false);
 			}
-			else MusicBeatState.switchState(new MainMenuState());
+			else MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 
 			persistentUpdate = false;
 			FlxG.autoPause = ClientPrefs.data.autoPause;
@@ -777,7 +777,7 @@ class ModsMenuState extends MusicBeatState
 		FlxTransitionableState.skipNextTransIn = true;
 		FlxTransitionableState.skipNextTransOut = true;
 		var curMod:ModItem = modsGroup.members[curSelectedMod];
-		MusicBeatState.switchState(new ModsMenuState(curMod != null ? curMod.folder : null));
+		MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new ModsMenuState(curMod != null ? curMod.folder : null));
 	}
 	
 	function saveTxt()

--- a/source/states/OutdatedState.hx
+++ b/source/states/OutdatedState.hx
@@ -41,7 +41,7 @@ class OutdatedState extends MusicBeatState
 				FlxG.sound.play(Paths.sound('cancelMenu'));
 				FlxTween.tween(warnText, {alpha: 0}, 1, {
 					onComplete: function (twn:FlxTween) {
-						MusicBeatState.switchState(new MainMenuState());
+						MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 					}
 				});
 			}

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1890,7 +1890,7 @@ class PlayState extends MusicBeatState
 		DiscordClient.resetClientID();
 		#end
 
-		MusicBeatState.switchState(new ChartingState());
+		MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new ChartingState());
 	}
 
 	function openCharacterEditor()
@@ -1901,7 +1901,7 @@ class PlayState extends MusicBeatState
 		if(FlxG.sound.music != null)
 			FlxG.sound.music.stop();
 		#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
-		MusicBeatState.switchState(new CharacterEditorState(SONG.player2));
+		MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new CharacterEditorState(SONG.player2));
 	}
 
 	public var isDead:Bool = false; //Don't mess with this on Lua!!!
@@ -1931,7 +1931,7 @@ class PlayState extends MusicBeatState
 
 				openSubState(new GameOverSubstate());
 
-				// MusicBeatState.switchState(new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
+				// MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
 				#if DISCORD_ALLOWED
 				// Game Over doesn't get his its variable because it's only used here
@@ -2350,7 +2350,7 @@ class PlayState extends MusicBeatState
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 					#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
 
-					MusicBeatState.switchState(new StoryMenuState());
+					MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new StoryMenuState());
 
 					// if ()
 					if(!ClientPrefs.getGameplaySetting('practice') && !ClientPrefs.getGameplaySetting('botplay')) {
@@ -2376,7 +2376,7 @@ class PlayState extends MusicBeatState
 					PlayState.SONG = Song.loadFromJson(PlayState.storyPlaylist[0] + difficulty, PlayState.storyPlaylist[0]);
 					FlxG.sound.music.stop();
 
-					LoadingState.loadAndSwitchState(new PlayState());
+					LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState());
 				}
 			}
 			else
@@ -2385,7 +2385,7 @@ class PlayState extends MusicBeatState
 				Mods.loadTopMod();
 				#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
 
-				MusicBeatState.switchState(new FreeplayState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FreeplayState());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				changedDifficulty = false;
 			}

--- a/source/states/StoryMenuState.hx
+++ b/source/states/StoryMenuState.hx
@@ -255,7 +255,7 @@ class StoryMenuState extends MusicBeatState
 		{
 			FlxG.sound.play(Paths.sound('cancelMenu'));
 			movedBack = true;
-			MusicBeatState.switchState(new MainMenuState());
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 		}
 
 		super.update(elapsed);
@@ -321,7 +321,7 @@ class StoryMenuState extends MusicBeatState
 
 			new FlxTimer().start(1, function(tmr:FlxTimer)
 			{
-				LoadingState.loadAndSwitchState(new PlayState(), true);
+				LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState(), true);
 				FreeplayState.destroyFreeplayVocals();
 			});
 			

--- a/source/states/TitleState.hx
+++ b/source/states/TitleState.hx
@@ -152,14 +152,14 @@ class TitleState extends MusicBeatState
 
 		FlxG.mouse.visible = false;
 		#if FREEPLAY
-		MusicBeatState.switchState(new FreeplayState());
+		MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FreeplayState());
 		#elseif CHARTING
-		MusicBeatState.switchState(new ChartingState());
+		MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new ChartingState());
 		#else
 		if(FlxG.save.data.flashing == null && !FlashingState.leftState) {
 			FlxTransitionableState.skipNextTransIn = true;
 			FlxTransitionableState.skipNextTransOut = true;
-			MusicBeatState.switchState(new FlashingState());
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FlashingState());
 		} else {
 			if (initialized)
 				startIntro();
@@ -414,9 +414,9 @@ class TitleState extends MusicBeatState
 				new FlxTimer().start(1, function(tmr:FlxTimer)
 				{
 					if (mustUpdate) {
-						MusicBeatState.switchState(new OutdatedState());
+						MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new OutdatedState());
 					} else {
-						MusicBeatState.switchState(new MainMenuState());
+						MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 					}
 					closedState = true;
 				});
@@ -454,7 +454,7 @@ class TitleState extends MusicBeatState
 								function(twn:FlxTween) {
 									FlxTransitionableState.skipNextTransIn = true;
 									FlxTransitionableState.skipNextTransOut = true;
-									MusicBeatState.switchState(new TitleState());
+									MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new TitleState());
 								}
 							});
 							FlxG.sound.music.fadeOut();

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -1034,10 +1034,10 @@ class CharacterEditorState extends MusicBeatState
 			FlxG.mouse.visible = false;
 			if(!_goToPlayState)
 			{
-				MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new states.editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			}
-			else MusicBeatState.switchState(new PlayState());
+			else MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState());
 			return;
 		}
 	}

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -1854,7 +1854,7 @@ class ChartingState extends MusicBeatState
 
 				//if(_song.stage == null) _song.stage = stageDropDown.selectedLabel;
 				StageData.loadDirectory(_song);
-				LoadingState.loadAndSwitchState(new PlayState());
+				LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new PlayState());
 			}
 
 			if(curSelectedNote != null && curSelectedNote[1] > -1) {
@@ -1873,7 +1873,7 @@ class ChartingState extends MusicBeatState
 				// Protect against lost data when quickly leaving the chart editor.
 				autosaveSong();
 				PlayState.chartingMode = false;
-				MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new states.editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				FlxG.mouse.visible = false;
 				return;

--- a/source/states/editors/DialogueCharacterEditorState.hx
+++ b/source/states/editors/DialogueCharacterEditorState.hx
@@ -647,7 +647,7 @@ class DialogueCharacterEditorState extends MusicBeatState
 			}
 
 			if(FlxG.keys.justPressed.ESCAPE) {
-				MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new states.editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'), 1);
 				transitioning = true;
 			}

--- a/source/states/editors/DialogueEditorState.hx
+++ b/source/states/editors/DialogueEditorState.hx
@@ -333,7 +333,7 @@ class DialogueEditorState extends MusicBeatState
 				reloadText(false);
 			}
 			if(FlxG.keys.justPressed.ESCAPE) {
-				MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new states.editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'), 1);
 				transitioning = true;
 			}

--- a/source/states/editors/MasterEditorMenu.hx
+++ b/source/states/editors/MasterEditorMenu.hx
@@ -98,26 +98,26 @@ class MasterEditorMenu extends MusicBeatState
 
 		if (controls.BACK)
 		{
-			MusicBeatState.switchState(new MainMenuState());
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MainMenuState());
 		}
 
 		if (controls.ACCEPT)
 		{
 			switch(options[curSelected]) {
 				case 'Chart Editor'://felt it would be cool maybe
-					LoadingState.loadAndSwitchState(new ChartingState(), false);
+					LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new ChartingState(), false);
 				case 'Character Editor':
-					LoadingState.loadAndSwitchState(new CharacterEditorState(Character.DEFAULT_CHARACTER, false));
+					LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new CharacterEditorState(Character.DEFAULT_CHARACTER, false));
 				case 'Week Editor':
-					MusicBeatState.switchState(new WeekEditorState());
+					MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new WeekEditorState());
 				case 'Menu Character Editor':
-					MusicBeatState.switchState(new MenuCharacterEditorState());
+					MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MenuCharacterEditorState());
 				case 'Dialogue Editor':
-					LoadingState.loadAndSwitchState(new DialogueEditorState(), false);
+					LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new DialogueEditorState(), false);
 				case 'Dialogue Portrait Editor':
-					LoadingState.loadAndSwitchState(new DialogueCharacterEditorState(), false);
+					LoadingState.loadAndSwitchState(#if (flixel >= version("5.6.0")) () -> #end new DialogueCharacterEditorState(), false);
 				case 'Note Splash Debug':
-					MusicBeatState.switchState(new NoteSplashDebugState());
+					MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new NoteSplashDebugState());
 			}
 			FlxG.sound.music.volume = 0;
 			FreeplayState.destroyFreeplayVocals();

--- a/source/states/editors/MenuCharacterEditorState.hx
+++ b/source/states/editors/MenuCharacterEditorState.hx
@@ -264,7 +264,7 @@ class MenuCharacterEditorState extends MusicBeatState
 		if(!blockInput) {
 			ClientPrefs.toggleVolumeKeys(true);
 			if(FlxG.keys.justPressed.ESCAPE) {
-				MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new states.editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			}
 

--- a/source/states/editors/NoteSplashDebugState.hx
+++ b/source/states/editors/NoteSplashDebugState.hx
@@ -192,7 +192,7 @@ class NoteSplashDebugState extends MusicBeatState
 		var notTyping:Bool = !nameInputText.hasFocus && !imageInputText.hasFocus;
 		if(controls.BACK && notTyping)
 		{
-			MusicBeatState.switchState(new MasterEditorMenu());
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MasterEditorMenu());
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			FlxG.mouse.visible = false;
 		}

--- a/source/states/editors/WeekEditorState.hx
+++ b/source/states/editors/WeekEditorState.hx
@@ -134,7 +134,7 @@ class WeekEditorState extends MusicBeatState
 		add(loadWeekButton);
 		
 		var freeplayButton:FlxButton = new FlxButton(0, 650, "Freeplay", function() {
-			MusicBeatState.switchState(new WeekEditorFreeplayState(weekFile));
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new WeekEditorFreeplayState(weekFile));
 			
 		});
 		freeplayButton.screenCenter(X);
@@ -432,7 +432,7 @@ class WeekEditorState extends MusicBeatState
 		if(!blockInput) {
 			ClientPrefs.toggleVolumeKeys(true);
 			if(FlxG.keys.justPressed.ESCAPE) {
-				MusicBeatState.switchState(new MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			}
 		}
@@ -643,7 +643,7 @@ class WeekEditorFreeplayState extends MusicBeatState
 		add(loadWeekButton);
 		
 		var storyModeButton:FlxButton = new FlxButton(0, 685, "Story Mode", function() {
-			MusicBeatState.switchState(new WeekEditorState(weekFile));
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new WeekEditorState(weekFile));
 			
 		});
 		storyModeButton.screenCenter(X);
@@ -778,7 +778,7 @@ class WeekEditorFreeplayState extends MusicBeatState
 			super.update(elapsed);
 			FlxTransitionableState.skipNextTransIn = true;
 			FlxTransitionableState.skipNextTransOut = true;
-			MusicBeatState.switchState(new WeekEditorFreeplayState(WeekEditorState.loadedWeek));
+			MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new WeekEditorFreeplayState(WeekEditorState.loadedWeek));
 			WeekEditorState.loadedWeek = null;
 			return;
 		}
@@ -791,7 +791,7 @@ class WeekEditorFreeplayState extends MusicBeatState
 		} else {
 			ClientPrefs.toggleVolumeKeys(true);
 			if(FlxG.keys.justPressed.ESCAPE) {
-				MusicBeatState.switchState(new MasterEditorMenu());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			}
 

--- a/source/substates/GameOverSubstate.hx
+++ b/source/substates/GameOverSubstate.hx
@@ -93,9 +93,9 @@ class GameOverSubstate extends MusicBeatSubstate
 
 			Mods.loadTopMod();
 			if (PlayState.isStoryMode)
-				MusicBeatState.switchState(new StoryMenuState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new StoryMenuState());
 			else
-				MusicBeatState.switchState(new FreeplayState());
+				MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FreeplayState());
 
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			PlayState.instance.callOnScripts('onGameOverConfirm', [false]);

--- a/source/substates/PauseSubState.hx
+++ b/source/substates/PauseSubState.hx
@@ -297,7 +297,7 @@ class PauseSubState extends MusicBeatSubstate
 				case 'Options':
 					PlayState.instance.paused = true; // For lua
 					PlayState.instance.vocals.volume = 0;
-					MusicBeatState.switchState(new OptionsState());
+					MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new OptionsState());
 					if(ClientPrefs.data.pauseMusic != 'None')
 					{
 						FlxG.sound.playMusic(Paths.music(Paths.formatToSongPath(ClientPrefs.data.pauseMusic)), pauseMusic.volume);
@@ -312,9 +312,9 @@ class PauseSubState extends MusicBeatSubstate
 
 					Mods.loadTopMod();
 					if(PlayState.isStoryMode)
-						MusicBeatState.switchState(new StoryMenuState());
+						MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new StoryMenuState());
 					else 
-						MusicBeatState.switchState(new FreeplayState());
+						MusicBeatState.switchState(#if (flixel >= version("5.6.0")) () -> #end new FreeplayState());
 
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 					PlayState.changedDifficulty = false;


### PR DESCRIPTION
now MusicBeatState.switchState uses NextState on Flixel 5.6.0 and higher. maybe a breaking change but idk, NexState can be an FlxState instance so everything should be fine.

also MusicBeatState.getState was removed because it isn't really usefull tbh