### PR TITLE
Fix hxvlc crashing issue

### DIFF
--- a/source/objects/FunkinVideo.hx
+++ b/source/objects/FunkinVideo.hx
@@ -1,0 +1,84 @@
+package backend;
+
+import flixel.FlxG;
+#if VIDEOS_ALLOWED
+import hxvlc.flixel.FlxVideoSprite;
+import hxvlc.flixel.FlxVideo; //Just so it's compiled into the build for something like hscript
+#end
+
+//Psych 1.0's VideoSprite class would end up crashing Psych so I made a new class that doesn't have this issue
+class FunkinVideo extends FlxVideoSprite {
+	public var onFinish:(skipped:Bool) -> Void;
+	
+	public var skippable:Bool = false;
+	public var loaded:Bool = false;
+	
+	public function new(videoName:String, canSkip:Bool = true, loop:Bool = false) {
+		this.skippable = canSkip;
+		
+		super();
+		
+		antialiasing = ClientPrefs.globalAntialiasing;
+		scrollFactor.set();
+		cameras = [FlxG.cameras.list[FlxG.cameras.list.length - 1]];
+		
+		bitmap.onFormatSetup.add(function() {
+			if (this != null && bitmap != null && bitmap.bitmapData != null) {
+				final scale:Float = Math.min(FlxG.width / bitmap.bitmapData.width, FlxG.height / bitmap.bitmapData.height);
+
+				setGraphicSize(Std.int(bitmap.bitmapData.width * scale), Std.int(bitmap.bitmapData.height * scale));
+				updateHitbox();
+				screenCenter();
+				
+				#if FLX_SOUND_SYSTEM
+				autoVolumeHandle = false;
+				bitmap.volume = getVolumeFromFlxG(); //The video is just too quiet...
+				#end
+			}
+		});
+		
+		bitmap.onEndReached.add(function() {
+			if(onFinish != null) onFinish(false);
+			destroy();
+		});
+	}
+	
+	public function loadVideo(filePath:String, ?loop:Dynamic = false):Bool {
+		if(!loaded) {
+			this.load(filePath, loop ? ['input-repeat=65545'] : null);
+			loaded = true;
+			return true;
+		}
+		trace("WARNING: Video already has it's data loaded!");
+		return false;
+	}
+	
+	public function playVideo():Bool {
+		if(!loaded) {
+			trace("WARNING: Cannot play video because it has not been loaded!");
+			return false;
+		}
+		this.play();
+		return true;
+	}
+	
+	override function update(elapsed:Float)
+	{
+		super.update(elapsed);
+		
+		bitmap.volume = getVolumeFromFlxG();
+		if(skippable && FlxG.keys.justPressed.SPACE) {
+			if(onFinish != null) onFinish(true);
+			this.destroy();
+		}
+	}
+	
+	override function destroy() {
+		onFinish = null;
+		super.destroy();
+	}
+	
+	private function getVolumeFromFlxG():Int {
+		return Std.int(3 * ((FlxG.sound.muted ? 0 : 1) * FlxG.sound.volume) * 100);
+	}
+}

--- a/source/objects/FunkinVideo.hx
+++ b/source/objects/FunkinVideo.hx
@@ -1,12 +1,12 @@
-package backend;
+package objects;
 
 import flixel.FlxG;
 #if VIDEOS_ALLOWED
 import hxvlc.flixel.FlxVideoSprite;
-import hxvlc.flixel.FlxVideo; //Just so it's compiled into the build for something like hscript
+import hxvlc.flixel.FlxVideo; //Just so it's compiled into the build for something like hscript-iris
 #end
 
-//Psych 1.0's VideoSprite class would end up crashing Psych so I made a new class that doesn't have this issue
+//VideoSprite.hx was broken when it reached the end of a video so I made a new class (Originally from My Psych fork) -TBar
 class FunkinVideo extends FlxVideoSprite {
 	public var onFinish:(skipped:Bool) -> Void;
 	

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -1263,6 +1263,7 @@ class FunkinLua {
 			}
 			return false;
 		});
+		/*
 		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, ?canSkip:Bool = true) {
 			#if VIDEOS_ALLOWED
 			if(FileSystem.exists(Paths.video(videoFile)))
@@ -1291,6 +1292,22 @@ class FunkinLua {
 				else
 					game.startCountdown();
 			});
+			return true;
+			#end
+		});
+		*/
+		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, canSkip:Bool = true, loopVid:Bool = false) {
+			#if VIDEOS_ALLOWED
+			if(FileSystem.exists(Paths.video(videoFile)) || videoFile.startsWith("https://")) {
+				PlayState.instance.startVideo(videoFile, canSkip, loopVid);
+				return true;
+			} else luaTrace('startVideo: Video file not found: $videoFile', false, false, FlxColor.RED);
+			return false;
+			#else
+			if(PlayState.instance.endingSong) PlayState.instance.endSong();
+			else PlayState.instance.startCountdown();
+
+			luaTrace("startVideo: Platform unsupported for Videos!", false, false, FlxColor.RED);
 			return true;
 			#end
 		});


### PR DESCRIPTION
Fixes an issue with VideoSprite.hx where letting a video played by `startVideo` play until the end will make the game unresponsive. A new class was created (FunkinVideo.hx) that fixes this issue.
The class also imports a couple of extra hxvlc classes for people to have more freedom with videos in haxe scripts or `runHaxeCode`, Doing things like running mid-song videos, preloading videos, and even playing videos from website urls.

-Fixes hxvlc issue.
-Adds a lua/hscript callback: `onVideoCompleted(tag:String, skipped:Bool)`
-Compiles extra hxvlc classes for more diverse haxe scripting possibilities with videos.