### PR TITLE
Note Splash Editor Improvements

### DIFF
--- a/assets/shared/images/noteSplashes/noteSplashes-diamond.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-diamond.json
@@ -113,6 +113,7 @@
 			"indices": []
 		}
 	},
-	"affectedByShader": true,
+	"allowRGB": true,
+	"allowPixel": true,
 	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-diamond.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-diamond.json
@@ -6,9 +6,11 @@
 				95,
 				68
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond purple 10",
-			"minFps": 22,
 			"name": "purple",
 			"indices": []
 		},
@@ -18,9 +20,11 @@
 				106,
 				60
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond blue 20",
-			"minFps": 22,
 			"name": "blue2",
 			"indices": []
 		},
@@ -30,9 +34,11 @@
 				106,
 				60
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond red 20",
-			"minFps": 22,
 			"name": "red2",
 			"indices": []
 		},
@@ -42,9 +48,11 @@
 				95,
 				68
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond red 10",
-			"minFps": 22,
 			"name": "red",
 			"indices": []
 		},
@@ -54,9 +62,11 @@
 				106,
 				60
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond purple 20",
-			"minFps": 22,
 			"name": "purple2",
 			"indices": []
 		},
@@ -66,9 +76,11 @@
 				95,
 				68
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond blue 10",
-			"minFps": 22,
 			"name": "blue",
 			"indices": []
 		},
@@ -78,9 +90,11 @@
 				106,
 				60
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond green 20",
-			"minFps": 22,
 			"name": "green2",
 			"indices": []
 		},
@@ -90,16 +104,15 @@
 				95,
 				68
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "note splash diamond green 10",
-			"minFps": 22,
 			"name": "green",
 			"indices": []
 		}
 	},
 	"affectedByShader": true,
-	"scale": [
-		1,
-		1
-	]
+	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-electric.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-electric.json
@@ -6,11 +6,13 @@
 				62
 			],
 			"noteData": 0,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash electro purple 10",
 			"indices": [],
-			"name": "purple",
-			"minFps": 22
+			"name": "purple"
 		},
 		"blue": {
 			"offsets": [
@@ -18,11 +20,13 @@
 				62
 			],
 			"noteData": 1,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash electro blue 10",
 			"indices": [],
-			"name": "blue",
-			"minFps": 22
+			"name": "blue"
 		},
 		"red": {
 			"offsets": [
@@ -30,11 +34,13 @@
 				62
 			],
 			"noteData": 3,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash electro red 10",
 			"indices": [],
-			"name": "red",
-			"minFps": 22
+			"name": "red"
 		},
 		"green": {
 			"offsets": [
@@ -42,11 +48,13 @@
 				62
 			],
 			"noteData": 2,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash electro green 10",
 			"indices": [],
-			"name": "green",
-			"minFps": 22
+			"name": "green"
 		}
 	},
 	"affectedByShader": true,
@@ -63,8 +71,5 @@
 		},
 		null
 	],
-	"scale": [
-		1,
-		1
-	]
+	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-electric.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-electric.json
@@ -57,7 +57,8 @@
 			"name": "green"
 		}
 	},
-	"affectedByShader": true,
+	"allowRGB": true,
+	"allowPixel": true,
 	"rgb": [
 		{
 			"b": 0,

--- a/assets/shared/images/noteSplashes/noteSplashes-sparkles.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-sparkles.json
@@ -6,11 +6,13 @@
 				68
 			],
 			"noteData": 1,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash sparkles blue 10",
 			"indices": [],
-			"name": "blue",
-			"minFps": 22
+			"name": "blue"
 		},
 		"purple": {
 			"offsets": [
@@ -18,23 +20,27 @@
 				68
 			],
 			"noteData": 0,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash sparkles purple 10",
 			"indices": [],
-			"name": "purple",
-			"minFps": 22
+			"name": "purple"
 		},
 		"green": {
 			"prefix": "splash sparkles green 10",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				70,
 				70
 			],
 			"indices": [],
 			"name": "green",
-			"noteData": 2,
-			"minFps": 22
+			"noteData": 2
 		},
 		"red": {
 			"offsets": [
@@ -42,16 +48,15 @@
 				68
 			],
 			"noteData": 3,
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "splash sparkles red 10",
 			"indices": [],
-			"name": "red",
-			"minFps": 22
+			"name": "red"
 		}
 	},
 	"affectedByShader": true,
-	"scale": [
-		1,
-		1
-	]
+	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-sparkles.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-sparkles.json
@@ -57,6 +57,7 @@
 			"name": "red"
 		}
 	},
-	"affectedByShader": true,
+	"allowRGB": true,
+	"allowPixel": true,
 	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-vanilla.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-vanilla.json
@@ -113,6 +113,7 @@
 			"indices": []
 		}
 	},
-	"affectedByShader": true,
+	"allowRGB": true,
+	"allowPixel": true,
 	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-vanilla.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-vanilla.json
@@ -6,9 +6,11 @@
 				95,
 				105
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash purple 10",
-			"minFps": 22,
 			"name": "purple",
 			"indices": []
 		},
@@ -18,9 +20,11 @@
 				105,
 				90
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash blue 20",
-			"minFps": 22,
 			"name": "blue2",
 			"indices": []
 		},
@@ -30,9 +34,11 @@
 				95,
 				100
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash red 20",
-			"minFps": 22,
 			"name": "red2",
 			"indices": []
 		},
@@ -42,9 +48,11 @@
 				80,
 				100
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash red 10",
-			"minFps": 22,
 			"name": "red",
 			"indices": []
 		},
@@ -54,9 +62,11 @@
 				105,
 				90
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash purple 20",
-			"minFps": 22,
 			"name": "purple2",
 			"indices": []
 		},
@@ -66,9 +76,11 @@
 				87,
 				103
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash blue 10",
-			"minFps": 22,
 			"name": "blue",
 			"indices": []
 		},
@@ -78,9 +90,11 @@
 				94,
 				100
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash green 20",
-			"minFps": 22,
 			"name": "green2",
 			"indices": []
 		},
@@ -90,16 +104,15 @@
 				90,
 				100
 			],
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"prefix": "vanilla splash green 10",
-			"minFps": 22,
 			"name": "green",
 			"indices": []
 		}
 	},
 	"affectedByShader": true,
-	"scale": [
-		1,
-		1
-	]
+	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes.json
+++ b/assets/shared/images/noteSplashes/noteSplashes.json
@@ -113,6 +113,7 @@
 			"noteData": 6
 		}
 	},
-	"affectedByShader": true,
+	"allowRGB": true,
+	"allowPixel": true,
 	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes.json
+++ b/assets/shared/images/noteSplashes/noteSplashes.json
@@ -2,104 +2,117 @@
 	"animations": {
 		"blue2": {
 			"prefix": "note splash blue 20",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				70,
 				76
 			],
 			"indices": [],
 			"name": "blue2",
-			"noteData": 5,
-			"minFps": 22
+			"noteData": 5
 		},
 		"purple": {
 			"prefix": "note splash purple 10",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				60,
 				60
 			],
 			"indices": [],
 			"name": "purple",
-			"noteData": 0,
-			"minFps": 22
+			"noteData": 0
 		},
 		"red": {
 			"prefix": "note splash red 10",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				57,
 				58
 			],
 			"indices": [],
 			"name": "red",
-			"noteData": 3,
-			"minFps": 22
+			"noteData": 3
 		},
 		"red2": {
 			"prefix": "note splash red 20",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				66,
 				80
 			],
 			"indices": [],
 			"name": "red2",
-			"noteData": 7,
-			"minFps": 22
+			"noteData": 7
 		},
 		"blue": {
 			"prefix": "note splash blue 10",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				55,
 				60
 			],
 			"indices": [],
 			"name": "blue",
-			"noteData": 1,
-			"minFps": 22
+			"noteData": 1
 		},
 		"purple2": {
 			"prefix": "note splash purple 20",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				76,
 				80
 			],
 			"indices": [],
 			"name": "purple2",
-			"noteData": 4,
-			"minFps": 22
+			"noteData": 4
 		},
 		"green": {
 			"prefix": "note splash green 10",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				57,
 				61
 			],
 			"indices": [],
 			"name": "green",
-			"noteData": 2,
-			"minFps": 22
+			"noteData": 2
 		},
 		"green2": {
 			"prefix": "note splash green 20",
-			"maxFps": 26,
+			"fps": [
+				22,
+				26
+			],
 			"offsets": [
 				70,
 				80
 			],
 			"indices": [],
 			"name": "green2",
-			"noteData": 6,
-			"minFps": 22
+			"noteData": 6
 		}
 	},
 	"affectedByShader": true,
-	"scale": [
-		1,
-		1
-	]
+	"scale": 1
 }

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -58,14 +58,14 @@ class NoteSplash extends FlxSprite
 	{
 		config = null; // Reset config to the default so when reloaded it can be set properly
 		skin = null;
-		
+
 		var skin:String = splash;
 		if (skin == null || skin.length < 1)
 			skin = try PlayState.SONG.splashSkin catch(e) null;
 
 		if (skin == null || skin.length < 1)
 			skin = DEFAULT_SKIN + getSplashSkinPostfix();
-		
+
 		this.skin = skin;
 
 		try frames = Paths.getSparrowAtlas(skin) catch (e) {
@@ -77,8 +77,7 @@ class NoteSplash extends FlxSprite
 		}
 
 		var path:String = 'images/$skin.json';
-		if (configs.exists(path))
-			this.config = configs.get(path);
+		if (configs.exists(path)) this.config = configs.get(path);
 		else if (Paths.fileExists(path, TEXT))
 		{
 			var config:Dynamic = haxe.Json.parse(Paths.getTextFromFile(path));
@@ -185,20 +184,17 @@ class NoteSplash extends FlxSprite
 						tempShader = new RGBPalette();
 						for (i in 0...colors.length)
 						{
-							if (i > 2)
-								break;
+							if (i > 2) break;
 
-							var rgb = colors[i];
 							var arr:Array<FlxColor> = ClientPrefs.data.arrowRGB[noteData % 4];
 							if(PlayState.isPixelStage) arr = ClientPrefs.data.arrowRGBPixel[noteData % 4];
+
+							var rgb = colors[i];
 							if (rgb == null)
 							{
-								if (i == 0)
-									tempShader.r = arr[0];
-								else if (i == 1)
-									tempShader.g = arr[1];
-								else if (i == 2)
-									tempShader.b = arr[2];
+								if (i == 0) tempShader.r = arr[0];
+								else if (i == 1) tempShader.g = arr[1];
+								else if (i == 2) tempShader.b = arr[2];
 								continue;
 							}
 
@@ -206,20 +202,14 @@ class NoteSplash extends FlxSprite
 							var g:Null<Int> = rgb.g;
 							var b:Null<Int> = rgb.b;
 
-							if (r == null || Math.isNaN(r) || r < 0)
-								r = arr[0];
-							if (g == null || Math.isNaN(g) || g < 0)
-								g = arr[1];
-							if (b == null || Math.isNaN(b) || b < 0)
-								b = arr[2];
+							if (r == null || Math.isNaN(r) || r < 0) r = arr[0];
+							if (g == null || Math.isNaN(g) || g < 0) g = arr[1];
+							if (b == null || Math.isNaN(b) || b < 0) b = arr[2];
 
 							var color:FlxColor = FlxColor.fromRGB(r, g, b);
-							if (i == 0)
-								tempShader.r = color;
-							else if (i == 1)
-								tempShader.g = color;
-							else if (i == 2)
-								tempShader.b = color;
+							if (i == 0) tempShader.r = color;
+							else if (i == 1) tempShader.g = color;
+							else if (i == 2) tempShader.b = color;
 						} 
 					}
 					else useDefault();
@@ -232,8 +222,10 @@ class NoteSplash extends FlxSprite
 
 		var conf = config.animations.get(anim);
 		var offsets:Array<Float> = [0, 0];
+
 		if (conf != null)
 			offsets = conf.offsets;
+
 		if (offsets != null)
 		{
 			centerOffsets();
@@ -254,11 +246,11 @@ class NoteSplash extends FlxSprite
 		if(animation.curAnim != null && conf != null)
 		{
 			var minFps = conf.fps[0];
-			if (minFps < 0)
-				minFps = 0;
+			if (minFps < 0) minFps = 0;
+
 			var maxFps = conf.fps[1];
-			if (maxFps < 0)
-				maxFps = 0;
+			if (maxFps < 0) maxFps = 0;
+
 			animation.curAnim.frameRate = FlxG.random.int(minFps, maxFps);
 		}
 	}
@@ -294,8 +286,7 @@ class NoteSplash extends FlxSprite
 
 	public static function addAnimationToConfig(config:NoteSplashConfig, scale:Float, name:String, prefix:String, fps:Array<Int>, offsets:Array<Float>, indices:Array<Int>, noteData:Int):NoteSplashConfig
 	{
-		if (config == null)
-			config = createConfig();
+		if (config == null) config = createConfig();
 
 		config.animations.set(name, {name: name, noteData: noteData, prefix: prefix, indices: indices, offsets: offsets, fps: fps});
 		config.scale = scale;
@@ -304,8 +295,7 @@ class NoteSplash extends FlxSprite
 
 	function set_config(value:NoteSplashConfig):NoteSplashConfig 
 	{
-		if (value == null)
-			value = createConfig();
+		if (value == null) value = createConfig();
 
 		noteDataMap.clear();
 
@@ -318,9 +308,11 @@ class NoteSplash extends FlxSprite
 					animation.addByIndices(key, i.prefix, i.indices, "", i.fps[1], false);
 				else
 					animation.addByPrefix(key, i.prefix, i.fps[1], false);
+
 				noteDataMap.set(i.noteData, key);
 			}
 		}
+
 		scale.set(value.scale, value.scale);
 		return config = value;
 	}
@@ -329,15 +321,12 @@ class NoteSplash extends FlxSprite
 class PixelSplashShaderRef 
 {
 	public var shader:PixelSplashShader = new PixelSplashShader();
+	public var enabled(default, set):Bool = true;
 	public var pixelAmount(default, set):Float = 1;
 
 	public function copyValues(tempShader:RGBPalette)
 	{
-		var enabled:Bool = false;
 		if(tempShader != null)
-			enabled = true;
-
-		if(enabled)
 		{
 			for (i in 0...3)
 			{
@@ -350,9 +339,11 @@ class PixelSplashShaderRef
 		else shader.mult.value[0] = 0.0;
 	}
 
-	public function set(enabled:Bool = true)
+	public function set_enabled(value:Bool)
 	{
-		shader.mult.value = [enabled ? 1 : 0];
+		enabled = value;
+		shader.mult.value = [value ? 1 : 0];
+		return value;
 	}
 
 	public function set_pixelAmount(value:Float)
@@ -372,7 +363,7 @@ class PixelSplashShaderRef
 	public function new()
 	{
 		reset();
-		set();
+		enabled = true;
 
 		if(!PlayState.isPixelStage) pixelAmount = 1;
 		else pixelAmount = PlayState.daPixelZoom;
@@ -384,7 +375,7 @@ class PixelSplashShader extends FlxShader
 {
 	@:glFragmentHeader('
 		#pragma header
-		
+
 		uniform vec3 r;
 		uniform vec3 g;
 		uniform vec3 b;
@@ -405,9 +396,9 @@ class PixelSplashShader extends FlxShader
 			vec4 newColor = color;
 			newColor.rgb = min(color.r * r + color.g * g + color.b * b, vec3(1.0));
 			newColor.a = color.a;
-			
+
 			color = mix(color, newColor, mult);
-			
+
 			if(color.a > 0.0) {
 				return vec4(color.rgb, color.a);
 			}

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -26,7 +26,8 @@ private typedef NoteSplashAnim = {
 typedef NoteSplashConfig = {
 	animations:Map<String, NoteSplashAnim>,
 	scale:Float,
-	affectedByShader:Bool,
+	allowRGB:Bool,
+	allowPixel:Bool,
 	rgb:Array<Null<RGB>>
 }
 
@@ -86,7 +87,8 @@ class NoteSplash extends FlxSprite
 				var tempConfig:NoteSplashConfig = {
 					animations: new Map(),
 					scale: config.scale,
-					affectedByShader: config.affectedByShader,
+					allowRGB: config.allowRGB,
+					allowPixel: config.allowPixel,
 					rgb: config.rgb
 				}
 
@@ -161,7 +163,7 @@ class NoteSplash extends FlxSprite
 		playDefaultAnim();
 
 		var tempShader:RGBPalette = null;
-		if (config.affectedByShader)
+		if (config.allowRGB)
 		{
 			if (note == null)
 				note = new Note(0, noteData);
@@ -217,8 +219,9 @@ class NoteSplash extends FlxSprite
 				else useDefault();
 			}
 		}
-		else tempShader = new RGBPalette();
 		rgbShader.copyValues(tempShader);
+
+		if(!config.allowPixel) rgbShader.pixelAmount = 1;
 
 		var conf = config.animations.get(anim);
 		var offsets:Array<Float> = [0, 0];
@@ -279,7 +282,8 @@ class NoteSplash extends FlxSprite
 		return {
 			animations: new Map(),
 			scale: 1,
-			affectedByShader: true,
+			allowRGB: true,
+			allowPixel: true,
 			rgb: null
 		}
 	}
@@ -336,7 +340,7 @@ class PixelSplashShaderRef
 			}
 			shader.mult.value[0] = tempShader.shader.mult.value[0];
 		}
-		else shader.mult.value[0] = 0.0;
+		else enabled = false;
 	}
 
 	public function set_enabled(value:Bool)

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -335,7 +335,7 @@ class LoadingState extends MusicBeatState
 			var noteSplash:String = NoteSplash.DEFAULT_SKIN;
 			if(PlayState.SONG.splashSkin != null && PlayState.SONG.splashSkin.length > 0) noteSplash = PlayState.SONG.splashSkin;
 			else noteSplash += NoteSplash.getSplashSkinPostfix();
-			imagesToPrepare.push("noteSplashes/" + noteSplash);
+			imagesToPrepare.push(noteSplash);
 
 			try
 			{

--- a/source/states/editors/NoteSplashEditorState.hx
+++ b/source/states/editors/NoteSplashEditorState.hx
@@ -373,7 +373,7 @@ class NoteSplashEditorState extends MusicBeatState
 
         ui.add(allowRGBCheck);
 
-        var allowPixelCheck:PsychUICheckBox = new PsychUICheckBox(allowRGBCheck.x + 150, allowRGBCheck.y, "", 1);
+        var allowPixelCheck:PsychUICheckBox = new PsychUICheckBox(allowRGBCheck.x + 110, allowRGBCheck.y, "", 1);
         function check()
         {
             if (config != null)

--- a/source/states/editors/NoteSplashEditorState.hx
+++ b/source/states/editors/NoteSplashEditorState.hx
@@ -1,21 +1,16 @@
 package states.editors;
 
-import openfl.net.FileFilter;
 import objects.Note;
 import objects.NoteSplash;
 import objects.StrumNote;
-import flixel.FlxSprite;
+
+import openfl.net.FileFilter;
 import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 import flixel.input.keyboard.FlxKey;
-import flixel.text.FlxText;
-import flixel.tweens.FlxTween;
-import flixel.util.FlxColor;
-import haxe.Json;
 import openfl.events.Event;
 import openfl.events.IOErrorEvent;
 import openfl.net.FileReference;
-
-using StringTools;
+import haxe.Json;
 
 @:access(objects.NoteSplash)
 class NoteSplashEditorState extends MusicBeatState
@@ -23,22 +18,18 @@ class NoteSplashEditorState extends MusicBeatState
     var strums:FlxTypedSpriteGroup<StrumNote> = new FlxTypedSpriteGroup();
     var splashes:FlxTypedSpriteGroup<NoteSplash> = new FlxTypedSpriteGroup();
     var config = NoteSplash.createConfig();
+
     var tipText:FlxText;
     var errorText:FlxText;
     var curText:FlxText;
 
     static var imageSkin:String = null;
-
     var splash:NoteSplash;
 
     var UI:PsychUIBox;
     var properUI:PsychUIBox;
     var shaderUI:PsychUIBox;
-    var noteData:Int;
 
-    var curType:String;
-
-    var currentNoteType:PsychUIInputText;
     override function create()
     {
         if (imageSkin == null)
@@ -92,7 +83,6 @@ class NoteSplashEditorState extends MusicBeatState
             babyArrow.postAddedToGroup();
             babyArrow.screenCenter(Y);
             babyArrow.ID = i;
-            //babyArrow.scale.scale(1.1, 1.1);
             strums.add(babyArrow);
         }
         
@@ -158,11 +148,11 @@ class NoteSplashEditorState extends MusicBeatState
         UI.add(indices_input);
 
         UI.add(new FlxText(20, 110, 0, "Minimum FPS:"));
-        var minFps:PsychUINumericStepper = new PsychUINumericStepper(20, 127.5, 1, 24, 1, 120);
+        var minFps:PsychUINumericStepper = new PsychUINumericStepper(20, 127.5, 1, 22, 1, 120);
         UI.add(minFps);
 
         UI.add(new FlxText(150, 110, 0, "Maximum FPS:"));
-        var maxFps:PsychUINumericStepper = new PsychUINumericStepper(150, 127.5, 1, 24, 1, 120);
+        var maxFps:PsychUINumericStepper = new PsychUINumericStepper(150, 127.5, 1, 26, 1, 120);
         UI.add(maxFps);
 
         animDropDown = new PsychUIDropDownMenu(-155, 57, [""], function(id:Int, name:String)
@@ -177,8 +167,8 @@ class NoteSplashEditorState extends MusicBeatState
                     numericStepperData.min = 0;     
                     numericStepperData.value = i.noteData;
                     curAnim = name;
-                    minFps.value = i.minFps;
-                    maxFps.value = i.maxFps;
+                    minFps.value = i.fps[0];
+                    maxFps.value = i.fps[1];
                     if (i.indices != null && i.indices.length > 0)
                     {
                         indices_input.text = i.indices.toString().substring(1, i.indices.toString().length - 2);
@@ -221,8 +211,8 @@ class NoteSplashEditorState extends MusicBeatState
             prefix_input.text = "";        
             indices_input.text = "";  
             numericStepperData.value = 0;
-            minFps.value = 24;
-            maxFps.value = 24;
+            minFps.value = 22;
+            maxFps.value = 26;
             setAnimDropDown();
             parseRGB();
             changeShader.selectedLabel = "Red";
@@ -244,7 +234,7 @@ class NoteSplashEditorState extends MusicBeatState
                 }
             }
 
-            var offsets = [0, 0];
+            var offsets:Array<Float> = [0, 0];
             var conf = config.animations.get(name_input.text);
             if (conf != null)
                 offsets = conf.offsets;
@@ -253,7 +243,7 @@ class NoteSplashEditorState extends MusicBeatState
             else 
                 offsets = offsets.copy();
 
-            config = NoteSplash.addAnimationToConfig([scaleXNumericStepper.value, scaleYNumericStepper.value], config, name_input.text, prefix_input.text, cast minFps.value, cast maxFps.value, offsets, indices, cast numericStepperData.value);
+            config = NoteSplash.addAnimationToConfig(config, scaleNumericStepper.value, name_input.text, prefix_input.text, [cast minFps.value, cast maxFps.value], offsets, indices, cast numericStepperData.value);
             curAnim = name_input.text;
             playStrumAnim(curAnim, cast numericStepperData.value);
             setAnimDropDown();
@@ -294,10 +284,10 @@ class NoteSplashEditorState extends MusicBeatState
 
             errorText.color = FlxColor.RED;
             FlxTween.cancelTweensOf(errorText);
-            var image = Paths.image("noteSplashes/" + imageSkin);
+            var image = Paths.image(imageSkin);
             if (image == null)
             {
-                errorText.text = "ERROR! Couldn't find noteSplashes/" + imageSkin + ".png";
+                errorText.text = 'ERROR! Couldn\'t find $imageSkin.png';
                 errorText.alpha = 1;
                 return;
             }
@@ -305,7 +295,7 @@ class NoteSplashEditorState extends MusicBeatState
             {
                 errorText.color = FlxColor.GREEN;
                 errorText.alpha = 1;
-                errorText.text = "Succesfully loaded noteSplashes/" + imageSkin + ".png";
+                errorText.text = 'Succesfully loaded $imageSkin.png';
             }
             NoteSplash.configs.clear();
             FlxTween.tween(errorText, {alpha: 0}, 1, {startDelay: 1, onComplete: (twn) -> {
@@ -324,8 +314,8 @@ class NoteSplashEditorState extends MusicBeatState
             prefix_input.text = "";        
             indices_input.text = "";  
             numericStepperData.value = 0;
-            minFps.value = 24;
-            maxFps.value = 24;
+            minFps.value = 22;
+            maxFps.value = 26;
             setAnimDropDown();
             parseRGB();
             changeShader.selectedLabel = "Red";
@@ -334,8 +324,7 @@ class NoteSplashEditorState extends MusicBeatState
     }
 
     var imageInputText:PsychUIInputText;
-    var scaleXNumericStepper:PsychUINumericStepper;
-    var scaleYNumericStepper:PsychUINumericStepper;
+    var scaleNumericStepper:PsychUINumericStepper;
     function addProperitiesTab()
     {
         var ui = properUI.getTab("Properties").menu;
@@ -350,12 +339,12 @@ class NoteSplashEditorState extends MusicBeatState
         });
         ui.add(reloadButton);
 
-        ui.add(new FlxText(20, 40, "Scale X / Y:"));
-        scaleXNumericStepper = new PsychUINumericStepper(20, 57.5, 0.25, 1, 0, 4, 2, 60);
-        ui.add(scaleXNumericStepper);
+        ui.add(new FlxText(20, 40, "Scale:"));
+        scaleNumericStepper = new PsychUINumericStepper(20, 57.5, 0.1, 1, 0, 4, 2, 60);
+        ui.add(scaleNumericStepper);
 
-        scaleYNumericStepper = new PsychUINumericStepper(20, 75, 0.25, 1, 0, 4, 2, 60);
-        ui.add(scaleYNumericStepper);
+        scaleNumericStepper.value = config != null ? config.scale : 1;
+
         ui.add(new FlxText(130, 40, "Animations:"));
 
         var saveButton:PsychUIButton = new PsychUIButton(20, 130, "Save", saveSplash);
@@ -366,12 +355,6 @@ class NoteSplashEditorState extends MusicBeatState
 
         var loadButton:PsychUIButton = new PsychUIButton(180, 155, "Convert TXT", loadTxt);
         ui.add(loadButton);
-
-        if (config != null && config.scale != null)
-        {
-            scaleXNumericStepper.value = config.scale[0];
-            scaleYNumericStepper.value = config.scale[1];
-        }
 
         var getsAffectedByShader:PsychUICheckBox = new PsychUICheckBox(20, 105, "", 1);
         function check()
@@ -500,7 +483,7 @@ class NoteSplashEditorState extends MusicBeatState
         //
     }
 
-    var copiedOffset:Array<Int> = [0, 0];
+    var copiedOffset:Array<Float> = [0, 0];
     override function update(elapsed:Float)
     { 
         super.update(elapsed);
@@ -511,7 +494,7 @@ class NoteSplashEditorState extends MusicBeatState
         curText.text += 'Current Animation: ${curAnim == null || curAnim.length < 1  ? "NONE" : curAnim}';
         if (config != null && !curText.text.contains('NONE'))
         {
-            var offsets:Array<Int> = try config.animations.get(curAnim).offsets catch (e) [0, 0];
+            var offsets:Array<Float> = try config.animations.get(curAnim).offsets catch (e) [0, 0];
             curText.text += ' ($offsets)'.replace(',', ', ');
         }
 
@@ -527,8 +510,7 @@ class NoteSplashEditorState extends MusicBeatState
                 addButton.label = 'Add';
             }
 
-            config.scale[0] = scaleXNumericStepper.value;
-            config.scale[1] = scaleYNumericStepper.value;
+            config.scale = scaleNumericStepper.value;
         }
 
         if (FlxG.keys.pressed.CONTROL)
@@ -562,28 +544,51 @@ class NoteSplashEditorState extends MusicBeatState
                 }
             }
 
-            var multiplier:Int = FlxG.keys.pressed.SHIFT ? 10 : 1;
+            var multiplier:Int = (FlxG.keys.pressed.SHIFT || FlxG.gamepads.anyPressed(LEFT_SHOULDER)) ? 10 : 1;
+			if(FlxG.keys.justPressed.ANY || FlxG.gamepads.anyJustPressed(ANY))
+			{
+				var controlArray:Array<Bool> = null;
+				if(!controls.controllerMode)
+				{
+					controlArray = [
+						FlxG.keys.justPressed.LEFT,
+						FlxG.keys.justPressed.RIGHT,
+						FlxG.keys.justPressed.UP,
+						FlxG.keys.justPressed.DOWN
+					];
+				}
+				else
+				{
+					controlArray = [
+						FlxG.gamepads.anyJustPressed(DPAD_LEFT),
+						FlxG.gamepads.anyJustPressed(DPAD_RIGHT),
+						FlxG.gamepads.anyJustPressed(DPAD_UP),
+						FlxG.gamepads.anyJustPressed(DPAD_DOWN)
+					];
+				}
 
-            if (FlxG.keys.justPressed.LEFT)
-            {
-                config.animations[curAnim].offsets[0] += multiplier;
-                splash();
-            }
-            else if (FlxG.keys.justPressed.RIGHT)
-            {
-                config.animations[curAnim].offsets[0] -= multiplier;
-                splash();
-            }
-            else if (FlxG.keys.justPressed.UP)
-            {
-                config.animations[curAnim].offsets[1] += multiplier;
-                splash();
-            }
-            else if (FlxG.keys.justPressed.DOWN)
-            {
-                config.animations[curAnim].offsets[1] -= multiplier;
-                splash();
-            }
+				if(controlArray.contains(true))
+				{
+					for (i in 0...controlArray.length)
+					{
+						if(controlArray[i])
+						{
+							switch(i)
+							{
+								case 0:
+									config.animations[curAnim].offsets[0] += multiplier;
+								case 1:
+									config.animations[curAnim].offsets[0] -= multiplier;
+								case 2:
+									config.animations[curAnim].offsets[1] += multiplier;
+								case 3:
+									config.animations[curAnim].offsets[1] -= multiplier;
+							}
+						}
+					}
+                    splash();
+				}
+			}
         }
 
         if (!blockInput)
@@ -913,20 +918,20 @@ class NoteSplashEditorState extends MusicBeatState
 			return config;
 
 		var animation:String = configs[0].rtrim();
-		var minFps:Null<Int> = 24;
-		var maxFps:Null<Int> = 24;
+		var minFps:Null<Int> = 22;
+		var maxFps:Null<Int> = 26;
 		if (configs[1] != null && configs[1].trim() != "")
 		{
 			var fps = configs[1].trim().split(" ");
 			minFps = Std.parseInt(fps[0]);
 			maxFps = Std.parseInt(fps[1]);
 			if (minFps == null)
-				minFps = 24;
+				minFps = 22;
 			if (maxFps == null)
-				maxFps = 24;
+				maxFps = 26;
 		}
 		var hasOneOffset = false;
-		var offsets = [[0, 0]];
+		var offsets:Array<Array<Null<Float>>> = [[0, 0]];
 		if (configs.length == 3 || configs.length == 2)
 		{
 			hasOneOffset = true;
@@ -936,14 +941,11 @@ class NoteSplashEditorState extends MusicBeatState
 				var offset = configs[2].trim();
 				if (offset != "")
 				{
-					var offset = offset.split(" ");
-					var x = Std.parseInt(offset[0]);
-					var y = Std.parseInt(offset[1]);
-					if (x == null)
-						x = 0;
-					if (y == null)
-						y = 0;
-
+					var offset:Array<String> = offset.split(" ");
+					var x:Null<Float> = Std.parseFloat(offset[0]);
+					var y:Null<Float> = Std.parseFloat(offset[1]);
+					if (x == null) x = 0;
+					if (y == null) y = 0;
 					offsets.push([x, y]);
 				}
 			}
@@ -957,14 +959,11 @@ class NoteSplashEditorState extends MusicBeatState
 				var offset = configs[i].trim();
 				if (offset != "")
 				{
-					var offset = offset.split(" ");
-					var x = Std.parseInt(offset[0]);
-					var y = Std.parseInt(offset[1]);
-					if (x == null)
-						x = 0;
-					if (y == null)
-						y = 0;
-
+					var offset:Array<String> = offset.split(" ");
+					var x:Null<Float> = Std.parseFloat(offset[0]);
+					var y:Null<Float> = Std.parseFloat(offset[1]);
+					if (x == null) x = 0;
+					if (y == null) y = 0;
 					offsets.push([x, y]);
 				}
 				i++;
@@ -978,7 +977,7 @@ class NoteSplashEditorState extends MusicBeatState
 			var offset = offsets[hasOneOffset ? 0 : i];
 			if (i + 1 > configs.length && !hasOneOffset)
 				break;
-			config = NoteSplash.addAnimationToConfig([1, 1], config, Note.colArray[i], '$animation ${Note.colArray[i]} 10', minFps, maxFps, offset, [], i);
+			config = NoteSplash.addAnimationToConfig(config, 1, Note.colArray[i], '$animation ${Note.colArray[i]} 10', [minFps, maxFps], offset, [], i);
 		}
 		if (offsets.length > 4)
 		{
@@ -987,7 +986,7 @@ class NoteSplashEditorState extends MusicBeatState
 				var offset = offsets[i + 4];
 				if (i + 1 > offsets.length)
 					break;
-				config = NoteSplash.addAnimationToConfig([1, 1], config, Note.colArray[i] + "2", '$animation ${Note.colArray[i]} 20', minFps, maxFps, offset, [], i + 4);
+				config = NoteSplash.addAnimationToConfig(config, 1, Note.colArray[i] + "2", '$animation ${Note.colArray[i]} 20', [minFps, maxFps], offset, [], i + 4);
 			}
 		}
 

--- a/source/states/editors/NoteSplashEditorState.hx
+++ b/source/states/editors/NoteSplashEditorState.hx
@@ -34,7 +34,7 @@ class NoteSplashEditorState extends MusicBeatState
     {
         if (imageSkin == null)
             imageSkin =  NoteSplash.DEFAULT_SKIN + NoteSplash.getSplashSkinPostfix();
-        
+
         FlxG.mouse.visible = true;
 
         FlxG.sound.volumeUpKeys = [];
@@ -85,7 +85,7 @@ class NoteSplashEditorState extends MusicBeatState
             babyArrow.ID = i;
             strums.add(babyArrow);
         }
-        
+
         add(strums);
         add(splashes);
 
@@ -357,23 +357,37 @@ class NoteSplashEditorState extends MusicBeatState
         var loadButton:PsychUIButton = new PsychUIButton(180, 155, "Convert TXT", loadTxt);
         ui.add(loadButton);
 
-        var getsAffectedByShader:PsychUICheckBox = new PsychUICheckBox(20, 105, "", 1);
+        var allowRGBCheck:PsychUICheckBox = new PsychUICheckBox(20, 105, "", 1);
         function check()
         {
             if (config != null)
-            {
-                config.affectedByShader = getsAffectedByShader.checked;
-            }
+                config.allowRGB = allowRGBCheck.checked;
         }
-        getsAffectedByShader.onClick = check;
-        getsAffectedByShader.checked = config != null && cast(config.affectedByShader, Null<Bool>) != null ? config.affectedByShader : false;
+        allowRGBCheck.onClick = check;
+        allowRGBCheck.checked = config != null && cast(config.allowRGB, Null<Bool>) != null ? config.allowRGB : false;
 
-        var text = new FlxText(getsAffectedByShader.x + 20, 0);
-        text.text = "Affected by Shader?";
-		text.y = getsAffectedByShader.y + 2.5;
-		ui.add(text);
+        var rgbText = new FlxText(allowRGBCheck.x + 20, 0);
+        rgbText.text = "Allow RGB?";
+		rgbText.y = allowRGBCheck.y + 2.5;
+		ui.add(rgbText);
 
-        ui.add(getsAffectedByShader);
+        ui.add(allowRGBCheck);
+
+        var allowPixelCheck:PsychUICheckBox = new PsychUICheckBox(allowRGBCheck.x + 150, allowRGBCheck.y, "", 1);
+        function check()
+        {
+            if (config != null)
+                config.allowPixel = allowPixelCheck.checked;
+        }
+        allowPixelCheck.onClick = check;
+        allowPixelCheck.checked = config != null && cast(config.allowPixel, Null<Bool>) != null ? config.allowPixel : false;
+
+        var pixelText = new FlxText(allowPixelCheck.x + 20, 0);
+        pixelText.text = "Allow Pixel?";
+		pixelText.y = allowPixelCheck.y + 2.5;
+		ui.add(pixelText);
+
+        ui.add(allowPixelCheck);
     }
 
     var redEnabled:Bool = true;


### PR DESCRIPTION
The new Note Splash json system and all is pretty good, but there were some things that seemed like they could be improved some more and also some things that need to be fixed.

Changes:
- You can hold the arrow keys to move the offsets
- Fixed the "affected by shader" option to properly disable the RGB
- Scale only needs 1 value now and FPS is in a table
- Reverted back the notesplash path to fix mod shit
- Changed "affectedByShader" to "allowRGB"
- Added "allowPixel" to turn on/off the Pixelization
- Formatting and other stuff