### PR TITLE
Add a recursive json finding function to CoolUtil.hx

### DIFF
--- a/source/backend/CoolUtil.hx
+++ b/source/backend/CoolUtil.hx
@@ -157,4 +157,28 @@ class CoolUtil
 				text.borderStyle = NONE;
 		}
 	}
+
+	public static function recursivelyReadFolders(path:String, ?erasePath:Bool = true) {
+		var ret:Array<String> = [];
+		for (i in FileSystem.readDirectory(path)) {
+			returnFileName(i, ret, path);
+		}
+		if (erasePath) {
+			path+='/';
+			for (i in 0...ret.length) {
+				ret[i] = ret[i].replace(path, '');
+			}
+		}
+		return ret;
+	}
+
+	static function returnFileName(path:String, toAdd:Array<String>, full:String) {
+		if (FileSystem.isDirectory(full+'/'+path)) {
+			for (i in FileSystem.readDirectory(full+'/'+path)) {
+				returnFileName(i, toAdd, full+'/'+path);
+			}
+		} else {
+			toAdd.push((full+'/'+path).replace('.json', ''));
+		}
+	}
 }


### PR DESCRIPTION
I added a recursive function to CoolUtil.hx to allow the game to find Json's in folders, and sub-folders.

I can't quite implement it completely into the codebase, as I do not know anything about the newer mod classes, (I stick with 0.6.3) so if someone would like they could implement it to be used those.

Example use in code

```haxe
// assets/characters/bf.json
// assets/characters/gf.json
// assets/characters/opponents/dad.json

characterList = CoolUtil.recursivelyReadFolders('assets/characters', true);

// ['bf', 'gf', 'opponents/dad']
```