### PR TITLE
Fix muffled audio/low quality audio for Windows

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -101,6 +101,12 @@
 		<assets path='example_mods' rename='mods' embed='false' type='template'/>
 	</section>
 	<assets path='art/readme.txt' rename='do NOT readme.txt' />
+	
+	<!-- OpenAL config -->
+	<section if="desktop">
+		<assets path="alsoft.txt" rename="plugins/alsoft.ini" type="text" if="windows"/>
+		<assets path="alsoft.txt" rename="plugins/alsoft.conf" type="text" unless="windows"/>
+	</section>
 
 	<!-- _______________________________ Libraries ______________________________ -->
 

--- a/alsoft.txt
+++ b/alsoft.txt
@@ -1,0 +1,14 @@
+[general]
+sample-type=float32
+stereo-mode=speakers
+stereo-encoding=panpot
+hrtf=false
+cf_level=0
+resampler=fast_bsinc24
+front-stablizer=false
+output-limiter=false
+volume-adjust=0
+[decoder]
+hq-mode=false
+distance-comp=false
+nfc=false

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -22,6 +22,10 @@ import states.TitleState;
 import lime.graphics.Image;
 #end
 
+#if desktop
+import backend.ALSoftConfig; // Just to make sure DCE doesn't remove this, since it's not directly referenced anywhere else.
+#end
+
 //crash handler stuff
 #if CRASH_HANDLER
 import openfl.events.UncaughtErrorEvent;

--- a/source/backend/ALSoftConfig.hx
+++ b/source/backend/ALSoftConfig.hx
@@ -1,0 +1,28 @@
+package backend;
+
+import haxe.io.Path;
+
+/*
+A class that simply points OpenALSoft to a custom configuration file when the game starts up.
+The config overrides a few global OpenALSoft settings with the aim of improving audio quality on desktop targets.
+*/
+@:keep class ALSoftConfig
+{
+	#if desktop
+	static function __init__():Void
+	{
+		var origin:String = #if hl Sys.getCwd() #else Sys.programPath() #end;
+
+		var configPath:String = Path.directory(Path.withoutExtension(origin));
+		#if windows
+		configPath += "/plugins/alsoft.ini";
+		#elseif mac
+		configPath = Path.directory(configPath) + "/Resources/plugins/alsoft.conf";
+		#else
+		configPath += "/plugins/alsoft.conf";
+		#end
+
+		Sys.putEnv("ALSOFT_CONF", configPath);
+	}
+	#end
+}


### PR DESCRIPTION
Lime's default OpenAL Soft audio settings cause muffling and bass reduction to any audio played due to a gain limiter being on by default, there are also other virtualization and spatialization settings that might ruin audio quality, which are also unlikely needed in a music rhythm game. This config file gets automatically detected by OpenAL Soft when it is in the same directory as the executable and turns these settings off resulting in much clearer and unmuffled audio, making it actually sound like it's supposed to when compared to outside media players