### PR TITLE
Restore the old behaviour for setting variables to hscript

### DIFF
--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -431,6 +431,11 @@ class HScript extends Iris
 	}
 	#end
 
+	override public function set(name:String, value:Dynamic, allowOverride:Bool = false):Void {
+		// should always override by default
+		super.set(name, value, true);
+	}
+
 	/*override function irisPrint(v):Void
 	{
 		FunkinLua.luaTrace('ERROR (${this.origin}:${interp.posInfos().lineNumber}): ${v}');


### PR DESCRIPTION
This fixes an issue where variables that should be constantly updated aren't and stays with the same value.
![image](https://github.com/user-attachments/assets/800efc1a-9b15-4f88-bbdd-e02d51eda964)
