### PR TITLE
Change Lime version to 8.2.0 due to compiling error

### DIFF
--- a/setup/unix.sh
+++ b/setup/unix.sh
@@ -7,7 +7,7 @@ echo Makking the main haxelib and setuping folder in same time..
 mkdir ~/haxelib && haxelib setup ~/haxelib
 echo Installing dependencies...
 echo This might take a few moments depending on your internet speed.
-haxelib install lime 8.1.2
+haxelib install lime 8.2.0
 haxelib install openfl 9.3.3
 haxelib install flixel 5.6.1
 haxelib install flixel-addons 3.2.2

--- a/setup/windows.bat
+++ b/setup/windows.bat
@@ -4,7 +4,7 @@ cd ..
 @echo on
 echo Installing dependencies...
 echo This might take a few moments depending on your internet speed.
-haxelib install lime 8.1.2
+haxelib install lime 8.2.0
 haxelib install openfl 9.3.3
 haxelib install flixel 5.6.1
 haxelib install flixel-addons 3.2.2


### PR DESCRIPTION
Using 8.1.2 version of Lime will cause the game crashed by compiling the game when booting up. The only way to make the game that isn't crashed is use Lime v8.2.0. Lime 8.1.2 doesn't work on v1.0 unless you're compiling the prerelease build.