### PR TITLE
Remove "0" and "1" from Change Character on `eventPushedUnique`

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1445,9 +1445,9 @@ class PlayState extends MusicBeatState
 			case "Change Character":
 				var charType:Int = 0;
 				switch(event.value1.toLowerCase()) {
-					case 'gf' | 'girlfriend' | '1':
+					case 'gf' | 'girlfriend':
 						charType = 2;
-					case 'dad' | 'opponent' | '0':
+					case 'dad' | 'opponent':
 						charType = 1;
 					default:
 						var val1:Int = Std.parseInt(event.value1);


### PR DESCRIPTION
Inconsistent with the actual Change Character event and adds to the wrong group