### PR TITLE
Better soft coding on icons

### DIFF
--- a/source/objects/HealthIcon.hx
+++ b/source/objects/HealthIcon.hx
@@ -34,6 +34,17 @@ class HealthIcon extends FlxSprite
 	}
 
 	private var iconSize:Int = 0;
+	/**
+	 * An index which decides which frame of the icon to use.
+	 */
+	@:isVar public var iconIndex(get, set):Int;
+	public function get_iconIndex() {
+		return iconIndex = animation?.curAnim.curFrame ?? 0;
+	}
+	public function set_iconIndex(i:Int):Int {
+		return iconIndex = animation.curAnim.curFrame = (i % iconSize);
+	}
+
 	private var iconOffsets:Array<Float> = [0, 0];
 	public function changeIcon(char:String, ?allowGPU:Bool = true) {
 		if(this.char != char) {

--- a/source/objects/HealthIcon.hx
+++ b/source/objects/HealthIcon.hx
@@ -1,3 +1,12 @@
+/*
+	The reason for all my changes here is so that icons can be more configurable out of the box, without having to change a thing from base source.
+	Yes, users can already make winning icons, but this supports a built in override, which I think is neat.
+
+	This also just seems like a good practice for icons anyway. As it provides a way to create really wacky icons by abusing the height value.
+
+	-- saturn-volv
+*/
+
 package objects;
 
 class HealthIcon extends FlxSprite
@@ -32,12 +41,15 @@ class HealthIcon extends FlxSprite
 			if(!Paths.fileExists('images/' + name + '.png', IMAGE)) name = 'icons/icon-face'; //Prevents crash from missing icon
 			
 			var graphic = Paths.image(name, allowGPU);
-			loadGraphic(graphic, true, Math.floor(graphic.width / 2), Math.floor(graphic.height));
-			iconOffsets[0] = (width - 150) / 2;
-			iconOffsets[1] = (height - 150) / 2;
+			var iconSize:Int = Math.floor(graphic.width / graphic.height); // Creates a stepper for how many icons based from the height.
+			loadGraphic(graphic, true, Math.floor(graphic.width / iconSize), Math.floor(graphic.height));
+			iconOffsets[0] = (width - 150) / iconSize;
+			iconOffsets[1] = (height - 150) / iconSize;
 			updateHitbox();
 
-			animation.add(char, [0, 1], 0, false, isPlayer);
+			animation.add(char, 
+				      [for(i in 0...iconSize-1) i], // Creates an array from 0 of iconSize in length;
+				      0, false, isPlayer);
 			animation.play(char);
 			this.char = char;
 

--- a/source/objects/HealthIcon.hx
+++ b/source/objects/HealthIcon.hx
@@ -33,6 +33,7 @@ class HealthIcon extends FlxSprite
 			setPosition(sprTracker.x + sprTracker.width + 12, sprTracker.y - 30);
 	}
 
+	private var iconSize:Int = 0;
 	private var iconOffsets:Array<Float> = [0, 0];
 	public function changeIcon(char:String, ?allowGPU:Bool = true) {
 		if(this.char != char) {
@@ -41,14 +42,14 @@ class HealthIcon extends FlxSprite
 			if(!Paths.fileExists('images/' + name + '.png', IMAGE)) name = 'icons/icon-face'; //Prevents crash from missing icon
 			
 			var graphic = Paths.image(name, allowGPU);
-			var iconSize:Int = Math.floor(graphic.width / graphic.height); // Creates a stepper for how many icons based from the height.
+			iconSize = Math.floor(graphic.width / graphic.height);
 			loadGraphic(graphic, true, Math.floor(graphic.width / iconSize), Math.floor(graphic.height));
 			iconOffsets[0] = (width - 150) / iconSize;
 			iconOffsets[1] = (height - 150) / iconSize;
 			updateHitbox();
 
 			animation.add(char, 
-				      [for(i in 0...iconSize-1) i], // Creates an array from 0 of iconSize in length;
+				      [for(i in 0...iconSize) i], // Creates an array from 0 of iconSize in length;
 				      0, false, isPlayer);
 			animation.play(char);
 			this.char = char;

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1843,8 +1843,8 @@ class PlayState extends MusicBeatState
 		var newPercent:Null<Float> = FlxMath.remapToRange(FlxMath.bound(healthBar.valueFunction(), healthBar.bounds.min, healthBar.bounds.max), healthBar.bounds.min, healthBar.bounds.max, 0, 100);
 		healthBar.percent = (newPercent != null ? newPercent : 0);
 
-		iconP1.animation.curAnim.curFrame = (healthBar.percent < 20) ? 1 : 0; //If health is under 20%, change player icon to frame 1 (losing icon), otherwise, frame 0 (normal)
-		iconP2.animation.curAnim.curFrame = (healthBar.percent > 80) ? 1 : 0; //If health is over 80%, change opponent icon to frame 1 (losing icon), otherwise, frame 0 (normal)
+		iconP1.iconIndex = (healthBar.percent < 20) ? 1 : 0; //If health is under 20%, change player icon to frame 1 (losing icon), otherwise, frame 0 (normal)
+		iconP2.iconIndex = (healthBar.percent > 80) ? 1 : 0; //If health is over 80%, change opponent icon to frame 1 (losing icon), otherwise, frame 0 (normal)
 		return health;
 	}
 


### PR DESCRIPTION
## How it works
Doesn't really change a whole lot outta the box without making new icons, such as winning icons. Just allows for progressively stepped ones I guess.
So now instead of having a fixed value of two (which wasn't already a static final variable), the division of icons is now handled based on the ratio of the graphic. (2:1 is the standard ratio).
If you wanna add more animation frames to your icon, just increase the width by however many sections as you like, as long as it's divisible by the height.

Now you can just:
```haxe
iconP2.animation.curAnim.curFrame = 3;
``` 
If your sprite width is 3 times your height