### PR TITLE
Added hxWindowColorMode

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -121,6 +121,7 @@
 	<haxelib name="hscript-iris" if="HSCRIPT_ALLOWED" version="1.1.0"/>
 	<haxelib name="hxvlc" if="VIDEOS_ALLOWED" version="1.9.2"/>
 	<haxelib name="hxdiscord_rpc" version="1.2.4" if="DISCORD_ALLOWED"/>
+	<haxelib name="hxWindowColorMode" version="0.2.0" if="windows"/>
 	<haxelib name="flxanimate"/>
 
 	<!-- Disable Discord IO Thread -->

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -132,6 +132,9 @@ class HScript extends Iris
 		#if flxanimate
 		set('FlxAnimate', FlxAnimate);
 		#end
+		#if hxWindowColorMode
+		set('WindowColorMode', hxwindowmode.WindowColorMode);
+		#end
 
 		// Functions & Variables
 		set('setVar', function(name:String, value:Dynamic) {


### PR DESCRIPTION
Added `hxWindowColorMode` to the engine, allowing for changing the window header, border, and title text!

run `haxelib install hxWindowColorMode 0.2.0` to add the library to your haxelibs.

The class is pre-added to HScript.hx so you can freely use it without having to use `import hxwindowmode.WindowColorMode;`

You can also use lua to call these functions using `callMethodFromClass` like:
`callMethodFromClass("hxwindowmode.WindowColorMode", "setWindowColorMode", {true, true});`