### PR TITLE
Close custom substate on destroy

### DIFF
--- a/source/psychlua/CustomSubstate.hx
+++ b/source/psychlua/CustomSubstate.hx
@@ -38,7 +38,6 @@ class CustomSubstate extends MusicBeatSubstate
 		if(instance != null)
 		{
 			PlayState.instance.closeSubState();
-			instance = null;
 			return true;
 		}
 		return false;
@@ -89,6 +88,7 @@ class CustomSubstate extends MusicBeatSubstate
 	override function destroy()
 	{
 		PlayState.instance.callOnScripts('onCustomSubstateDestroy', [name]);
+		instance = null;
 		name = 'unnamed';
 
 		PlayState.instance.setOnHScript('customSubstate', null);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3106,6 +3106,8 @@ class PlayState extends MusicBeatState
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
 
+		psychlua.CustomSubstate.closeCustomSubstate();
+
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_UP, onKeyRelease);
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -46,6 +46,7 @@ import psychlua.*;
 #else
 import psychlua.LuaUtils;
 import psychlua.HScript;
+import psychlua.CustomSubstate;
 #end
 
 #if HSCRIPT_ALLOWED
@@ -3106,7 +3107,13 @@ class PlayState extends MusicBeatState
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
 
-		psychlua.CustomSubstate.closeCustomSubstate();
+		if (CustomSubstate.instance != null)
+		{
+			closeSubstate();
+			CustomSubstate.instance.destroy();
+			CustomSubstate.instance = null;
+			subState = null;
+		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_UP, onKeyRelease);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3107,12 +3107,11 @@ class PlayState extends MusicBeatState
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
 
-		if (CustomSubstate.instance != null)
+		if (subState != null)
 		{
-			closeSubstate();
-			CustomSubstate.instance.destroy();
-			CustomSubstate.instance = null;
-			subState = null;
+			closeSubState();
+			resetSubState();
+			if (CustomSubstate.instance != null) CustomSubstate.instance = null;
 		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -46,6 +46,7 @@ import psychlua.*;
 #else
 import psychlua.LuaUtils;
 import psychlua.HScript;
+import psychlua.CustomSubstate;
 #end
 
 #if HSCRIPT_ALLOWED
@@ -3106,10 +3107,11 @@ class PlayState extends MusicBeatState
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
 
-		if (subState != null)
+		if (CustomSubstate.instance != null)
 		{
 			closeSubState();
-			resetSubState();
+			CustomSubstate.instance.destroy();
+			subState = null;
 		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3084,6 +3084,12 @@ class PlayState extends MusicBeatState
 	}
 
 	override function destroy() {
+		if (psychlua.CustomSubstate.instance != null)
+		{
+			closeSubState();
+			resetSubState();
+		}
+
 		#if LUA_ALLOWED
 		for (lua in luaArray)
 		{
@@ -3105,12 +3111,6 @@ class PlayState extends MusicBeatState
 		hscriptArray = null;
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
-
-		if (psychlua.CustomSubstate.instance != null)
-		{
-			closeSubState();
-			resetSubState();
-		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_UP, onKeyRelease);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -46,7 +46,6 @@ import psychlua.*;
 #else
 import psychlua.LuaUtils;
 import psychlua.HScript;
-import psychlua.CustomSubstate;
 #end
 
 #if HSCRIPT_ALLOWED
@@ -3111,7 +3110,6 @@ class PlayState extends MusicBeatState
 		{
 			closeSubState();
 			resetSubState();
-			if (CustomSubstate.instance != null) CustomSubstate.instance = null;
 		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -46,7 +46,6 @@ import psychlua.*;
 #else
 import psychlua.LuaUtils;
 import psychlua.HScript;
-import psychlua.CustomSubstate;
 #end
 
 #if HSCRIPT_ALLOWED
@@ -3107,11 +3106,10 @@ class PlayState extends MusicBeatState
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
 
-		if (CustomSubstate.instance != null)
+		if (psychlua.CustomSubstate.instance != null)
 		{
 			closeSubState();
-			CustomSubstate.instance.destroy();
-			subState = null;
+			resetSubState();
 		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);


### PR DESCRIPTION
Close the custom substate manually on destroy to prevent a crash that happens if the state gets reset or changed while the substate is still active

This PR also makes it so that `CustomSubstate.instance` is no longer set to null when `closeCustomSubstate` is called, and is instead set to null when `destroy` is called

Anyways, the reason that the custom substate crashes is most likely due to the substate being closed by Flixel itself, WAY after PlayState has already been destroyed
And thus, the game is trying to call `PlayState.instance.callOnScripts` while the `instance` variable has already been set to null 