### PR TITLE
Fix DialogueBox's music causing huge song skip (lmao???)

### DIFF
--- a/source/cutscenes/DialogueBox.hx
+++ b/source/cutscenes/DialogueBox.hx
@@ -166,7 +166,7 @@ class DialogueBox extends FlxSpriteGroup
 						FlxG.sound.play(Paths.sound('clickText'), 0.8);	
 
 						if (songName == 'senpai' || songName == 'thorns')
-							FlxG.sound.music.fadeOut(1.5, 0);
+							FlxG.sound.music.fadeOut(1.5, 0, (_) -> FlxG.sound.music.stop());
 
 						new FlxTimer().start(0.2, function(tmr:FlxTimer)
 						{

--- a/source/cutscenes/DialogueBoxPsych.hx
+++ b/source/cutscenes/DialogueBoxPsych.hx
@@ -189,7 +189,7 @@ class DialogueBoxPsych extends FlxSpriteGroup
 						daText.destroy();
 					}
 					updateBoxOffsets(box);
-					FlxG.sound.music.fadeOut(1, 0);
+					FlxG.sound.music.fadeOut(1, 0, (_) -> FlxG.sound.music.stop());
 				} else {
 					startNextDialog();
 				}


### PR DESCRIPTION
This also includes DialogueBoxPsych, since they share the same problem - not stopping music from playing after it fades out.

### EDIT: forgot to actually explain what the problem is like.

So basically because both dialogue boxes use **FlxG.sound.music** as background track instance that makes that on one frame right after countdown ends game tries to sync **Conductor.songPosition** with current music time (aka dialogue music) and may skips pretty lengthy part of the chart and then sync back to the real music on the next frame. This appeared after the **resync-vocals-rework** branch got merged into **experimental** and may lead to either instantly dying or this part that was skipped being absent after game actually syncs song position with music time.