### PR TITLE
general scripting improvements (the sequel)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ name: Build
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ main, experimental, script-fix ]
+    branches: [ main, experimental ]
   pull_request:
     branches: [ main, experimental ]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ name: Build
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ main, experimental ]
+    branches: [ main, experimental, script-fix ]
   pull_request:
     branches: [ main, experimental ]
 

--- a/Project.xml
+++ b/Project.xml
@@ -30,11 +30,11 @@
 	
 	<define name="SHOW_LOADING_SCREEN" />
 	<define name="PSYCH_WATERMARKS"/> <!-- DELETE THIS TO REMOVE THE PSYCH LOGO FROM LOADING SCREEN -->
-
-	<section if="officialBuild">
 		<define name="TITLE_SCREEN_EASTER_EGG"/>
 		<define name="BASE_GAME_FILES" />
 		<define name="VIDEOS_ALLOWED" if="windows || linux || android" unless="32bits"/> <!-- IF YOU WANT TO USE VIDEOS ON YOUR SOURCE MOD, GET THIS LINE OUTSIDE OF THE SECTION -->
+
+	<section if="officialBuild">
 	</section>
 
 	<!-- ____________________________ Window Settings ___________________________ -->
@@ -130,6 +130,9 @@
 	<haxedef name="HXC_LIBVLC_LOGGING" if="VIDEOS_ALLOWED debug" />
 	<haxedef name="HXVLC_NO_SHARE_DIRECTORY" if="VIDEOS_ALLOWED" />
 	<define name="x86_BUILD" if="32bits" />
+	
+	<!-- Iris error debugging -->
+	<haxedef name="hscriptPos" if="HSCRIPT_ALLOWED" />
 	
 	<!-- ______________________________ Haxedefines _____________________________ -->
 

--- a/Project.xml
+++ b/Project.xml
@@ -30,11 +30,11 @@
 	
 	<define name="SHOW_LOADING_SCREEN" />
 	<define name="PSYCH_WATERMARKS"/> <!-- DELETE THIS TO REMOVE THE PSYCH LOGO FROM LOADING SCREEN -->
+
+	<section if="officialBuild">
 		<define name="TITLE_SCREEN_EASTER_EGG"/>
 		<define name="BASE_GAME_FILES" />
 		<define name="VIDEOS_ALLOWED" if="windows || linux || android" unless="32bits"/> <!-- IF YOU WANT TO USE VIDEOS ON YOUR SOURCE MOD, GET THIS LINE OUTSIDE OF THE SECTION -->
-
-	<section if="officialBuild">
 	</section>
 
 	<!-- ____________________________ Window Settings ___________________________ -->

--- a/source/backend/Paths.hx
+++ b/source/backend/Paths.hx
@@ -239,7 +239,7 @@ class Paths
 	{
 		var folderKey:String = Language.getFileTranslation('fonts/$key');
 		#if MODS_ALLOWED
-		var file:String = modFolders(key);
+		var file:String = modFolders(folderKey);
 		if(FileSystem.exists(file)) return file;
 		#end
 		return 'assets/$folderKey';

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -32,9 +32,7 @@ import substates.GameOverSubstate;
 
 import psychlua.LuaUtils;
 import psychlua.LuaUtils.LuaTweenOptions;
-#if HSCRIPT_ALLOWED
 import psychlua.HScript;
-#end
 import psychlua.DebugLuaText;
 import psychlua.ModchartSprite;
 
@@ -49,13 +47,34 @@ class FunkinLua {
 	public var scriptName:String = '';
 	public var modFolder:String = null;
 	public var closed:Bool = false;
-
-	#if HSCRIPT_ALLOWED
-	public var hscript:HScript = null;
-	#end
-
+	
 	public var callbacks:Map<String, Dynamic> = new Map<String, Dynamic>();
 	public static var customFunctions:Map<String, Dynamic> = new Map<String, Dynamic>();
+	
+	#if LUA_ALLOWED
+	public var parentLua:FunkinLua;
+	#end
+	
+	#if HSCRIPT_ALLOWED
+	public var hscript:HScript = null;
+	public function initHaxeModule(code:String = '', ?varsToBring:Dynamic) {
+		@:privateAccess {
+		if (hscript == null) {
+			trace('initializing haxe interp for: $scriptName');
+			hscript = new HScript(this);
+		}
+		try {
+			if (hscript.scriptCode != code) {
+				hscript.scriptCode = code;
+				hscript.parse(true);
+			}
+		} catch (e) {
+			throw e;
+		}
+		hscript.varsToBring = varsToBring;
+		}
+	}
+	#end
 
 	public function new(scriptName:String) {
 		lua = LuaL.newstate();
@@ -1539,10 +1558,10 @@ class FunkinLua {
 			return closed;
 		});
 
+		HScript.implement(this);
 		#if DISCORD_ALLOWED DiscordClient.addLuaCallbacks(lua); #end
 		#if ACHIEVEMENTS_ALLOWED Achievements.addLuaCallbacks(lua); #end
 		#if TRANSLATIONS_ALLOWED Language.addLuaCallbacks(lua); #end
-		#if HSCRIPT_ALLOWED HScript.implement(this); #end
 		#if flxanimate FlxAnimateFunctions.implement(this); #end
 		ReflectionFunctions.implement(this);
 		TextFunctions.implement(this);
@@ -1567,12 +1586,7 @@ class FunkinLua {
 
 			var resultStr:String = Lua.tostring(lua, result);
 			if(resultStr != null && result != 0) {
-				trace(resultStr);
-				#if windows
-				lime.app.Application.current.window.alert(resultStr, 'Error on lua script!');
-				#else
-				luaTrace('$scriptName\n$resultStr', true, false, FlxColor.RED);
-				#end
+				luaTrace('ERROR ON LOADING ($scriptName): $resultStr', true, false, 0xffb30000);
 				lua = null;
 				return;
 			}

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -28,7 +28,6 @@ class HScript extends Iris {
 		PlayState.instance.addTextToDebug(errorToString(e, funcName, this), executed ? FlxColor.RED : 0xffb30000);
 	}
 	public static function hscriptLog(severity:ErrorSeverity, x:Dynamic, ?pos:haxe.PosInfos) {
-		trace('loggg $x');
 		var message:String = Std.string(x);
 		var origin:String = pos?.fileName ?? 'hscript';
 		#if hscriptPos

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -283,7 +283,7 @@ class HScript extends Iris {
 		set('createCallback', function(name:String, func:Dynamic, ?funk:FunkinLua = null) {
 			if(funk == null) funk = parentLua;
 			
-			if(parentLua != null) funk.addLocalCallback(name, func);
+			if(funk != null) funk.addLocalCallback(name, func);
 			else FunkinLua.luaTrace('createCallback ($name): 3rd argument is null', false, false, FlxColor.RED);
 		});
 		#end
@@ -414,6 +414,7 @@ class HScript extends Iris {
 			if (funk.hscript == null) funk.initHaxeModule();
 			
 			var cls:Dynamic = Type.resolveClass('$libPackage.$libName');
+			if (cls == null) cls = Type.resolveEnum('$libPackage.$libName');
 			if (cls == null) {
 				FunkinLua.luaTrace('addHaxeLibrary: Class "$libPackage.$libName" wasn\'t found!', false, false, FlxColor.RED);
 				return false;

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -39,7 +39,7 @@ class HScript extends Iris {
 		var color:FlxColor;
 		switch (severity) {
 			case FATAL:
-				color = 0xff800000;
+				color = 0xffb30000;
 				fullTrace = 'FATAL ' + fullTrace;
 			case ERROR:
 				color = FlxColor.RED;
@@ -280,9 +280,9 @@ class HScript extends Iris {
 
 		// this one was tested
 		set('createCallback', function(name:String, func:Dynamic, ?funk:FunkinLua = null) {
-			if(funk == null) funk = parentLua;
+			if (funk == null) funk = parentLua;
 			
-			if(funk != null) funk.addLocalCallback(name, func);
+			if (funk != null) funk.addLocalCallback(name, func);
 			else FunkinLua.luaTrace('createCallback ($name): 3rd argument is null', false, false, FlxColor.RED);
 		});
 		#end
@@ -412,10 +412,13 @@ class HScript extends Iris {
 		funk.addLocalCallback("addHaxeLibrary", function(libName:String, ?libPackage:String = '') {
 			if (funk.hscript == null) funk.initHaxeModule();
 			
-			var cls:Dynamic = Type.resolveClass('$libPackage.$libName');
-			if (cls == null) cls = Type.resolveEnum('$libPackage.$libName');
+			libName = libName ?? '';
+			var str:String = libPackage.length > 0 ? '$libPackage.$libName' : libName;
+			var cls:Dynamic = Type.resolveClass(str);
+			if (cls == null) cls = Type.resolveEnum(str);
+			
 			if (cls == null) {
-				FunkinLua.luaTrace('addHaxeLibrary: Class "$libPackage.$libName" wasn\'t found!', false, false, FlxColor.RED);
+				FunkinLua.luaTrace('addHaxeLibrary: Class "$str" wasn\'t found!', false, false, FlxColor.RED);
 				return false;
 			} else {
 				funk.hscript.set(libName, cls);
@@ -424,9 +427,6 @@ class HScript extends Iris {
 		});
 	}
 	#end
-
-	override public function set(name:String, value:Dynamic, allowOverride:Bool = true):Void
-		super.set(name, value, allowOverride);
 
 	override public function destroy() {
 		origin = null;

--- a/source/psychlua/LuaUtils.hx
+++ b/source/psychlua/LuaUtils.hx
@@ -264,6 +264,10 @@ class LuaUtils
 		return false;
 	}
 	
+	public static function typeSupported(value:Dynamic) {
+		return (value == null || isOfTypes(value, [Bool, Int, Float, String, Array]) || Type.typeof(value) == Type.ValueType.TObject);
+	}
+	
 	public static function getTargetInstance()
 	{
 		if(PlayState.instance != null) return PlayState.instance.isDead ? GameOverSubstate.instance : PlayState.instance;

--- a/source/psychlua/ReflectionFunctions.hx
+++ b/source/psychlua/ReflectionFunctions.hx
@@ -25,10 +25,10 @@ class ReflectionFunctions
 		Lua_helper.add_callback(lua, "setProperty", function(variable:String, value:Dynamic, ?allowMaps:Bool = false, ?allowInstances:Bool = false) {
 			var split:Array<String> = variable.split('.');
 			if(split.length > 1) {
-				LuaUtils.setVarInArray(LuaUtils.getPropertyLoop(split, true, allowMaps), split[split.length-1], allowInstances ? parseSingleInstance(value) : value, allowMaps);
+				LuaUtils.setVarInArray(LuaUtils.getPropertyLoop(split, true, allowMaps), split[split.length-1], allowInstances ? parseInstances(value) : value, allowMaps);
 				return value;
 			}
-			LuaUtils.setVarInArray(LuaUtils.getTargetInstance(), variable, allowInstances ? parseSingleInstance(value) : value, allowMaps);
+			LuaUtils.setVarInArray(LuaUtils.getTargetInstance(), variable, allowInstances ? parseInstances(value) : value, allowMaps);
 			return value;
 		});
 		Lua_helper.add_callback(lua, "getPropertyFromClass", function(classVar:String, variable:String, ?allowMaps:Bool = false) {
@@ -63,10 +63,10 @@ class ReflectionFunctions
 				for (i in 1...split.length-1)
 					obj = LuaUtils.getVarInArray(obj, split[i], allowMaps);
 
-				LuaUtils.setVarInArray(obj, split[split.length-1], allowInstances ? parseSingleInstance(value) : value, allowMaps);
+				LuaUtils.setVarInArray(obj, split[split.length-1], allowInstances ? parseInstances(value) : value, allowMaps);
 				return value;
 			}
-			LuaUtils.setVarInArray(myClass, variable, allowInstances ? parseSingleInstance(value) : value, allowMaps);
+			LuaUtils.setVarInArray(myClass, variable, allowInstances ? parseInstances(value) : value, allowMaps);
 			return value;
 		});
 		Lua_helper.add_callback(lua, "getPropertyFromGroup", function(group:String, index:Int, variable:Dynamic, ?allowMaps:Bool = false) {
@@ -120,14 +120,14 @@ class ReflectionFunctions
 						{
 							if(Type.typeof(variable) == ValueType.TInt)
 							{
-								leArray[variable] = allowInstances ? parseSingleInstance(value) : value;
+								leArray[variable] = allowInstances ? parseInstances(value) : value;
 								return value;
 							}
-							LuaUtils.setGroupStuff(leArray, variable, allowInstances ? parseSingleInstance(value) : value, allowMaps);
+							LuaUtils.setGroupStuff(leArray, variable, allowInstances ? parseInstances(value) : value, allowMaps);
 						}
 
 					default: //Is Group
-						LuaUtils.setGroupStuff(realObject.members[index], variable, allowInstances ? parseSingleInstance(value) : value, allowMaps);
+						LuaUtils.setGroupStuff(realObject.members[index], variable, allowInstances ? parseInstances(value) : value, allowMaps);
 				}
 			}
 			else FunkinLua.luaTrace('setPropertyFromGroup: Group/Array $group doesn\'t exist!', false, false, FlxColor.RED);
@@ -197,28 +197,29 @@ class ReflectionFunctions
 			}
 		});
 		
-		Lua_helper.add_callback(lua, "callMethod", function(funcToRun:String, ?args:Array<Dynamic> = null) {
+		Lua_helper.add_callback(lua, "callMethod", function(funcToRun:String, ?args:Array<Dynamic>) {
 			var parent:Dynamic = PlayState.instance;
 			var split:Array<String> = funcToRun.split('.');
 			var varParent:Dynamic = MusicBeatState.getVariables().get(split[0].trim());
-			if(varParent != null)
-			{
+			if (!Std.isOfType(args, Array)) args = [];
+			if(varParent != null) {
 				split.shift();
 				funcToRun = split.join('.').trim();
 				parent = varParent;
 			}
 			
-			if(funcToRun.length > 0)
-			{
+			if(funcToRun.length > 0) {
 				return callMethodFromObject(parent, funcToRun, parseInstances(args));
 			}
 			return Reflect.callMethod(null, parent, parseInstances(args));
 		});
-		Lua_helper.add_callback(lua, "callMethodFromClass", function(className:String, funcToRun:String, ?args:Array<Dynamic> = null) {
+		Lua_helper.add_callback(lua, "callMethodFromClass", function(className:String, funcToRun:String, ?args:Array<Dynamic>) {
+			if (!Std.isOfType(args, Array)) args = [];
 			return callMethodFromObject(Type.resolveClass(className), funcToRun, parseInstances(args));
 		});
 
-		Lua_helper.add_callback(lua, "createInstance", function(variableToSave:String, className:String, ?args:Array<Dynamic> = null) {
+		Lua_helper.add_callback(lua, "createInstance", function(variableToSave:String, className:String, ?args:Array<Dynamic>) {
+			if (!Std.isOfType(args, Array)) args = [];
 			variableToSave = variableToSave.trim().replace('.', '');
 			if(MusicBeatState.getVariables().get(variableToSave) == null)
 			{
@@ -266,17 +267,19 @@ class ReflectionFunctions
 		});
 	}
 
-	static function parseInstances(args:Array<Dynamic>)
-	{
-		if(args == null) return [];
-
-		for (i in 0...args.length)
-		{
-			args[i] = parseSingleInstance(args[i]);
-		}
-		return args;
+	static function parseInstanceArray(arg:Array<Dynamic>) {
+		var newArray:Array<Dynamic> = [];
+		for (val in arg)
+			newArray.push(parseInstances(val));
+		return newArray;
 	}
-	
+	public static function parseInstances(arg:Dynamic):Dynamic {
+		if (Std.isOfType(arg, Array)) {
+			return parseInstanceArray(arg);
+		} else {
+			return parseSingleInstance(arg);
+		}
+	}
 	public static function parseSingleInstance(arg:Dynamic)
 	{
 		var argStr:String = cast arg;

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3292,7 +3292,8 @@ class PlayState extends MusicBeatState
 			if (newScript != null) newScript.destroy();
 			return;
 		}
-		
+
+		if (newScript == null) return;
 		if (Std.isOfType(newScript.returnValue, crowplexus.hscript.Expr.Error)) {
 			newScript.destroy();
 		} else {

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3366,10 +3366,11 @@ class PlayState extends MusicBeatState
 
 			var callValue:Dynamic = script.run(funcToCall, args);
 			if (callValue == null) continue;
-			
-			if((callValue == LuaUtils.Function_StopHScript || callValue == LuaUtils.Function_StopAll) && !excludeValues.contains(callValue) && !ignoreStops) {
-				returnVal = callValue;
-				break;
+			if (!excludeValues.contains(callValue)) {
+				if ((callValue == LuaUtils.Function_StopHScript || callValue == LuaUtils.Function_StopAll) && !ignoreStops)
+					return callValue;
+				if (callValue != null && !excludeValues.contains(callValue))
+					returnVal = callValue;
 			}
 		}
 		#end

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3283,7 +3283,15 @@ class PlayState extends MusicBeatState
 
 	public function initHScript(file:String)
 	{
-		var newScript:HScript = new HScript(null, file);
+		var newScript:HScript = null;
+		try {
+			var newScript:HScript = new HScript(null, file);
+		} catch (e:Dynamic) {
+			addTextToDebug('ERROR ON LOADING ($file) - $e', FlxColor.RED);
+			var newScript:HScript = cast (Iris.instances.get(file), HScript);
+			if (newScript != null) newScript.destroy();
+			return;
+		}
 		
 		if (Std.isOfType(newScript.returnValue, crowplexus.hscript.Expr.Error)) {
 			newScript.destroy();


### PR DESCRIPTION
implements all proposed hscript fixes in https://github.com/ShadowMario/FNF-PsychEngine/pull/15621, and has other additional changes:
- (INTERNAL) some of the hscript class code has been overhauled to be more efficient; should still be entirely compatible with versions prior!
  - also added a function to the class `run(?functionName, ?functionArguments)`, similar to `executeFunction` previously but also allows the main body to be executed if no function name is provided
- FATAL hscript errors and warnings are now logged when luaDebugMode is enabled too, with their own colors
![image](https://github.com/user-attachments/assets/c09672f0-eb88-4931-ab25-cb3f13752ea6)
the trace function has also been added to print a message with the line number (highlighted with the cyan color)
- FATAL errors in lua scripts are now only printed in the game's debug console, rather than showing an alert (in windows)
![image](https://github.com/user-attachments/assets/3564c8ea-c82c-41c1-a0d3-970f5f7cd33d)
to differentiate them from the rest of the errors and very much like the new fatal hscript errors, they're highlighted in dark red
- ~`Paths.font` has been fixed? changed an incorrect variable when getting the font path, so `setTextFont` in lua API should work correctly now~ fixed in another pr (which has been merged)
- the reflection functions (like get/setProperty[FromClass]) now allow instance argument parsing inside arrays; this means you can, for instance, set camera filters without needing to use hscript at all
  code example:
  ```lua
  makeLuaSprite('shd')
  setSpriteShader('shd', 'adjustColor')
  createInstance('filter', 'openfl.filters.ShaderFilter', {instanceArg('shd.shader')})
  setProperty('camGame.filters', {instanceArg('filter')}, false, true) -- this was previously not possible!
  setShaderFloat('shd', 'hue', -15)
  ```
- `callMethod`, `callMethodFromClass` and `createInstance` now allow you to not pass the arguments array at all; no more {''} (ex. `callMethod('openPauseMenu', {''})` -> `callMethod('openPauseMenu')`)
- if `HSCRIPT_ALLOWED` is disabled, trying to use hscript related API functions in lua should now actually just show a warning (this was accounted for already, but did not work because the hscript class wasn't even created if the flag wasn't defined)