### PR TITLE
Note Direction Math Optimization

### DIFF
--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -470,7 +470,6 @@ class Note extends FlxSprite
 		distance = (0.45 * (Conductor.songPosition - strumTime) * songSpeed * multSpeed);
 		if (!myStrum.downScroll) distance *= -1;
 
-		var angleDir = strumDirection * Math.PI / 180;
 		if (copyAngle)
 			angle = strumDirection - 90 + strumAngle + offsetAngle;
 
@@ -478,11 +477,11 @@ class Note extends FlxSprite
 			alpha = strumAlpha * multAlpha;
 
 		if(copyX)
-			x = strumX + offsetX + Math.cos(angleDir) * distance;
+			x = strumX + offsetX + myStrum._dirCos * distance;
 
 		if(copyY)
 		{
-			y = strumY + offsetY + correctionOffset + Math.sin(angleDir) * distance;
+			y = strumY + offsetY + correctionOffset + myStrum._dirSin * distance;
 			if(myStrum.downScroll && isSustainNote)
 			{
 				if(PlayState.isPixelStage)

--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -477,10 +477,13 @@ class Note extends FlxSprite
 			alpha = strumAlpha * multAlpha;
 
 		if(copyX)
+		{
+			@:privateAccess
 			x = strumX + offsetX + myStrum._dirCos * distance;
-
+		}
 		if(copyY)
 		{
+			@:privateAccess
 			y = strumY + offsetY + correctionOffset + myStrum._dirSin * distance;
 			if(myStrum.downScroll && isSustainNote)
 			{

--- a/source/objects/StrumNote.hx
+++ b/source/objects/StrumNote.hx
@@ -10,10 +10,22 @@ class StrumNote extends FlxSprite
 	public var rgbShader:RGBShaderReference;
 	public var resetAnim:Float = 0;
 	private var noteData:Int = 0;
-	public var direction:Float = 90;//plan on doing scroll directions soon -bb
+	public var direction(default, set):Float;//plan on doing scroll directions soon -bb
 	public var downScroll:Bool = false;//plan on doing scroll directions soon -bb
 	public var sustainReduce:Bool = true;
 	private var player:Int;
+
+	private var _dirSin:Float;
+	private var _dirCos:Float;
+
+	private function set_direction(_fDir:Float):Float
+	{
+		// 0.01745329251 = Math.PI / 180
+		_dirSin = Math.sin(_fDir * 0.01745329251);
+		_dirCos = Math.cos(_fDir * 0.01745329251);
+
+		return direction = _fDir;
+	}
 	
 	public var texture(default, set):String = null;
 	private function set_texture(value:String):String {
@@ -26,6 +38,8 @@ class StrumNote extends FlxSprite
 
 	public var useRGBShader:Bool = true;
 	public function new(x:Float, y:Float, leData:Int, player:Int) {
+		direction = 90;
+		
 		animation = new PsychAnimationController(this);
 
 		rgbShader = new RGBShaderReference(this, Note.initializeGlobalRGBShader(leData));


### PR DESCRIPTION
The `followStrum` function in `Note.hx` uses sin and cos funcions to change the incoming angle of the notes.
That's good but the function calls those math functions and its a bit bad, so, instead of doing that, when `direction` variable change its value, caches the sin and cos of the angle, and the `followStrum` function uses it to prevent calling those functions every frame.