### PR TITLE
Move script rating variables

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3444,10 +3444,10 @@ class PlayState extends MusicBeatState
 			}
 			fullComboFunction();
 		}
-		updateScore(badHit); // score will only update after rating is calculated, if it's a badHit, it shouldn't bounce
 		setOnScripts('rating', ratingPercent);
 		setOnScripts('ratingName', ratingName);
 		setOnScripts('ratingFC', ratingFC);
+		updateScore(badHit); // score will only update after rating is calculated, if it's a badHit, it shouldn't bounce
 	}
 
 	#if ACHIEVEMENTS_ALLOWED


### PR DESCRIPTION
Currently, using any of these rating variables inside of onUpdateScore won't give you the true value and instead give you a value that's delayed by one hit
This fixes that by moving the positions