### PR TITLE
general scripting fixes

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -124,6 +124,9 @@
 	<haxedef name="HXC_LIBVLC_LOGGING" if="VIDEOS_ALLOWED debug" />
 	<haxedef name="HXVLC_NO_SHARE_DIRECTORY" if="VIDEOS_ALLOWED" />
 	<define name="x86_BUILD" if="32bits" />
+
+	<!-- Iris error debugging -->
+	<haxedef name="hscriptPos" if="HSCRIPT_ALLOWED"/>
 	
 	<!-- ______________________________ Haxedefines _____________________________ -->
 

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -11,7 +11,6 @@ import psychlua.FunkinLua;
 
 #if HSCRIPT_ALLOWED
 import crowplexus.iris.Iris;
-import crowplexus.hscript.Printer;
 import crowplexus.hscript.Expr.Error as IrisError;
 
 class HScript extends Iris
@@ -46,7 +45,7 @@ class HScript extends Iris
 		if(hs == null)
 		{
 			trace('initializing haxe interp for: ${parent.scriptName}');
-			parent.hscript = new HScript(parent, '', varsToBring);
+			parent.hscript = new HScript(parent, code, varsToBring);
 			return parent.hscript.returnValue;
 		}
 		else
@@ -118,7 +117,7 @@ class HScript extends Iris
 			this.returnValue = execute();
 		} catch (e:IrisError) {
 			this.errorCaught(e);
-			this.returnValue = null;
+			this.returnValue = e;
 		}
 	}
 

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -104,9 +104,9 @@ class HScript extends Iris
 			this.returnValue = execute();
 		} catch (e:Dynamic) {
 			#if LUA_ALLOWED
-			FunkinLua.luaTrace('ERROR (${hs.origin}) - $e', false, false, FlxColor.RED);
+			FunkinLua.luaTrace('ERROR (${this.origin}) - $e', false, false, FlxColor.RED);
 			#else
-			PlayState.instance.addTextToDebug('ERROR (${hs.origin}) - $e', FlxColor.RED);
+			PlayState.instance.addTextToDebug('ERROR (${this.origin}) - $e', FlxColor.RED);
 			#end
 			this.returnValue = null;
 		}

--- a/source/psychlua/LuaUtils.hx
+++ b/source/psychlua/LuaUtils.hx
@@ -255,6 +255,10 @@ class LuaUtils
 		}
 	}
 	
+	public static function typeSupported(value:Dynamic) {
+		return (value == null || isOfTypes(value, [Bool, Int, Float, String, Array]) || Type.typeof(value) == Type.ValueType.TObject);
+	}
+	
 	public static function isOfTypes(value:Any, types:Array<Dynamic>)
 	{
 		for (type in types)

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3290,7 +3290,7 @@ class PlayState extends MusicBeatState
 	#end
 
 	public function callOnScripts(funcToCall:String, args:Array<Dynamic> = null, ignoreStops = false, exclusions:Array<String> = null, excludeValues:Array<Dynamic> = null):Dynamic {
-		var returnVal:String = LuaUtils.Function_Continue;
+		var returnVal:Dynamic = LuaUtils.Function_Continue;
 		if(args == null) args = [];
 		if(exclusions == null) exclusions = [];
 		if(excludeValues == null) excludeValues = [LuaUtils.Function_Continue];
@@ -3301,7 +3301,7 @@ class PlayState extends MusicBeatState
 	}
 
 	public function callOnLuas(funcToCall:String, args:Array<Dynamic> = null, ignoreStops = false, exclusions:Array<String> = null, excludeValues:Array<Dynamic> = null):Dynamic {
-		var returnVal:String = LuaUtils.Function_Continue;
+		var returnVal:Dynamic = LuaUtils.Function_Continue;
 		#if LUA_ALLOWED
 		if(args == null) args = [];
 		if(exclusions == null) exclusions = [];
@@ -3340,7 +3340,7 @@ class PlayState extends MusicBeatState
 	}
 
 	public function callOnHScript(funcToCall:String, args:Array<Dynamic> = null, ?ignoreStops:Bool = false, exclusions:Array<String> = null, excludeValues:Array<Dynamic> = null):Dynamic {
-		var returnVal:String = LuaUtils.Function_Continue;
+		var returnVal:Dynamic = LuaUtils.Function_Continue;
 
 		#if HSCRIPT_ALLOWED
 		if(exclusions == null) exclusions = new Array();


### PR DESCRIPTION
- in PlayState, the callOnLuas/HScript/Scripts functions define the return variable as a string; this causes any return value received from these functions to be casted to a string (which isn't pretty useful). Fixed by simply changing the type definition from String back to Dynamic
- in HScript, the executeCode function expects an IrisCall value, but the function returns the call's returnValue (which most certainly isn't an IrisCall), causing the return value to fail in runHaxeCode when a function is provided. This is fixed by simply returning the actual call instead of it's returnValue. Additionally, runHaxeCode's return value was also an IrisCall, which cannot be passed to lua and also presents issues similar to previously described ones; simply changed to Dynamic
- its not possible to run more than one haxe code string per lua instance; the code is never parsed again, so its only executed again but never changed. this is fixed by calling `parse(true)` when the code is initialized again! ive also attempted to fix return values without a provided function (ex. `runHaxeCode("return 1234;")` *should* properly return 1234)
- the type check for runHaxeCode and runHaxeFunction to check for lua compatible types has been moved to a little helper function in LuaUtils; i thought this would be convenient. linc_luajit is also able to convert objects to lua tables, so this has been added!
- as an additional little bonus :] sscript imports a lot of classes that arent present in hscript-iris; i picked 4 of them (`Type`, `Reflect`, `File`, `FileSystem`) to add to the default imports as they are commonly used

test script to verify everything works as intended:
```lua
function onCreate()
  luaDebugMode = true
  debugPrint(runHaxeCode('return "hi!!";')) -- should return "hi!!"
  debugPrint(runHaxeCode([[
    debugPrint(testVar);
    function test(abc) {
      return {a:1, b:2};
    }
    function testb(theVar) {
      return theVar;
    }
    return 789;
  ]], {testVar = 'abcd'}, 'test', {123})) -- should print "abcd", return table {a = 1, b = 2}
  debugPrint('  -------------')
  debugPrint(runHaxeCode([[
    debugPrint(testVar2);
    debugPrint('abc');
    return 123;
  ]], {testVar2 = 'efgh'})) -- should print "efgh" (testVar2), "abc", return 123
  debugPrint('  -------------')
  debugPrint(runHaxeCode([[
    debugPrint('def');
    return [4, 5, 6];
  ]])) -- should print "def", return table {4, 5, 6}
  debugPrint('  -------------')
  debugPrint(runHaxeFunction('testb', {78910})) -- should return 78910
  debugPrint('  -------------')
  debugPrint(runHaxeCode('//nothing')) -- should return nil (no return value)
  runHaxeCode('this has an error in it, apparently') -- should print an error
end
```
![image](https://github.com/user-attachments/assets/2741e6c9-32b8-4607-abca-f15509ea5c18)
