### PR TITLE
Disable FileFilter on macOS

### DIFF
--- a/source/states/editors/DialogueCharacterEditorState.hx
+++ b/source/states/editors/DialogueCharacterEditorState.hx
@@ -624,7 +624,7 @@ class DialogueCharacterEditorState extends MusicBeatState implements PsychUIEven
 		_file.addEventListener(#if desktop Event.SELECT #else Event.COMPLETE #end, onLoadComplete);
 		_file.addEventListener(Event.CANCEL, onLoadCancel);
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file.browse([jsonFilter]);
+		_file.browse([#if !mac jsonFilter #end]);
 	}
 
 	function onLoadComplete(_):Void

--- a/source/states/editors/DialogueEditorState.hx
+++ b/source/states/editors/DialogueEditorState.hx
@@ -420,7 +420,7 @@ class DialogueEditorState extends MusicBeatState implements PsychUIEventHandler.
 		_file.addEventListener(#if desktop Event.SELECT #else Event.COMPLETE #end, onLoadComplete);
 		_file.addEventListener(Event.CANCEL, onLoadCancel);
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file.browse([jsonFilter]);
+		_file.browse([#if !mac jsonFilter #end]);
 	}
 
 	function onLoadComplete(_):Void

--- a/source/states/editors/MenuCharacterEditorState.hx
+++ b/source/states/editors/MenuCharacterEditorState.hx
@@ -268,7 +268,7 @@ class MenuCharacterEditorState extends MusicBeatState implements PsychUIEventHan
 		_file.addEventListener(#if desktop Event.SELECT #else Event.COMPLETE #end, onLoadComplete);
 		_file.addEventListener(Event.CANCEL, onLoadCancel);
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file.browse([jsonFilter]);
+		_file.browse([#if !mac jsonFilter #end]);
 	}
 
 	function onLoadComplete(_):Void

--- a/source/states/editors/NoteSplashEditorState.hx
+++ b/source/states/editors/NoteSplashEditorState.hx
@@ -830,7 +830,7 @@ class NoteSplashEditorState extends MusicBeatState
 		_file.addEventListener(Event.SELECT, onLoadComplete);
 		_file.addEventListener(Event.CANCEL, onLoadCancel);
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file.browse([#if windows jsonFilter #end]);
+		_file.browse([#if !mac jsonFilter #end]);
 	}
 
 	function onLoadComplete(_):Void

--- a/source/states/editors/StageEditorState.hx
+++ b/source/states/editors/StageEditorState.hx
@@ -1662,7 +1662,7 @@ class StageEditorState extends MusicBeatState implements PsychUIEventHandler.Psy
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
 
 		final filters = [new FileFilter('PNG (Image)', '*.png'), new FileFilter('XML (Sparrow)', '*.xml'), new FileFilter('JSON (Aseprite)', '*.json'), new FileFilter('TXT (Packer)', '*.txt')];
-		_file.browse(filters);
+		_file.browse(#if !mac filters #else [] #end);
 	}
 	
 	private function onLoadComplete(_):Void

--- a/source/states/editors/WeekEditorState.hx
+++ b/source/states/editors/WeekEditorState.hx
@@ -428,7 +428,7 @@ class WeekEditorState extends MusicBeatState implements PsychUIEventHandler.Psyc
 		_file.addEventListener(#if desktop Event.SELECT #else Event.COMPLETE #end, onLoadComplete);
 		_file.addEventListener(Event.CANCEL, onLoadCancel);
 		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file.browse([jsonFilter]);
+		_file.browse([#if !mac jsonFilter #end]);
 	}
 	
 	public static var loadedWeek:WeekFile = null;

--- a/source/states/editors/content/FileDialogHandler.hx
+++ b/source/states/editors/content/FileDialogHandler.hx
@@ -58,6 +58,9 @@ class FileDialogHandler extends FlxBasic
 		this._dialogMode = OPEN;
 		_startUp(onComplete, onCancel, onError);
 		if(filter == null) filter = [new FileFilter('JSON', 'json')];
+		#if mac
+		filter = [];
+		#end
 
 		removeEvents();
 		_currentEvent = onLoadComplete;

--- a/source/states/editors/content/PreloadListSubState.hx
+++ b/source/states/editors/content/PreloadListSubState.hx
@@ -153,7 +153,7 @@ class PreloadListSubState extends MusicBeatSubstate implements PsychUIEvent
 		{
 			if(!fileDialog.completed) return;
 			
-			fileDialog.open(null, 'Load a .PNG/.OGG File...', [new FileFilter('Image/Audio', '*.png;*.ogg')], function()
+			fileDialog.open(null, 'Load a .PNG/.OGG File...', [#if !mac new FileFilter('Image/Audio', '*.png;*.ogg') #end], function()
 			{
 				var path:Path = new Path(fileDialog.path.replace('\\', '/'));
 	


### PR DESCRIPTION
FileFilter is broken on macOS, no matter which extension is in a filter all files will be grayed out when browsing
Also fixes #15816
