### PR TITLE
[BUGFIX] Hscript early return fix

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3321,7 +3321,11 @@ class PlayState extends MusicBeatState
 				else
 				{
 					myValue = callValue.returnValue;
-					if((myValue == LuaUtils.Function_StopHScript || myValue == LuaUtils.Function_StopAll) && !excludeValues.contains(myValue) && !ignoreStops)
+
+					// compiler fuckup fix
+					final stopHscript = myValue == LuaUtils.Function_StopHScript;
+					final stopAll = myValue == LuaUtils.Function_StopAll;
+					if((stopHscript || stopAll) && !excludeValues.contains(myValue) && !ignoreStops)
 					{
 						returnVal = myValue;
 						break;


### PR DESCRIPTION
Fixes a bug with Hscript script calls breaking if function return is not Function_Continue.
Honestly I don't fucking know how exactly does this fixes the issue, it just does? Probably an issue with how Dynamic values work in haxe and how they are compiled.