### PR TITLE
really basic chart format edit to allow for multi-key to be *possible* to make

### DIFF
--- a/source/backend/Song.hx
+++ b/source/backend/Song.hx
@@ -41,6 +41,8 @@ typedef SwagSection =
 	@:optional var gfSection:Bool;
 	@:optional var bpm:Float;
 	@:optional var changeBPM:Bool;
+	@:optional @default(4)
+	var totalColumns: Int;
 }
 
 class Song
@@ -62,6 +64,7 @@ class Song
 	public var player1:String = 'bf';
 	public var player2:String = 'dad';
 	public var gfVersion:String = 'gf';
+	public var totalColumns:Int = 4;
 	public var format:String = 'psych_v1';
 
 	public static function convert(songJson:Dynamic) // Convert old charts to psych_v1 format
@@ -110,8 +113,11 @@ class Song
 
 			for (note in section.sectionNotes)
 			{
-				var gottaHitNote:Bool = (note[1] < 4) ? section.mustHitSection : !section.mustHitSection;
-				note[1] = (note[1] % 4) + (gottaHitNote ? 0 : 4);
+				// NOTE: Psych Engine does NOT have multikey out of the box, this is simply done in case you WANT to add it via scripting
+				// there's no UI element in the chart editor to modify the value of `totalColumns` so you might wanna change that manually yourself
+				// if you're forking the engine, you might wanna add that
+				var gottaHitNote:Bool = (note[1] < songJson.totalColumns) ? section.mustHitSection : !section.mustHitSection;
+				note[1] = (note[1] % songJson.totalColumns) + (gottaHitNote ? 0 : 4);
 
 				if(note[3] != null && !Std.isOfType(note[3], String))
 					note[3] = Note.defaultNoteTypes[note[3]]; //compatibility with Week 7 and 0.1-0.3 psych charts
@@ -132,6 +138,7 @@ class Song
 	}
 
 	static var _lastPath:String;
+
 	public static function getChart(jsonInput:String, ?folder:String):SwagSong
 	{
 		if(folder == null) folder = jsonInput;

--- a/source/backend/Song.hx
+++ b/source/backend/Song.hx
@@ -116,8 +116,10 @@ class Song
 				// NOTE: Psych Engine does NOT have multikey out of the box, this is simply done in case you WANT to add it via scripting
 				// there's no UI element in the chart editor to modify the value of `totalColumns` so you might wanna change that manually yourself
 				// if you're forking the engine, you might wanna add that
-				var gottaHitNote:Bool = (note[1] < songJson.totalColumns) ? section.mustHitSection : !section.mustHitSection;
-				note[1] = (note[1] % songJson.totalColumns) + (gottaHitNote ? 0 : 4);
+				var totalColumns: Int = cast(songJson.totalColumns, Int);
+				if (totalColumns < 1) totalColumns = 4; // just in case
+				var gottaHitNote:Bool = (note[1] < totalColumns) ? section.mustHitSection : !section.mustHitSection;
+				note[1] = (note[1] % totalColumns) + (gottaHitNote ? 0 : 4);
 
 				if(note[3] != null && !Std.isOfType(note[3], String))
 					note[3] = Note.defaultNoteTypes[note[3]]; //compatibility with Week 7 and 0.1-0.3 psych charts

--- a/source/backend/Song.hx
+++ b/source/backend/Song.hx
@@ -111,15 +111,16 @@ class Song
 				if(Reflect.hasField(section, 'lengthInSteps')) Reflect.deleteField(section, 'lengthInSteps');
 			}
 
+			// NOTE: Psych Engine does NOT have multikey out of the box, this is simply done in case you WANT to add it via scripting
+			// there's no UI element in the chart editor to modify the value of `totalColumns` so you might wanna change that manually yourself
+			// if you're forking the engine, you might wanna add that
+			var totalColumns: Int = cast(songJson.totalColumns, Int);
+			if (totalColumns < 1) totalColumns = 4; // just in case
+
 			for (note in section.sectionNotes)
 			{
-				// NOTE: Psych Engine does NOT have multikey out of the box, this is simply done in case you WANT to add it via scripting
-				// there's no UI element in the chart editor to modify the value of `totalColumns` so you might wanna change that manually yourself
-				// if you're forking the engine, you might wanna add that
-				var totalColumns: Int = cast(songJson.totalColumns, Int);
-				if (totalColumns < 1) totalColumns = 4; // just in case
 				var gottaHitNote:Bool = (note[1] < totalColumns) ? section.mustHitSection : !section.mustHitSection;
-				note[1] = (note[1] % totalColumns) + (gottaHitNote ? 0 : 4);
+				note[1] = (note[1] % totalColumns) + (gottaHitNote ? 0 : totalColumns);
 
 				if(note[3] != null && !Std.isOfType(note[3], String))
 					note[3] = Note.defaultNoteTypes[note[3]]; //compatibility with Week 7 and 0.1-0.3 psych charts

--- a/source/backend/Song.hx
+++ b/source/backend/Song.hx
@@ -30,6 +30,8 @@ typedef SwagSong =
 
 	@:optional var arrowSkin:String;
 	@:optional var splashSkin:String;
+	@:optional @default(4)
+	var totalColumns: Int;
 }
 
 typedef SwagSection =
@@ -41,8 +43,6 @@ typedef SwagSection =
 	@:optional var gfSection:Bool;
 	@:optional var bpm:Float;
 	@:optional var changeBPM:Bool;
-	@:optional @default(4)
-	var totalColumns: Int;
 }
 
 class Song

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -2919,7 +2919,7 @@ class PlayState extends MusicBeatState
 			var postfix:String = '';
 			if(note != null) postfix = note.animSuffix;
 
-			var animToPlay:String = singAnimations[Std.int(Math.abs(Math.min(singAnimations.length-1, direction)))] + 'miss' + postfix;
+			var animToPlay:String = singAnimations[direction % singAnimations.length-1] + 'miss' + postfix;
 			char.playAnim(animToPlay, true);
 
 			if(char != gf && lastCombo > 5 && gf != null && gf.hasAnimation('sad'))
@@ -2950,7 +2950,7 @@ class PlayState extends MusicBeatState
 		else if(!note.noAnimation)
 		{
 			var char:Character = dad;
-			var animToPlay:String = singAnimations[Std.int(Math.abs(Math.min(singAnimations.length-1, note.noteData)))] + note.animSuffix;
+			var animToPlay:String = singAnimations[note.noteData & singAnimations.length-1] + note.animSuffix;
 			if(note.gfNote) char = gf;
 
 			if(char != null)
@@ -3002,7 +3002,7 @@ class PlayState extends MusicBeatState
 		{
 			if(!note.noAnimation)
 			{
-				var animToPlay:String = singAnimations[Std.int(Math.abs(Math.min(singAnimations.length-1, note.noteData)))] + note.animSuffix;
+				var animToPlay:String = singAnimations[note.noteData % singAnimations.length-1] + note.animSuffix;
 
 				var char:Character = boyfriend;
 				var animCheck:String = 'hey';

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1245,7 +1245,6 @@ class PlayState extends MusicBeatState
 
 	private var noteTypes:Array<String> = [];
 	private var eventsPushed:Array<String> = [];
-	private var totalColumns: Int = 4;
 
 	private function generateSong():Void
 	{
@@ -1322,13 +1321,13 @@ class PlayState extends MusicBeatState
 			{
 				final songNotes: Array<Dynamic> = section.sectionNotes[i];
 				var spawnTime: Float = songNotes[0];
-				var noteColumn: Int = Std.int(songNotes[1] % totalColumns);
+				var noteColumn: Int = Std.int(songNotes[1]);
 				var holdLength: Float = songNotes[2];
 				var noteType: String = songNotes[3];
 				if (Math.isNaN(holdLength))
 					holdLength = 0.0;
 
-				var gottaHitNote:Bool = (songNotes[1] < totalColumns);
+				var gottaHitNote:Bool = (songNotes[1] < songData.totalColumns);
 
 				if (i != 0) {
 					// CLEAR ANY POSSIBLE GHOST NOTES

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1774,7 +1774,7 @@ class PlayState extends MusicBeatState
 							var strumGroup:FlxTypedGroup<StrumNote> = playerStrums;
 							if(!daNote.mustPress) strumGroup = opponentStrums;
 
-							var strum:StrumNote = strumGroup.members[daNote.noteData];
+							var strum:StrumNote = strumGroup.members[daNote.noteData % strumGroup.members.length - 1];
 							daNote.followStrumNote(strum, fakeCrochet, songSpeed / playbackRate);
 
 							if(daNote.mustPress)
@@ -2716,7 +2716,7 @@ class PlayState extends MusicBeatState
 		//more accurate hit time for the ratings? part 2 (Now that the calculations are done, go back to the time it was before for not causing a note stutter)
 		Conductor.songPosition = lastTime;
 
-		var spr:StrumNote = playerStrums.members[key];
+		var spr:StrumNote = playerStrums.members[key % playerStrums.members.length - 1];
 		if(strumsBlocked[key] != true && spr != null && spr.animation.curAnim.name != 'confirm')
 		{
 			spr.playAnim('pressed');
@@ -2749,7 +2749,7 @@ class PlayState extends MusicBeatState
 		var ret:Dynamic = callOnScripts('onKeyReleasePre', [key]);
 		if(ret == LuaUtils.Function_Stop) return;
 
-		var spr:StrumNote = playerStrums.members[key];
+		var spr:StrumNote = playerStrums.members[key % playerStrums.members.length - 1];
 		if(spr != null)
 		{
 			spr.playAnim('static');
@@ -3039,7 +3039,7 @@ class PlayState extends MusicBeatState
 
 			if(!cpuControlled)
 			{
-				var spr = playerStrums.members[note.noteData];
+				var spr = playerStrums.members[note.noteData % playerStrums.members.length - 1];
 				if(spr != null) spr.playAnim('confirm', true);
 			}
 			else strumPlayAnim(false, Std.int(Math.abs(note.noteData)), Conductor.stepCrochet * 1.25 / 1000 / playbackRate);
@@ -3089,7 +3089,7 @@ class PlayState extends MusicBeatState
 
 	public function spawnNoteSplashOnNote(note:Note) {
 		if(note != null) {
-			var strum:StrumNote = playerStrums.members[note.noteData];
+			var strum:StrumNote = playerStrums.members[note.noteData % playerStrums.members.length - 1];
 			if(strum != null)
 				spawnNoteSplash(note, strum);
 		}
@@ -3425,9 +3425,9 @@ class PlayState extends MusicBeatState
 	function strumPlayAnim(isDad:Bool, id:Int, time:Float) {
 		var spr:StrumNote = null;
 		if(isDad) {
-			spr = opponentStrums.members[id];
+			spr = opponentStrums.members[id % opponentStrums.members.length - 1];
 		} else {
-			spr = playerStrums.members[id];
+			spr = playerStrums.members[id % playerStrums.members.length - 1];
 		}
 
 		if(spr != null) {

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1321,7 +1321,7 @@ class PlayState extends MusicBeatState
 			{
 				final songNotes: Array<Dynamic> = section.sectionNotes[i];
 				var spawnTime: Float = songNotes[0];
-				var noteColumn: Int = Std.int(songNotes[1]);
+				var noteColumn: Int = Std.int(songNotes[1] % songData.totalColumns);
 				var holdLength: Float = songNotes[2];
 				var noteType: String = songNotes[3];
 				if (Math.isNaN(holdLength))

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1259,7 +1259,7 @@ class PlayState extends MusicBeatState
 				songSpeed = ClientPrefs.getGameplaySetting('scrollspeed');
 		}
 
-		var songData = SONG;
+		var songData: SwagSong = SONG;
 		Conductor.bpm = songData.bpm;
 
 		curSong = songData.song;

--- a/source/states/editors/content/EditorPlayState.hx
+++ b/source/states/editors/content/EditorPlayState.hx
@@ -209,7 +209,7 @@ class EditorPlayState extends MusicBeatSubstate
 				var strumGroup:FlxTypedGroup<StrumNote> = playerStrums;
 				if(!daNote.mustPress) strumGroup = opponentStrums;
 
-				var strum:StrumNote = strumGroup.members[daNote.noteData];
+				var strum:StrumNote = strumGroup.members[daNote.noteData % strumGroup.members.length - 1];
 				daNote.followStrumNote(strum, fakeCrochet, songSpeed / playbackRate);
 
 				if(!daNote.mustPress && daNote.wasGoodHit && !daNote.hitByOpponent && !daNote.ignoreNote)
@@ -703,7 +703,7 @@ class EditorPlayState extends MusicBeatSubstate
 		//more accurate hit time for the ratings? part 2 (Now that the calculations are done, go back to the time it was before for not causing a note stutter)
 		Conductor.songPosition = lastTime;
 
-		var spr:StrumNote = playerStrums.members[key];
+		var spr:StrumNote = playerStrums.members[key % playerStrums.members.length - 1];
 		if(spr != null && spr.animation.curAnim.name != 'confirm')
 		{
 			spr.playAnim('pressed');
@@ -722,7 +722,7 @@ class EditorPlayState extends MusicBeatSubstate
 
 	private function keyReleased(key:Int)
 	{
-		var spr:StrumNote = playerStrums.members[key];
+		var spr:StrumNote = playerStrums.members[key % playerStrums.members.length - 1];
 		if(spr != null)
 		{
 			spr.playAnim('static');
@@ -781,7 +781,7 @@ class EditorPlayState extends MusicBeatSubstate
 		if (PlayState.SONG.needsVoices && opponentVocals.length <= 0)
 			vocals.volume = 1;
 
-		var strum:StrumNote = opponentStrums.members[Std.int(Math.abs(note.noteData))];
+		var strum:StrumNote = opponentStrums.members[note.noteData % opponentStrums.members.length - 1];
 		if(strum != null) {
 			strum.playAnim('confirm', true);
 			strum.resetAnim = Conductor.stepCrochet * 1.25 / 1000 / playbackRate;
@@ -817,7 +817,7 @@ class EditorPlayState extends MusicBeatSubstate
 			popUpScore(note);
 		}
 
-		var spr:StrumNote = playerStrums.members[note.noteData];
+		var spr:StrumNote = playerStrums.members[note.noteData % playerStrums.members.length - 1];
 		if(spr != null) spr.playAnim('confirm', true);
 		vocals.volume = 1;
 
@@ -880,7 +880,7 @@ class EditorPlayState extends MusicBeatSubstate
 
 	function spawnNoteSplashOnNote(note:Note) {
 		if(note != null) {
-			var strum:StrumNote = playerStrums.members[note.noteData];
+			var strum:StrumNote = playerStrums.members[note.noteData % playerStrums.members.length - 1];
 			if(strum != null)
 				spawnNoteSplash(strum.x, strum.y, note.noteData, note, strum);
 		}


### PR DESCRIPTION
since the new chart format changes how legacy charts are loaded, multikey is no longer as feasible as it used to, this changes it by moving `PlayState.totalColumns` to the chart format and accounting for it when parsing

this may also fix issues with some modded charts parsing incorrectly if you did something weird with them, granted, manually, but still