### PR TITLE
Disable rounded corners on Windows 11

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -36,6 +36,15 @@ import haxe.io.Path;
 ')
 #end
 
+#if windows
+@:cppFileCode('
+	#include <windows.h>
+	#include <dwmapi.h>
+
+	#pragma comment(lib, "Dwmapi")
+')
+#end
+
 class Main extends Sprite
 {
 	var game = {
@@ -91,6 +100,13 @@ class Main extends Sprite
 		setupGame();
 	}
 
+	#if windows
+	@:functionCode('
+		HWND hwnd = GetActiveWindow();
+		const DWM_WINDOW_CORNER_PREFERENCE corner_preference = DWMWCP_DONOTROUND;
+		DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &corner_preference, sizeof(corner_preference));
+	')
+	#end
 	private function setupGame():Void
 	{
 		var stageWidth:Int = Lib.current.stage.stageWidth;


### PR DESCRIPTION
Self explanatory title. However, for compiling: this increases the Windows SDK requirement to `Windows 11 SDK (10.0.22000.0)`.

![Screenshot_2024-05-01_210015](https://github.com/ShadowMario/FNF-PsychEngine/assets/15317421/2f1ee003-854c-435e-9cf7-94daf9924b11)