### PR TITLE
Fix Looking for soundFile when preloading. (Experimental Branch)

### DIFF
--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -618,7 +618,7 @@ class LoadingState extends MusicBeatState
 		{
 			if (#if sys FileSystem.exists(file) || #end OpenFlAssets.exists(file, SOUND))
 			{
-				var sound:Sound = OpenFlAssets.getSound(file, false);
+				var sound:Sound = #if sys Sound.fromFile(file) #else OpenFlAssets.getSound(file, false) #end;
 				mutex.acquire();
 				Paths.currentTrackedSounds.set(file, sound);
 				mutex.release();


### PR DESCRIPTION
Bug causes freakyMenu to play because it couldn't find inst or voices.

I found this bug on my own engine, I thought I did something wrong but no.


Videos of bug:

1. Without the #if sys line
https://streamable.com/jpj5d7

2. With the #if sys line
https://streamable.com/rexrqd