### PR TITLE
Update AttachedSprite.hx to support the library parameter on non-animated sprites

### DIFF
--- a/source/objects/AttachedSprite.hx
+++ b/source/objects/AttachedSprite.hx
@@ -20,7 +20,7 @@ class AttachedSprite extends FlxSprite
 			animation.addByPrefix('idle', anim, 24, loop);
 			animation.play('idle');
 		} else if(file != null) {
-			loadGraphic(Paths.image(file));
+			loadGraphic(Paths.image(file, library));
 		}
 		antialiasing = ClientPrefs.data.antialiasing;
 		scrollFactor.set();


### PR DESCRIPTION
The library parameter in the constructor does not apply to non animated sprites for some reason. my very very, simple commit makes it call `Paths.image` with the library parameter.