### PR TITLE
Time Fix

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1684,19 +1684,25 @@ class PlayState extends MusicBeatState
 				Conductor.songPosition = -Conductor.crochet * 5;
 		}
 		else if (!paused && updateTime)
-		{
-			var curTime:Float = Math.max(0, Conductor.songPosition - ClientPrefs.data.noteOffset);
-			songPercent = (curTime / songLength);
-
-			var songCalc:Float = (songLength - curTime);
-			if(ClientPrefs.data.timeBarType == 'Time Elapsed') songCalc = curTime;
-
-			var secondsTotal:Int = Math.floor(songCalc / 1000);
-			if(secondsTotal < 0) secondsTotal = 0;
-
-			if(ClientPrefs.data.timeBarType != 'Song Name')
-				timeTxt.text = FlxStringUtil.formatTime(secondsTotal, false);
-		}
+			{
+				var curTime:Float = Math.max(0, Conductor.songPosition - ClientPrefs.data.noteOffset);
+				songPercent = (curTime / songLength);
+	
+				var songCalc:Float = (songLength - curTime) / playbackRate; // time fix
+	
+				if (ClientPrefs.data.timeBarType == 'Time Elapsed') songCalc = curTime; // amount of time passed is ok
+	
+				var secondsTotal:Int = Math.floor(songCalc / 1000);
+				if(secondsTotal < 0) secondsTotal = 0;
+	
+				if(ClientPrefs.data.timeBarType != 'Song Name')
+					timeTxt.text = FlxStringUtil.formatTime(secondsTotal, false);
+				else { // this is what was fucked up, hopefully this fixes it.
+					var secondsTotal:Int = Math.floor(songCalc/1000);
+					if(secondsTotal < 0) secondsTotal = 0;
+					timeTxt.text = FlxStringUtil.formatTime(secondsTotal,false);
+				}
+			}
 
 		if (camZooming)
 		{


### PR DESCRIPTION
Suprised nobody's tried this yet (Least, as far as I can tell) [experimental branch]

The way the timer currently works, the time will be based off the regular speed of the song, which is fine at 1x speed, but when you throw playbackRate into the mix, suddenly a second on the timer lasts either way longer (if playbackRate is decreased) or way shorter (if playbackRate is increased). This (honestly very simple) PR should fix the timeTxt so that it's accurate to how long the song will take, no matter the playbackRate, and a second will always be a second.

Before (0.7.3 for comparison, but experimental does the same thing):
https://github.com/ShadowMario/FNF-PsychEngine/assets/99047355/3bbb207d-f931-4f3e-9e83-fef5e0de1820

After:
https://github.com/ShadowMario/FNF-PsychEngine/assets/99047355/add12d0d-8dad-4ba0-b36d-60c9db00d207

Dont ask why why my stage is missing but the point is the timeTxt is fixed.

[First pull request ever so sorry if this is wrong]