### PR TITLE
Bool value fix for "Set Property" event

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -2215,11 +2215,16 @@ class PlayState extends MusicBeatState
 			case 'Set Property':
 				try
 				{
+					var trueValue:Dynamic = value2.trim();
+					if (trueValue == 'true' || trueValue == 'false') trueValue = trueValue == 'true';
+					else if (flValue2 != null) trueValue = flValue2;
+					else trueValue = value2;
+
 					var split:Array<String> = value1.split('.');
 					if(split.length > 1) {
-						LuaUtils.setVarInArray(LuaUtils.getPropertyLoop(split), split[split.length-1], value2);
+						LuaUtils.setVarInArray(LuaUtils.getPropertyLoop(split), split[split.length-1], trueValue);
 					} else {
-						LuaUtils.setVarInArray(this, value1, value2);
+						LuaUtils.setVarInArray(this, value1, trueValue);
 					}
 				}
 				catch(e:Dynamic)


### PR DESCRIPTION
Changes the event to use a variable that is actually a bool since they don't work correctly when as a string

Also used parsed floats for numbers
I don't think it's necessary, but just to be safe