### PR TITLE
Fix `instanceArg` second argument

### DIFF
--- a/source/psychlua/ReflectionFunctions.hx
+++ b/source/psychlua/ReflectionFunctions.hx
@@ -189,6 +189,7 @@ class ReflectionFunctions
 
 	static function parseInstances(args:Array<Dynamic>)
 	{
+		if (args == null) return [];
 		for (i in 0...args.length)
 		{
 			var myArg:String = cast args[i];
@@ -201,8 +202,8 @@ class ReflectionFunctions
 					//trace('Op1: $myArg');
 					var lastIndex:Int = myArg.lastIndexOf('::');
 
-					var split:Array<String> = myArg.split('.');
-					args[i] = (lastIndex > -1) ? Type.resolveClass(myArg.substring(0, lastIndex)) : PlayState.instance;
+					var split:Array<String> = (lastIndex > -1) ? myArg.substring(0, lastIndex).split('.') : myArg.split('.');
+					args[i] = (lastIndex > -1) ? Type.resolveClass(myArg.substring(lastIndex+2)) : PlayState.instance;
 					for (j in 0...split.length)
 					{
 						//trace('Op2: ${Type.getClass(args[i])}, ${split[j]}');


### PR DESCRIPTION
Fixes the `parseInstances` class name stuff aka `instanceArg` second argument
Also made it so that if args is null, it'll return an empty array to fix some null object reference shit