### PR TITLE
Building documentation fixes plus some additions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,7 +75,9 @@ sudo emerge --ask dev-vcs/git-sh dev-lang/haxe media-video/vlc
 
 Open a terminal or command prompt window in the root directory of this repository.
 
-For building the game, in every system, you're going to execute `haxelib newrepo`.
+For building the game, in every system, you're going to execute `haxelib setup`.
+
+In Mac and Linux, you need to create a folder to put your Haxe libraries in, do `mkdir ~/haxelib && haxelib setup ~/haxelib`.
 
 Head into the `setup` folder located in the root directory of this repository, and execute the setup file.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,15 +53,12 @@ Commands will vary depending on your distro, refer to your package manager's ins
 sudo add-apt-repository ppa:haxe/releases -y
 sudo apt update
 sudo apt install haxe libvlc-dev libvlccore-dev -y
-mkdir ~/haxelib && haxelib setup ~/haxelib
 ```
 
 #### Arch based Distros:
 
 ```bash
 sudo pacman -Syu haxe git vlc --noconfirm
-mkdir ~/haxelib;
-haxelib setup ~/haxelib
 ```
 
 #### Gentoo:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,63 +5,68 @@
 
 ---
 
-### Dependencies
+# Dependencies
 
 - `git`
-- (Windows-only) Microsoft Visual Studio Community
-- (Linux-only) VLC
-- Haxe (4.2.5 or greater)
+- (Windows only) Microsoft Visual Studio Community 2022
+- (Linux only) VLC
+- Haxe (4.3.4 or greater)
 
 ---
 
 ### Windows & Mac
 
-For `git`, you're likely gonna want [git-scm](https://git-scm.com/downloads),
-and download their binary executable through there
+For `git`, you're gonna want [git-scm](https://git-scm.com/downloads), download their binary executable there
+
 For Haxe, you can get it from [the Haxe website](https://haxe.org/download/)
 
 ---
 
 **(Next step is Windows only, Mac users may skip this)**
 
-After installing `git`, it is RECOMMENDED that you
-open up a command prompt window and type the following
+After installing `git`, open a command prompt window and enter the following:
 
-```
+```batch
 curl -# -O https://download.visualstudio.microsoft.com/download/pr/3105fcfe-e771-41d6-9a1c-fc971e7d03a7/8eb13958dc429a6e6f7e0d6704d43a55f18d02a253608351b6bf6723ffdaf24e/vs_Community.exe
 vs_Community.exe --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 -p
 ```
 
-this will use `curl`, which is a tool for downloading certain files through the command-line,
-to Download the binary for Microsoft Visual Studio with the specific package you need for compiling on Windows.
+This will use `curl`, which is a tool for downloading certain files through your command prompt,
+to download the binary for Microsoft Visual Studio with the specific packages you need for compiling on Windows.
 
-(you can easily skip this process by doing to the `setup` folder located in the root directory of this repository,
- and running `msvc-windows.bat`)
+(If you wish to not do this manually, go to the `setup` folder located in the root directory of this repository, and run `msvc-windows.bat`)
 
 ---
 ### Linux Distributions
 
-For getting all the packages you need, distros often have similar or near identical names
+For getting all the packages you need, distros often have similar or near identical package names 
 
-for pretty much every distro, install the `git`, `haxe`, and `vlc` packages
+For building on Linux, you need to install the `git`, `haxe`, and `vlc` packages
 
 Commands will vary depending on your distro, refer to your package manager's install command syntax.
+
 ### Installation for common Linux distros
+
 #### Ubuntu/Debian based Distros:
+
 ```bash
 sudo add-apt-repository ppa:haxe/releases -y
 sudo apt update
 sudo apt install haxe libvlc-dev libvlccore-dev -y
 mkdir ~/haxelib && haxelib setup ~/haxelib
 ```
+
 #### Arch based Distros:
+
 ```bash
 sudo pacman -Syu haxe git vlc --noconfirm
 mkdir ~/haxelib;
 haxelib setup ~/haxelib
 ```
+
 #### Gentoo:
-```
+
+```bash
 sudo emerge --ask dev-vcs/git-sh dev-lang/haxe media-video/vlc
 ```
 
@@ -71,37 +76,34 @@ sudo emerge --ask dev-vcs/git-sh dev-lang/haxe media-video/vlc
 
 # Building
 
-for Building the actual game, in pretty much EVERY system, you're going to want to execute `haxelib setup`
+Open a terminal or command prompt window in the root directory of this repository.
 
-particularly in Mac and Linux, you may need to create a folder to put your haxe stuff into, try `mkdir ~/haxelib && haxelib setup ~/haxelib`
+For building the game, in every system, you're going to execute `haxelib newrepo`.
 
-head into the `setup` folder located in the root directory of this repository, and execute the `setup` file
+Head into the `setup` folder located in the root directory of this repository, and execute the setup file.
 
 ### "Which setup file?"
 
-It depends on your Operating System, for Windows, run `windows.bat`, for anything else, `unix.sh`
+It depends on your operating system. For Windows, run `windows.bat`, for anything else, run `unix.sh`.
 
-sit back, relax, wait for haxelib to do its magic, and once everything is done, run
+Sit back, relax, and wait for haxelib to do its magic. You will be done when you see the word "**Finished!**"
 
-`lime test <platform>`
-
-where `<platform>` gets replaced with `windows`, `linux`, or `mac`
+To build the game, run `lime test <platform>`, where `<platform>` gets replaced with `windows`, `linux`, or `mac` respectively.
 
 ---
 
 ### "It's taking a while, should I be worried?"
 
-No, that is normal, when you compile flixel games for the first time, it usually takes around 5 to 10 minutes,
-it really depends on how powerful your hrdware is
-
-### "I had an error saying that 'hxCodec' could not be found!"
-
-Refer to Issue ShadowMario/FNF-PsychEngine#12770.
+No, it's completely normal. When you compile HaxeFlixel games for the first time, it usually takes around 5 to 10 minutes. It depends on how powerful your hardware is.
 
 ### "I had an error relating to g++ on Linux!"
 
 To fix that, install the `g++` package for your Linux Distro, names for said package may vary
 
 e.g: Fedora is `gcc-c++`, Gentoo is `sys-devel/gcc`, and so on.
+
+### "I have an error saying ApplicationMain.exe : fatal error LNK1120: 1 unresolved externals!"
+
+Run `lime test <platform> -clean` again, or delete the export folder and compile again.
 
 ---

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -75,7 +75,7 @@ sudo emerge --ask dev-vcs/git-sh dev-lang/haxe media-video/vlc
 
 Open a terminal or command prompt window in the root directory of this repository.
 
-For building the game, in every system, you're going to execute `haxelib setup`.
+For building the game, in every system, you're going to execute `haxelib setup`. If you are asked to enter the name of the haxelib repository, type `.haxelib`.
 
 In Mac and Linux, you need to create a folder to put your Haxe libraries in, do `mkdir ~/haxelib && haxelib setup ~/haxelib`.
 
@@ -87,7 +87,7 @@ It depends on your operating system. For Windows, run `windows.bat`, for anythin
 
 Sit back, relax, and wait for haxelib to do its magic. You will be done when you see the word "**Finished!**"
 
-To build the game, run `lime test <platform>`, where `<platform>` gets replaced with `windows`, `linux`, or `mac` respectively.
+To build the game, run `lime test cpp`.
 
 ---
 
@@ -103,6 +103,6 @@ e.g: Fedora is `gcc-c++`, Gentoo is `sys-devel/gcc`, and so on.
 
 ### "I have an error saying ApplicationMain.exe : fatal error LNK1120: 1 unresolved externals!"
 
-Run `lime test <platform> -clean` again, or delete the export folder and compile again.
+Run `lime test cpp -clean` again, or delete the export folder and compile again.
 
 ---

--- a/Project.xml
+++ b/Project.xml
@@ -39,7 +39,7 @@
 	<!-- ____________________________ Window Settings ___________________________ -->
 
 	<!--These window settings apply to all targets-->
-	<window width="1280" height="720" fps="" background="#000000" hardware="true" vsync="false" />
+	<window width="1280" height="720" fps="60" background="#000000" hardware="true" vsync="false" />
 
 	<!--HTML5-specific-->
 	<window if="html5" resizable="true" />
@@ -164,6 +164,10 @@
 	
 	<!--Disable deprecated warnings-->
 	<haxedef name='no-deprecation-warnings' />
+
+	<!-- Haxe 4.3.0+: Enable pretty syntax errors and stuff. -->
+	<!-- pretty (haxeflixel default), indent, classic (haxe compiler default) -->
+	<haxedef name="message.reporting" value="pretty" />
 
 	<!--Macro fixes-->
 	<haxeflag name="--macro" value="allowPackage('flash')" />

--- a/setup/read_this_if_you_cant_compile.html
+++ b/setup/read_this_if_you_cant_compile.html
@@ -1,0 +1,5 @@
+<!-- https://github.com/ShadowMario/FNF-PsychEngine/wiki/Libraries-versions -->
+
+<script>
+    window.location.href = 'https://github.com/ShadowMario/FNF-PsychEngine/wiki/Libraries-versions';
+</script>

--- a/setup/read_this_if_you_cant_compile.txt
+++ b/setup/read_this_if_you_cant_compile.txt
@@ -1,1 +1,0 @@
-https://github.com/ShadowMario/FNF-PsychEngine/wiki/Libraries-versions

--- a/setup/unix.sh
+++ b/setup/unix.sh
@@ -2,6 +2,7 @@
 # SETUP FOR MAC AND LINUX SYSTEMS!!!
 # REMINDER THAT YOU NEED HAXE INSTALLED PRIOR TO USING THIS
 # https://haxe.org/download
+cd ..
 echo Installing dependencies...
 echo This might take a few moments depending on your internet speed.
 haxelib install lime 8.1.2


### PR DESCRIPTION
- markdown syntax fixes
- grammar fixes
- removed words like "likely," "recommended," "may," "going to want," "pretty much," which do not explicitly state a requirement and prompting users to skip them if they want
- unix setup cd command added
- added lime test platform -clean error guide.
- added haxe pretty message reporting (it's actually really good)
- changed the recommended haxe version to 4.3.4
- changes the `setup/read_this_if_you_cant_compile.txt` file to an html redirect
- added a hxcpp debug server extension fix
- removed the issue link since hxCodec is no longer used (?)

if theres anything wrong please tell