### PR TITLE
Compatibility for Flixel 5.8.0

### DIFF
--- a/assets/base_game/shared/characters/bf-christmas.json
+++ b/assets/base_game/shared/characters/bf-christmas.json
@@ -108,7 +108,7 @@
 			"fps": 24,
 			"anim": "hey",
 			"indices": [],
-			"name": "BF HEY"
+			"name": "BF HEY!!"
 		}
 	],
 	"no_antialiasing": false,

--- a/assets/base_game/shared/characters/bf-holding-gf.json
+++ b/assets/base_game/shared/characters/bf-holding-gf.json
@@ -9,7 +9,7 @@
 			"fps": 24,
 			"anim": "idle",
 			"indices": [],
-			"name": "BF idle dance"
+			"name": "BF idle dance w gf"
 		},
 		{
 			"offsets": [

--- a/assets/base_game/shared/characters/bf-pixel.json
+++ b/assets/base_game/shared/characters/bf-pixel.json
@@ -9,7 +9,7 @@
 			"fps": 24,
 			"anim": "idle",
 			"indices": [],
-			"name": "BF IDLE"
+			"name": "BF IDLE instance 1"
 		},
 		{
 			"loop": false,
@@ -19,7 +19,7 @@
 			],
 			"anim": "singLEFTmiss",
 			"fps": 24,
-			"name": "BF LEFT MISS",
+			"name": "BF LEFT MISS instance 1",
 			"indices": []
 		},
 		{
@@ -30,7 +30,7 @@
 			],
 			"anim": "singLEFT",
 			"fps": 24,
-			"name": "BF LEFT NOTE",
+			"name": "BF LEFT NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -41,7 +41,7 @@
 			],
 			"anim": "singUPmiss",
 			"fps": 24,
-			"name": "BF UP MISS",
+			"name": "BF UP MISS instance 1",
 			"indices": []
 		},
 		{
@@ -52,7 +52,7 @@
 			],
 			"anim": "singUP",
 			"fps": 24,
-			"name": "BF UP NOTE",
+			"name": "BF UP NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -63,7 +63,7 @@
 			],
 			"anim": "singRIGHT",
 			"fps": 24,
-			"name": "BF RIGHT NOTE",
+			"name": "BF RIGHT NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -74,7 +74,7 @@
 			],
 			"anim": "singRIGHTmiss",
 			"fps": 24,
-			"name": "BF RIGHT MISS",
+			"name": "BF RIGHT MISS instance 1",
 			"indices": []
 		},
 		{
@@ -85,7 +85,7 @@
 			],
 			"anim": "singDOWN",
 			"fps": 24,
-			"name": "BF DOWN NOTE",
+			"name": "BF DOWN NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -96,7 +96,7 @@
 			],
 			"anim": "singDOWNmiss",
 			"fps": 24,
-			"name": "BF DOWN MISS",
+			"name": "BF DOWN MISS instance 1",
 			"indices": []
 		}
 	],

--- a/assets/base_game/shared/characters/senpai-angry.json
+++ b/assets/base_game/shared/characters/senpai-angry.json
@@ -8,7 +8,7 @@
 			"loop": false,
 			"anim": "idle",
 			"fps": 24,
-			"name": "Angry Senpai Idle",
+			"name": "Angry Senpai Idle instance 1",
 			"indices": []
 		},
 		{
@@ -19,7 +19,7 @@
 			"loop": false,
 			"anim": "singUP",
 			"fps": 24,
-			"name": "Angry Senpai UP NOTE",
+			"name": "Angry Senpai UP NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -30,7 +30,7 @@
 			"loop": false,
 			"anim": "singLEFT",
 			"fps": 24,
-			"name": "Angry Senpai LEFT NOTE",
+			"name": "Angry Senpai LEFT NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -41,7 +41,7 @@
 			"loop": false,
 			"anim": "singRIGHT",
 			"fps": 24,
-			"name": "Angry Senpai RIGHT NOTE",
+			"name": "Angry Senpai RIGHT NOTE instance 1",
 			"indices": []
 		},
 		{
@@ -52,7 +52,7 @@
 			"loop": false,
 			"anim": "singDOWN",
 			"fps": 24,
-			"name": "Angry Senpai DOWN NOTE",
+			"name": "Angry Senpai DOWN NOTE instance 1",
 			"indices": []
 		}
 	],

--- a/assets/shared/characters/bf.json
+++ b/assets/shared/characters/bf.json
@@ -108,7 +108,7 @@
 			"fps": 24,
 			"anim": "hey",
 			"indices": [],
-			"name": "BF HEY"
+			"name": "BF HEY!!"
 		},
 		{
 			"offsets": [

--- a/source/backend/MusicBeatState.hx
+++ b/source/backend/MusicBeatState.hx
@@ -1,6 +1,9 @@
 package backend;
 
 import flixel.FlxState;
+
+import flixel.util.typeLimit.NextState;
+
 import backend.PsychCamera;
 
 class MusicBeatState extends FlxState
@@ -131,39 +134,24 @@ class MusicBeatState extends FlxState
 		curStep = lastChange.stepTime + Math.floor(shit);
 	}
 
-	public static function switchState(nextState:FlxState = null) {
-		if(nextState == null) nextState = FlxG.state;
-		if(nextState == FlxG.state)
+	override function startOutro(onOutroComplete:()->Void):Void
+	{
+		if (!FlxTransitionableState.skipNextTransIn)
 		{
-			resetState();
+			FlxG.state.openSubState(new CustomFadeTransition(0.6, false));
+
+			CustomFadeTransition.finishCallback = onOutroComplete;
+
 			return;
 		}
 
-		if(FlxTransitionableState.skipNextTransIn) FlxG.switchState(nextState);
-		else startTransition(nextState);
 		FlxTransitionableState.skipNextTransIn = false;
+
+		onOutroComplete();
 	}
 
-	public static function resetState() {
-		if(FlxTransitionableState.skipNextTransIn) FlxG.resetState();
-		else startTransition();
-		FlxTransitionableState.skipNextTransIn = false;
-	}
-
-	// Custom made Trans in
-	public static function startTransition(nextState:FlxState = null)
+	public static function getState():MusicBeatState
 	{
-		if(nextState == null)
-			nextState = FlxG.state;
-
-		FlxG.state.openSubState(new CustomFadeTransition(0.6, false));
-		if(nextState == FlxG.state)
-			CustomFadeTransition.finishCallback = function() FlxG.resetState();
-		else
-			CustomFadeTransition.finishCallback = function() FlxG.switchState(nextState);
-	}
-
-	public static function getState():MusicBeatState {
 		return cast (FlxG.state, MusicBeatState);
 	}
 

--- a/source/objects/Alphabet.hx
+++ b/source/objects/Alphabet.hx
@@ -385,13 +385,13 @@ class AlphaCharacter extends FlxSprite
 			if(curLetter != null && curLetter.anim != null) alphaAnim = curLetter.anim;
 
 			var anim:String = alphaAnim + postfix;
-			animation.addByPrefix(anim, anim, 24);
+			animation.addByPrefix(anim, anim + " instance 1", 24);
 			animation.play(anim, true);
 			if(animation.curAnim == null)
 			{
 				if(postfix != ' bold') postfix = ' normal';
 				anim = 'question' + postfix;
-				animation.addByPrefix(anim, anim, 24);
+				animation.addByPrefix(anim, anim + " instance 1", 24);
 				animation.play(anim, true);
 			}
 		}
@@ -430,7 +430,7 @@ class AlphaCharacter extends FlxSprite
 		
 		if (lastAnim != null)
 		{
-			animation.addByPrefix(lastAnim, lastAnim, 24);
+			animation.addByPrefix(lastAnim, lastAnim + " instance 1", 24);
 			animation.play(lastAnim, true);
 			
 			updateHitbox();

--- a/source/options/LanguageSubState.hx
+++ b/source/options/LanguageSubState.hx
@@ -111,7 +111,7 @@ class LanguageSubState extends MusicBeatSubstate
 			{
 				FlxTransitionableState.skipNextTransIn = true;
 				FlxTransitionableState.skipNextTransOut = true;
-				MusicBeatState.resetState();
+				FlxG.resetState();
 			}
 			else close();
 			FlxG.sound.play(Paths.sound('cancelMenu'));

--- a/source/options/NoteOffsetState.hx
+++ b/source/options/NoteOffsetState.hx
@@ -405,7 +405,7 @@ class NoteOffsetState extends MusicBeatState
 			if(beatTween != null) beatTween.cancel();
 
 			persistentUpdate = false;
-			MusicBeatState.switchState(new options.OptionsState());
+			FlxG.switchState(() -> new options.OptionsState());
 			if(OptionsState.onPlayState)
 			{
 				if(ClientPrefs.data.pauseMusic != 'None')

--- a/source/options/OptionsState.hx
+++ b/source/options/OptionsState.hx
@@ -33,7 +33,7 @@ class OptionsState extends MusicBeatState
 			case 'Gameplay':
 				openSubState(new options.GameplaySettingsSubState());
 			case 'Adjust Delay and Combo':
-				MusicBeatState.switchState(new options.NoteOffsetState());
+				FlxG.switchState(() -> new options.NoteOffsetState());
 			case 'Language':
 				openSubState(new options.LanguageSubState());
 		}
@@ -104,7 +104,7 @@ class OptionsState extends MusicBeatState
 				LoadingState.loadAndSwitchState(new PlayState());
 				FlxG.sound.music.volume = 0;
 			}
-			else MusicBeatState.switchState(new MainMenuState());
+			else FlxG.switchState(() -> new MainMenuState());
 		}
 		else if (controls.ACCEPT) openSelectedSubstate(options[curSelected]);
 	}

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -756,9 +756,9 @@ class FunkinLua {
 			}
 
 			if(PlayState.isStoryMode)
-				MusicBeatState.switchState(new StoryMenuState());
+				FlxG.switchState(() -> new StoryMenuState());
 			else
-				MusicBeatState.switchState(new FreeplayState());
+				FlxG.switchState(() -> new FreeplayState());
 
 			#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
 

--- a/source/states/AchievementsMenuState.hx
+++ b/source/states/AchievementsMenuState.hx
@@ -205,7 +205,7 @@ class AchievementsMenuState extends MusicBeatState
 
 		if (controls.BACK) {
 			FlxG.sound.play(Paths.sound('cancelMenu'));
-			MusicBeatState.switchState(new MainMenuState());
+			FlxG.switchState(() -> new MainMenuState());
 			goingBack = true;
 		}
 		super.update(elapsed);

--- a/source/states/CreditsState.hx
+++ b/source/states/CreditsState.hx
@@ -181,7 +181,7 @@ class CreditsState extends MusicBeatState
 			if (controls.BACK)
 			{
 				FlxG.sound.play(Paths.sound('cancelMenu'));
-				MusicBeatState.switchState(new MainMenuState());
+				FlxG.switchState(() -> new MainMenuState());
 				quitting = true;
 			}
 		}

--- a/source/states/FlashingState.hx
+++ b/source/states/FlashingState.hx
@@ -43,14 +43,14 @@ class FlashingState extends MusicBeatState
 					FlxG.sound.play(Paths.sound('confirmMenu'));
 					FlxFlicker.flicker(warnText, 1, 0.1, false, true, function(flk:FlxFlicker) {
 						new FlxTimer().start(0.5, function (tmr:FlxTimer) {
-							MusicBeatState.switchState(new TitleState());
+							FlxG.switchState(() -> new TitleState());
 						});
 					});
 				} else {
 					FlxG.sound.play(Paths.sound('cancelMenu'));
 					FlxTween.tween(warnText, {alpha: 0}, 1, {
 						onComplete: function (twn:FlxTween) {
-							MusicBeatState.switchState(new TitleState());
+							FlxG.switchState(() -> new TitleState());
 						}
 					});
 				}

--- a/source/states/FreeplayState.hx
+++ b/source/states/FreeplayState.hx
@@ -67,9 +67,9 @@ class FreeplayState extends MusicBeatState
 			{
 				FlxTransitionableState.skipNextTransIn = true;
 				persistentUpdate = false;
-				MusicBeatState.switchState(new states.ErrorState("NO WEEKS ADDED FOR FREEPLAY\n\nPress ACCEPT to go to the Week Editor Menu.\nPress BACK to return to Main Menu.",
-					function() MusicBeatState.switchState(new states.editors.WeekEditorState()),
-					function() MusicBeatState.switchState(new states.MainMenuState())));
+				FlxG.switchState(() -> new states.ErrorState("NO WEEKS ADDED FOR FREEPLAY\n\nPress ACCEPT to go to the Week Editor Menu.\nPress BACK to return to Main Menu.",
+					function() FlxG.switchState(() -> new states.editors.WeekEditorState()),
+					function() FlxG.switchState(() -> new states.MainMenuState())));
 				return;
 			}
 
@@ -316,7 +316,7 @@ class FreeplayState extends MusicBeatState
 			{
 				persistentUpdate = false;
 				FlxG.sound.play(Paths.sound('cancelMenu'));
-				MusicBeatState.switchState(new MainMenuState());
+				FlxG.switchState(() -> new MainMenuState());
 			}
 		}
 

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -6,7 +6,7 @@ import openfl.display.BitmapData;
 import openfl.utils.AssetType;
 import openfl.utils.Assets as OpenFlAssets;
 import flixel.graphics.FlxGraphic;
-import flixel.FlxState;
+import flixel.util.typeLimit.NextState;
 
 import backend.Song;
 import backend.StageData;
@@ -27,7 +27,7 @@ class LoadingState extends MusicBeatState
 	static var requestedBitmaps:Map<String, BitmapData> = [];
 	static var mutex:Mutex = new Mutex();
 
-	function new(target:FlxState, stopMusic:Bool)
+	function new(target:NextState, stopMusic:Bool)
 	{
 		this.target = target;
 		this.stopMusic = stopMusic;
@@ -35,10 +35,10 @@ class LoadingState extends MusicBeatState
 		super();
 	}
 
-	inline static public function loadAndSwitchState(target:FlxState, stopMusic = false, intrusive:Bool = true)
-		MusicBeatState.switchState(getNextState(target, stopMusic, intrusive));
+	inline static public function loadAndSwitchState(target:NextState, stopMusic = false, intrusive:Bool = true)
+		FlxG.switchState(getNextState(target, stopMusic, intrusive));
 	
-	var target:FlxState = null;
+	var target:NextState = null;
 	var stopMusic:Bool = false;
 	var dontUpdate:Bool = false;
 
@@ -236,7 +236,7 @@ class LoadingState extends MusicBeatState
 
 		FlxG.camera.visible = false;
 		FlxTransitionableState.skipNextTransIn = true;
-		MusicBeatState.switchState(target);
+		FlxG.switchState(target);
 		transitioning = true;
 		finishedLoading = true;
 	}
@@ -265,7 +265,7 @@ class LoadingState extends MusicBeatState
 		trace('Setting asset folder to ' + directory);
 	}
 
-	static function getNextState(target:FlxState, stopMusic = false, intrusive:Bool = true):FlxState
+	static function getNextState(target:NextState, stopMusic = false, intrusive:Bool = true):NextState
 	{
 		loadNextDirectory();
 		if(intrusive)

--- a/source/states/MainMenuState.hx
+++ b/source/states/MainMenuState.hx
@@ -246,7 +246,7 @@ class MainMenuState extends MusicBeatState
 				selectedSomethin = true;
 				FlxG.mouse.visible = false;
 				FlxG.sound.play(Paths.sound('cancelMenu'));
-				MusicBeatState.switchState(new TitleState());
+				FlxG.switchState(() -> new TitleState());
 			}
 
 			if (controls.ACCEPT || (FlxG.mouse.justPressed && allowMouse))
@@ -282,24 +282,24 @@ class MainMenuState extends MusicBeatState
 						switch (option)
 						{
 							case 'story_mode':
-								MusicBeatState.switchState(new StoryMenuState());
+								FlxG.switchState(() -> new StoryMenuState());
 							case 'freeplay':
-								MusicBeatState.switchState(new FreeplayState());
+								FlxG.switchState(() -> new FreeplayState());
 
 							#if MODS_ALLOWED
 							case 'mods':
-								MusicBeatState.switchState(new ModsMenuState());
+								FlxG.switchState(() -> new ModsMenuState());
 							#end
 
 							#if ACHIEVEMENTS_ALLOWED
 							case 'achievements':
-								MusicBeatState.switchState(new AchievementsMenuState());
+								FlxG.switchState(() -> new AchievementsMenuState());
 							#end
 
 							case 'credits':
-								MusicBeatState.switchState(new CreditsState());
+								FlxG.switchState(() -> new CreditsState());
 							case 'options':
-								MusicBeatState.switchState(new OptionsState());
+								FlxG.switchState(() -> new OptionsState());
 								OptionsState.onPlayState = false;
 								if (PlayState.SONG != null)
 								{
@@ -325,7 +325,7 @@ class MainMenuState extends MusicBeatState
 			{
 				selectedSomethin = true;
 				FlxG.mouse.visible = false;
-				MusicBeatState.switchState(new MasterEditorMenu());
+				FlxG.switchState(() -> new MasterEditorMenu());
 			}
 			#end
 		}

--- a/source/states/ModsMenuState.hx
+++ b/source/states/ModsMenuState.hx
@@ -314,7 +314,7 @@ class ModsMenuState extends MusicBeatState
 			FlxG.sound.play(Paths.sound('cancelMenu'));
 			if(waitingToRestart)
 			{
-				//MusicBeatState.switchState(new TitleState());
+				//FlxG.switchState(() -> new TitleState());
 				TitleState.initialized = false;
 				TitleState.closedState = false;
 				FlxG.sound.music.fadeOut(0.3);
@@ -325,7 +325,7 @@ class ModsMenuState extends MusicBeatState
 				}
 				FlxG.camera.fade(FlxColor.BLACK, 0.5, false, FlxG.resetGame, false);
 			}
-			else MusicBeatState.switchState(new MainMenuState());
+			else FlxG.switchState(() -> new MainMenuState());
 
 			persistentUpdate = false;
 			FlxG.autoPause = ClientPrefs.data.autoPause;
@@ -769,7 +769,7 @@ class ModsMenuState extends MusicBeatState
 		FlxTransitionableState.skipNextTransIn = true;
 		FlxTransitionableState.skipNextTransOut = true;
 		var curMod:ModItem = modsGroup.members[curSelectedMod];
-		MusicBeatState.switchState(new ModsMenuState(curMod != null ? curMod.folder : null));
+		FlxG.switchState(() -> new ModsMenuState(curMod != null ? curMod.folder : null));
 	}
 	
 	function saveTxt()

--- a/source/states/OutdatedState.hx
+++ b/source/states/OutdatedState.hx
@@ -41,7 +41,7 @@ class OutdatedState extends MusicBeatState
 				FlxG.sound.play(Paths.sound('cancelMenu'));
 				FlxTween.tween(warnText, {alpha: 0}, 1, {
 					onComplete: function (twn:FlxTween) {
-						MusicBeatState.switchState(new MainMenuState());
+						FlxG.switchState(() -> new MainMenuState());
 					}
 				});
 			}

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1881,7 +1881,7 @@ class PlayState extends MusicBeatState
 		DiscordClient.resetClientID();
 		#end
 
-		MusicBeatState.switchState(new ChartingState());
+		FlxG.switchState(() -> new ChartingState());
 	}
 
 	function openCharacterEditor()
@@ -1899,7 +1899,7 @@ class PlayState extends MusicBeatState
 			opponentVocals.pause();
 
 		#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
-		MusicBeatState.switchState(new CharacterEditorState(SONG.player2));
+		FlxG.switchState(() -> new CharacterEditorState(SONG.player2));
 	}
 
 	public var isDead:Bool = false; //Don't mess with this on Lua!!!
@@ -1925,7 +1925,7 @@ class PlayState extends MusicBeatState
 
 				openSubState(new GameOverSubstate());
 
-				// MusicBeatState.switchState(new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
+				// FlxG.switchState(() -> new GameOverState(boyfriend.getScreenPosition().x, boyfriend.getScreenPosition().y));
 
 				#if DISCORD_ALLOWED
 				// Game Over doesn't get his its variable because it's only used here
@@ -2345,7 +2345,7 @@ class PlayState extends MusicBeatState
 					#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
 
 					canResync = false;
-					MusicBeatState.switchState(new StoryMenuState());
+					FlxG.switchState(() -> new StoryMenuState());
 
 					// if ()
 					if(!ClientPrefs.getGameplaySetting('practice') && !ClientPrefs.getGameplaySetting('botplay')) {
@@ -2383,7 +2383,7 @@ class PlayState extends MusicBeatState
 				#if DISCORD_ALLOWED DiscordClient.resetClientID(); #end
 
 				canResync = false;
-				MusicBeatState.switchState(new FreeplayState());
+				FlxG.switchState(() -> new FreeplayState());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				changedDifficulty = false;
 			}

--- a/source/states/StoryMenuState.hx
+++ b/source/states/StoryMenuState.hx
@@ -60,9 +60,9 @@ class StoryMenuState extends MusicBeatState
 		{
 			FlxTransitionableState.skipNextTransIn = true;
 			persistentUpdate = false;
-			MusicBeatState.switchState(new states.ErrorState("NO WEEKS ADDED FOR STORY MODE\n\nPress ACCEPT to go to the Week Editor Menu.\nPress BACK to return to Main Menu.",
-				function() MusicBeatState.switchState(new states.editors.WeekEditorState()),
-				function() MusicBeatState.switchState(new states.MainMenuState())));
+			FlxG.switchState(() -> new states.ErrorState("NO WEEKS ADDED FOR STORY MODE\n\nPress ACCEPT to go to the Week Editor Menu.\nPress BACK to return to Main Menu.",
+				function() FlxG.switchState(() -> new states.editors.WeekEditorState()),
+				function() FlxG.switchState(() -> new states.MainMenuState())));
 			return;
 		}
 
@@ -202,7 +202,7 @@ class StoryMenuState extends MusicBeatState
 			{
 				FlxG.sound.play(Paths.sound('cancelMenu'));
 				movedBack = true;
-				MusicBeatState.switchState(new MainMenuState());
+				FlxG.switchState(() -> new MainMenuState());
 			}
 			super.update(elapsed);
 			return;
@@ -279,7 +279,7 @@ class StoryMenuState extends MusicBeatState
 		{
 			FlxG.sound.play(Paths.sound('cancelMenu'));
 			movedBack = true;
-			MusicBeatState.switchState(new MainMenuState());
+			FlxG.switchState(() -> new MainMenuState());
 		}
 
 		super.update(elapsed);

--- a/source/states/TitleState.hx
+++ b/source/states/TitleState.hx
@@ -138,14 +138,14 @@ class TitleState extends MusicBeatState
 
 		FlxG.mouse.visible = false;
 		#if FREEPLAY
-		MusicBeatState.switchState(new FreeplayState());
+		FlxG.switchState(() -> new FreeplayState());
 		#elseif CHARTING
-		MusicBeatState.switchState(new ChartingState());
+		FlxG.switchState(() -> new ChartingState());
 		#else
 		if(FlxG.save.data.flashing == null && !FlashingState.leftState) {
 			FlxTransitionableState.skipNextTransIn = true;
 			FlxTransitionableState.skipNextTransOut = true;
-			MusicBeatState.switchState(new FlashingState());
+			FlxG.switchState(() -> new FlashingState());
 		} else {
 			if (initialized)
 				startIntro();
@@ -396,9 +396,9 @@ class TitleState extends MusicBeatState
 				new FlxTimer().start(1, function(tmr:FlxTimer)
 				{
 					if (mustUpdate) {
-						MusicBeatState.switchState(new OutdatedState());
+						FlxG.switchState(() -> new OutdatedState());
 					} else {
-						MusicBeatState.switchState(new MainMenuState());
+						FlxG.switchState(() -> new MainMenuState());
 					}
 					closedState = true;
 				});
@@ -436,7 +436,7 @@ class TitleState extends MusicBeatState
 								function(twn:FlxTween) {
 									FlxTransitionableState.skipNextTransIn = true;
 									FlxTransitionableState.skipNextTransOut = true;
-									MusicBeatState.switchState(new TitleState());
+									FlxG.switchState(() -> new TitleState());
 								}
 							});
 							FlxG.sound.music.fadeOut();

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -1031,12 +1031,12 @@ class CharacterEditorState extends MusicBeatState implements PsychUIEventHandler
 			{
 				if(!unsavedProgress)
 				{
-					MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+					FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				}
 				else openSubState(new ExitConfirmationPrompt());
 			}
-			else MusicBeatState.switchState(new PlayState());
+			else FlxG.switchState(() -> new PlayState());
 			return;
 		}
 	}

--- a/source/states/editors/CharacterEditorState.hx
+++ b/source/states/editors/CharacterEditorState.hx
@@ -4,9 +4,12 @@ import flixel.FlxObject;
 import flixel.graphics.FlxGraphic;
 
 import flixel.animation.FlxAnimation;
+#if FLX_DEBUG
 import flixel.system.debug.interaction.tools.Pointer.GraphicCursorCross;
+#else
+import openfl.display.BitmapData;
+#end
 import flixel.util.FlxDestroyUtil;
-
 import openfl.net.FileReference;
 import openfl.events.Event;
 import openfl.events.IOErrorEvent;
@@ -19,6 +22,11 @@ import objects.Bar;
 
 import states.editors.content.Prompt;
 import states.editors.content.PsychJsonPrinter;
+
+#if !FLX_DEBUG
+@:bitmap("assets/images/debugger/cursorCross.png")
+private class GraphicCursorCross extends BitmapData {}
+#end
 
 class CharacterEditorState extends MusicBeatState implements PsychUIEventHandler.PsychUIEvent
 {

--- a/source/states/editors/ChartingState.hx
+++ b/source/states/editors/ChartingState.hx
@@ -2924,7 +2924,7 @@ class ChartingState extends MusicBeatState implements PsychUIEventHandler.PsychU
 		var btn:PsychUIButton = new PsychUIButton(btnX, btnY, '  Exit', function()
 		{
 			PlayState.chartingMode = false;
-			MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+			FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			FlxG.mouse.visible = false;
 		}, btnWid);

--- a/source/states/editors/DialogueCharacterEditorState.hx
+++ b/source/states/editors/DialogueCharacterEditorState.hx
@@ -602,7 +602,7 @@ class DialogueCharacterEditorState extends MusicBeatState implements PsychUIEven
 			if(FlxG.keys.justPressed.ESCAPE) {
 				if(!unsavedProgress)
 				{
-					MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+					FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 					transitioning = true;
 				}

--- a/source/states/editors/DialogueEditorState.hx
+++ b/source/states/editors/DialogueEditorState.hx
@@ -314,7 +314,7 @@ class DialogueEditorState extends MusicBeatState implements PsychUIEventHandler.
 			if(FlxG.keys.justPressed.ESCAPE) {
 				if(!unsavedProgress)
 				{
-					MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+					FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 					transitioning = true;
 				}

--- a/source/states/editors/MasterEditorMenu.hx
+++ b/source/states/editors/MasterEditorMenu.hx
@@ -99,7 +99,7 @@ class MasterEditorMenu extends MusicBeatState
 
 		if (controls.BACK)
 		{
-			MusicBeatState.switchState(new MainMenuState());
+			FlxG.switchState(() -> new MainMenuState());
 		}
 
 		if (controls.ACCEPT)
@@ -112,15 +112,15 @@ class MasterEditorMenu extends MusicBeatState
 				case 'Stage Editor':
 					LoadingState.loadAndSwitchState(new StageEditorState());
 				case 'Week Editor':
-					MusicBeatState.switchState(new WeekEditorState());
+					FlxG.switchState(() -> new WeekEditorState());
 				case 'Menu Character Editor':
-					MusicBeatState.switchState(new MenuCharacterEditorState());
+					FlxG.switchState(() -> new MenuCharacterEditorState());
 				case 'Dialogue Editor':
 					LoadingState.loadAndSwitchState(new DialogueEditorState(), false);
 				case 'Dialogue Portrait Editor':
 					LoadingState.loadAndSwitchState(new DialogueCharacterEditorState(), false);
 				case 'Note Splash Debug':
-					MusicBeatState.switchState(new NoteSplashDebugState());
+					FlxG.switchState(() -> new NoteSplashDebugState());
 			}
 			FlxG.sound.music.volume = 0;
 			FreeplayState.destroyFreeplayVocals();

--- a/source/states/editors/MenuCharacterEditorState.hx
+++ b/source/states/editors/MenuCharacterEditorState.hx
@@ -215,7 +215,7 @@ class MenuCharacterEditorState extends MusicBeatState implements PsychUIEventHan
 			if(FlxG.keys.justPressed.ESCAPE) {
 				if(!unsavedProgress)
 				{
-					MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+					FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				}
 				else openSubState(new ExitConfirmationPrompt());

--- a/source/states/editors/NoteSplashDebugState.hx
+++ b/source/states/editors/NoteSplashDebugState.hx
@@ -1,8 +1,10 @@
 package states.editors;
 
+import flixel.graphics.frames.FlxFrame;
+
 import objects.Note;
-import objects.StrumNote;
 import objects.NoteSplash;
+import objects.StrumNote;
 
 class NoteSplashDebugState extends MusicBeatState implements PsychUIEventHandler.PsychUIEvent
 {
@@ -175,7 +177,7 @@ class NoteSplashDebugState extends MusicBeatState implements PsychUIEventHandler
 		var notTyping:Bool = (PsychUIInputText.focusOn == null);
 		if(controls.BACK && notTyping)
 		{
-			MusicBeatState.switchState(new MasterEditorMenu());
+			FlxG.switchState(() -> new MasterEditorMenu());
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			FlxG.mouse.visible = false;
 		}
@@ -447,8 +449,21 @@ class NoteSplashDebugState extends MusicBeatState implements PsychUIEventHandler
 
 	function addAnimAndCheck(spr:FlxSprite, name:String, anim:String, ?framerate:Int = 24, ?loop:Bool = false)
 	{
+		var frames:Array<FlxFrame> = [];
+
+		@:privateAccess
+		{
+			spr.animation.findByPrefix(frames, anim, true);
+		}
+
+		if (frames.length < 1)
+		{
+			return false;
+		}
+
 		spr.animation.addByPrefix(name, anim, framerate, loop);
-		return spr.animation.getByName(name) != null;
+
+		return true;
 	}
 
 	override function destroy()

--- a/source/states/editors/StageEditorState.hx
+++ b/source/states/editors/StageEditorState.hx
@@ -617,7 +617,7 @@ class StageEditorState extends MusicBeatState implements PsychUIEventHandler.Psy
 			stageJson.directory = selected;
 			saveObjectsToJson();
 			FlxTransitionableState.skipNextTransIn = FlxTransitionableState.skipNextTransOut = true;
-			MusicBeatState.switchState(new StageEditorState(lastLoadedStage, stageJson));
+			FlxG.switchState(() -> new StageEditorState(lastLoadedStage, stageJson));
 		});
 		directoryDropDown.selectedLabel = stageJson.directory;
 
@@ -1284,7 +1284,7 @@ class StageEditorState extends MusicBeatState implements PsychUIEventHandler.Psy
 		{
 			if(!unsavedProgress)
 			{
-				MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+				FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			}
 			else openSubState(new ExitConfirmationPrompt());

--- a/source/states/editors/WeekEditorState.hx
+++ b/source/states/editors/WeekEditorState.hx
@@ -120,7 +120,7 @@ class WeekEditorState extends MusicBeatState implements PsychUIEventHandler.Psyc
 		loadWeekButton.x -= 120;
 		add(loadWeekButton);
 		
-		var freeplayButton:PsychUIButton = new PsychUIButton(0, 650, "Freeplay", function() MusicBeatState.switchState(new WeekEditorFreeplayState(weekFile)));
+		var freeplayButton:PsychUIButton = new PsychUIButton(0, 650, "Freeplay", function() FlxG.switchState(() -> new WeekEditorFreeplayState(weekFile)));
 		freeplayButton.screenCenter(X);
 		add(freeplayButton);
 	
@@ -402,7 +402,7 @@ class WeekEditorState extends MusicBeatState implements PsychUIEventHandler.Psyc
 			{
 				if(!unsavedProgress)
 				{
-					MusicBeatState.switchState(new MasterEditorMenu());
+					FlxG.switchState(() -> new MasterEditorMenu());
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				}
 				else openSubState(new ExitConfirmationPrompt(function() unsavedProgress = false));
@@ -615,7 +615,7 @@ class WeekEditorFreeplayState extends MusicBeatState implements PsychUIEventHand
 		add(loadWeekButton);
 		
 		var storyModeButton:PsychUIButton = new PsychUIButton(0, 685, "Story Mode", function() {
-			MusicBeatState.switchState(new WeekEditorState(weekFile));
+			FlxG.switchState(() -> new WeekEditorState(weekFile));
 			
 		});
 		storyModeButton.screenCenter(X);
@@ -745,7 +745,7 @@ class WeekEditorFreeplayState extends MusicBeatState implements PsychUIEventHand
 			super.update(elapsed);
 			FlxTransitionableState.skipNextTransIn = true;
 			FlxTransitionableState.skipNextTransOut = true;
-			MusicBeatState.switchState(new WeekEditorFreeplayState(WeekEditorState.loadedWeek));
+			FlxG.switchState(() -> new WeekEditorFreeplayState(WeekEditorState.loadedWeek));
 			WeekEditorState.loadedWeek = null;
 			return;
 		}
@@ -758,7 +758,7 @@ class WeekEditorFreeplayState extends MusicBeatState implements PsychUIEventHand
 			if(FlxG.keys.justPressed.ESCAPE) {
 				if(!WeekEditorState.unsavedProgress)
 				{
-					MusicBeatState.switchState(new MasterEditorMenu());
+					FlxG.switchState(() -> new MasterEditorMenu());
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 				}
 				else openSubState(new ExitConfirmationPrompt());

--- a/source/states/editors/content/Prompt.hx
+++ b/source/states/editors/content/Prompt.hx
@@ -10,7 +10,7 @@ class ExitConfirmationPrompt extends Prompt
 		super('There\'s unsaved progress,\nare you sure you want to exit?', function()
 		{
 			FlxG.mouse.visible = false;
-			MusicBeatState.switchState(new states.editors.MasterEditorMenu());
+			FlxG.switchState(() -> new states.editors.MasterEditorMenu());
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			if(finishCallback != null) finishCallback();
 		}, 'Exit');

--- a/source/states/stages/Limo.hx
+++ b/source/states/stages/Limo.hx
@@ -39,7 +39,7 @@ class Limo extends BaseStage
 			bgLimo = new BGSprite('limo/bgLimo', -150, 480, 0.4, 0.4, ['background limo pink'], true);
 			add(bgLimo);
 
-			limoCorpse = new BGSprite('gore/noooooo', -500, limoMetalPole.y - 130, 0.4, 0.4, ['Henchmen on rail'], true);
+			limoCorpse = new BGSprite('gore/noooooo', -500, limoMetalPole.y - 130, 0.4, 0.4, ['Henchmen on rail PINK'], true);
 			add(limoCorpse);
 
 			limoCorpseTwo = new BGSprite('gore/noooooo', -500, limoMetalPole.y, 0.4, 0.4, ['henchmen death'], true);

--- a/source/states/stages/SchoolEvil.hx
+++ b/source/states/stages/SchoolEvil.hx
@@ -21,7 +21,7 @@ class SchoolEvil extends BaseStage
 
 		var bg:BGSprite;
 		if(!ClientPrefs.data.lowQuality)
-			bg = new BGSprite('weeb/animatedEvilSchool', posX, posY, 0.8, 0.9, ['background 2'], true);
+			bg = new BGSprite('weeb/animatedEvilSchool', posX, posY, 0.8, 0.9, ['background 2 instance 1'], true);
 		else
 			bg = new BGSprite('weeb/animatedEvilSchool_low', posX, posY, 0.8, 0.9);
 

--- a/source/states/stages/Tank.hx
+++ b/source/states/stages/Tank.hx
@@ -42,12 +42,12 @@ class Tank extends BaseStage
 
 		if(!ClientPrefs.data.lowQuality)
 		{
-			var smokeLeft:BGSprite = new BGSprite('smokeLeft', -200, -100, 0.4, 0.4, ['SmokeBlurLeft'], true);
+			var smokeLeft:BGSprite = new BGSprite('smokeLeft', -200, -100, 0.4, 0.4, ['SmokeBlurLeft instance 1'], true);
 			add(smokeLeft);
-			var smokeRight:BGSprite = new BGSprite('smokeRight', 1100, -100, 0.4, 0.4, ['SmokeRight'], true);
+			var smokeRight:BGSprite = new BGSprite('smokeRight', 1100, -100, 0.4, 0.4, ['SmokeRight instance 1'], true);
 			add(smokeRight);
 
-			tankWatchtower = new BGSprite('tankWatchtower', 100, 50, 0.5, 0.5, ['watchtower gradient color']);
+			tankWatchtower = new BGSprite('tankWatchtower', 100, 50, 0.5, 0.5, ['watchtower gradient color instance 1']);
 			add(tankWatchtower);
 		}
 
@@ -63,12 +63,12 @@ class Tank extends BaseStage
 		add(ground);
 
 		foregroundSprites = new FlxTypedGroup<BGSprite>();
-		foregroundSprites.add(new BGSprite('tank0', -500, 650, 1.7, 1.5, ['fg']));
-		if(!ClientPrefs.data.lowQuality) foregroundSprites.add(new BGSprite('tank1', -300, 750, 2, 0.2, ['fg']));
-		foregroundSprites.add(new BGSprite('tank2', 450, 940, 1.5, 1.5, ['foreground']));
-		if(!ClientPrefs.data.lowQuality) foregroundSprites.add(new BGSprite('tank4', 1300, 900, 1.5, 1.5, ['fg']));
-		foregroundSprites.add(new BGSprite('tank5', 1620, 700, 1.5, 1.5, ['fg']));
-		if(!ClientPrefs.data.lowQuality) foregroundSprites.add(new BGSprite('tank3', 1300, 1200, 3.5, 2.5, ['fg']));
+		foregroundSprites.add(new BGSprite('tank0', -500, 650, 1.7, 1.5, ['fg tankhead far right instance 1']));
+		if(!ClientPrefs.data.lowQuality) foregroundSprites.add(new BGSprite('tank1', -300, 750, 2, 0.2, ['fg tankhead 5 instance 1']));
+		foregroundSprites.add(new BGSprite('tank2', 450, 940, 1.5, 1.5, ['foreground man 3 instance 1']));
+		if(!ClientPrefs.data.lowQuality) foregroundSprites.add(new BGSprite('tank4', 1300, 900, 1.5, 1.5, ['fg tankman bobbin 3 instance 1']));
+		foregroundSprites.add(new BGSprite('tank5', 1620, 700, 1.5, 1.5, ['fg tankhead far right instance 1']));
+		if(!ClientPrefs.data.lowQuality) foregroundSprites.add(new BGSprite('tank3', 1300, 1200, 3.5, 2.5, ['fg tankhead 4 instance 1']));
 
 		// Default GFs
 		if(songName == 'stress') setDefaultGF('pico-speaker');

--- a/source/states/stages/objects/BackgroundTank.hx
+++ b/source/states/stages/objects/BackgroundTank.hx
@@ -8,7 +8,7 @@ class BackgroundTank extends BGSprite
 	public var tankAngle:Float = 0;
 	public function new()
 	{
-		super('tankRolling', 0, 0, 0.5, 0.5, ['BG tank w lighting'], true);
+		super('tankRolling', 0, 0, 0.5, 0.5, ['BG tank w lighting instance 1'], true);
 		tankSpeed = FlxG.random.float(5, 7);
 		tankAngle = FlxG.random.int(-90, 45);
 		antialiasing = ClientPrefs.data.antialiasing;

--- a/source/states/stages/objects/MallCrowd.hx
+++ b/source/states/stages/objects/MallCrowd.hx
@@ -3,7 +3,7 @@ package states.stages.objects;
 class MallCrowd extends BGSprite
 {
 	public var heyTimer:Float = 0;
-	public function new(x:Float = 0, y:Float = 0, sprite:String = 'christmas/bottomBop', idle:String = 'Bottom Level Boppers Idle', hey:String = 'Bottom Level Boppers HEY')
+	public function new(x:Float = 0, y:Float = 0, sprite:String = 'christmas/bottomBop', idle:String = 'Bottom Level Boppers Idle', hey:String = 'Bottom Level Boppers HEY!!')
 	{
 		super(sprite, x, y, 0.9, 0.9, [idle]);
 		animation.addByPrefix('hey', hey, 24, false);

--- a/source/substates/GameOverSubstate.hx
+++ b/source/substates/GameOverSubstate.hx
@@ -93,9 +93,9 @@ class GameOverSubstate extends MusicBeatSubstate
 
 			Mods.loadTopMod();
 			if (PlayState.isStoryMode)
-				MusicBeatState.switchState(new StoryMenuState());
+				FlxG.switchState(() -> new StoryMenuState());
 			else
-				MusicBeatState.switchState(new FreeplayState());
+				FlxG.switchState(() -> new FreeplayState());
 
 			FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			PlayState.instance.callOnScripts('onGameOverConfirm', [false]);
@@ -163,7 +163,7 @@ class GameOverSubstate extends MusicBeatSubstate
 			{
 				FlxG.camera.fade(FlxColor.BLACK, 2, false, function()
 				{
-					MusicBeatState.resetState();
+					FlxG.resetState();
 				});
 			});
 			PlayState.instance.callOnScripts('onGameOverConfirm', [true]);

--- a/source/substates/PauseSubState.hx
+++ b/source/substates/PauseSubState.hx
@@ -224,7 +224,7 @@ class PauseSubState extends MusicBeatSubstate
 					{
 						Song.loadFromJson(poop, songLowercase);
 						PlayState.storyDifficulty = curSelected;
-						MusicBeatState.resetState();
+						FlxG.resetState();
 						FlxG.sound.music.volume = 0;
 						PlayState.changedDifficulty = true;
 						PlayState.chartingMode = false;
@@ -301,7 +301,7 @@ class PauseSubState extends MusicBeatSubstate
 					PlayState.instance.paused = true; // For lua
 					PlayState.instance.vocals.volume = 0;
 					PlayState.instance.canResync = false;
-					MusicBeatState.switchState(new OptionsState());
+					FlxG.switchState(() -> new OptionsState());
 					if(ClientPrefs.data.pauseMusic != 'None')
 					{
 						FlxG.sound.playMusic(Paths.music(Paths.formatToSongPath(ClientPrefs.data.pauseMusic)), pauseMusic.volume);
@@ -317,9 +317,9 @@ class PauseSubState extends MusicBeatSubstate
 					PlayState.instance.canResync = false;
 					Mods.loadTopMod();
 					if(PlayState.isStoryMode)
-						MusicBeatState.switchState(new StoryMenuState());
+						FlxG.switchState(() -> new StoryMenuState());
 					else 
-						MusicBeatState.switchState(new FreeplayState());
+						FlxG.switchState(() -> new FreeplayState());
 
 					FlxG.sound.playMusic(Paths.music('freakyMenu'));
 					PlayState.changedDifficulty = false;
@@ -352,7 +352,7 @@ class PauseSubState extends MusicBeatSubstate
 			FlxTransitionableState.skipNextTransIn = true;
 			FlxTransitionableState.skipNextTransOut = true;
 		}
-		MusicBeatState.resetState();
+		FlxG.resetState();
 	}
 
 	override function destroy()

--- a/source/unused/GitarooPause.hx
+++ b/source/unused/GitarooPause.hx
@@ -57,7 +57,7 @@ class GitarooPause extends MusicBeatState
 		{
 			if (replaySelect)
 			{
-				MusicBeatState.switchState(new PlayState());
+				FlxG.switchState(() -> new PlayState());
 			}
 			else
 			{
@@ -66,7 +66,7 @@ class GitarooPause extends MusicBeatState
 				PlayState.seenCutscene = false;
 				PlayState.deathCounter = 0;
 				PlayState.cpuControlled = false;
-				MusicBeatState.switchState(new MainMenuState());
+				FlxG.switchState(() -> new MainMenuState());
 				FlxG.sound.playMusic(Paths.music('freakyMenu'));
 			}
 		}


### PR DESCRIPTION
## The (Main) Problem
In versions of Flixel past 5.6.1, errors related to incorrectly parsed XML's flood the debug terminal.

## The Cause
In Psych's code there is a lot of the following:
```haxe
var animation:String = "animation bop 10000";
addByPrefix("bop", "animation bop", 24, false);
```
This causes some confusion in flixel. Flixel is seemingly designed to error if a requested animation prefix does not start with 0. This is why the following code causes an error.

## The Solution
Instead of the above code, what we need to do is:
```haxe
var animation:String = "animation bop 10000";
addByPrefix("bop", "animation bop 1", 24, false);
```
That's it, a lot of the changes here involving adding 1 character (sometimes a few more) to 1 line. This fixes 95% of the issues caused by upgrading.

## Other Changes
`MusicBeatState.switchState`/`resetState` have been removed in order for an easier to understand solution through overriding `MusicBeatState.onOutroComplete`.
Fixed a bug in `CharacterEditorState` where the main camera would not render in release mode.