### PR TITLE
Note Splash Revamp

### DIFF
--- a/assets/shared/images/noteSplashes/noteSplashes-diamond.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-diamond.json
@@ -3,112 +3,112 @@
 		"purple": {
 			"noteData": 0,
 			"offsets": [
-				95,
-				68
+				-28,
+				-52
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond purple 10",
+			"prefix": "note splash diamond purple 1",
 			"name": "purple",
 			"indices": []
 		},
 		"blue2": {
 			"noteData": 5,
 			"offsets": [
-				106,
-				60
+				-16,
+				-55
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond blue 20",
+			"prefix": "note splash diamond blue 2",
 			"name": "blue2",
 			"indices": []
 		},
 		"red2": {
 			"noteData": 7,
 			"offsets": [
-				106,
-				60
+				-16,
+				-55
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond red 20",
+			"prefix": "note splash diamond red 2",
 			"name": "red2",
 			"indices": []
 		},
 		"red": {
 			"noteData": 3,
 			"offsets": [
-				95,
-				68
+				-28,
+				-52
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond red 10",
+			"prefix": "note splash diamond red 1",
 			"name": "red",
 			"indices": []
 		},
 		"purple2": {
 			"noteData": 4,
 			"offsets": [
-				106,
-				60
+				-16,
+				-55
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond purple 20",
+			"prefix": "note splash diamond purple 2",
 			"name": "purple2",
 			"indices": []
 		},
 		"blue": {
 			"noteData": 1,
 			"offsets": [
-				95,
-				68
+				-28,
+				-52
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond blue 10",
+			"prefix": "note splash diamond blue 1",
 			"name": "blue",
 			"indices": []
 		},
 		"green2": {
 			"noteData": 6,
 			"offsets": [
-				106,
-				60
+				-16,
+				-55
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond green 20",
+			"prefix": "note splash diamond green 2",
 			"name": "green2",
 			"indices": []
 		},
 		"green": {
 			"noteData": 2,
 			"offsets": [
-				95,
-				68
+				-28,
+				-52
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "note splash diamond green 10",
+			"prefix": "note splash diamond green 1",
 			"name": "green",
 			"indices": []
 		}

--- a/assets/shared/images/noteSplashes/noteSplashes-electric.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-electric.json
@@ -2,75 +2,62 @@
 	"animations": {
 		"purple": {
 			"offsets": [
-				82,
-				62
+				-44,
+				-54
 			],
 			"noteData": 0,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash electro purple 10",
+			"prefix": "splash electro purple 1",
 			"indices": [],
 			"name": "purple"
 		},
 		"blue": {
 			"offsets": [
-				82,
-				62
+				-44,
+				-54
 			],
 			"noteData": 1,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash electro blue 10",
+			"prefix": "splash electro blue 1",
 			"indices": [],
 			"name": "blue"
 		},
 		"red": {
 			"offsets": [
-				82,
-				62
+				-44,
+				-54
 			],
 			"noteData": 3,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash electro red 10",
+			"prefix": "splash electro red 1",
 			"indices": [],
 			"name": "red"
 		},
 		"green": {
 			"offsets": [
-				82,
-				62
+				-44,
+				-54
 			],
 			"noteData": 2,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash electro green 10",
+			"prefix": "splash electro green 1",
 			"indices": [],
 			"name": "green"
 		}
 	},
 	"allowRGB": true,
 	"allowPixel": true,
-	"rgb": [
-		{
-			"b": 0,
-			"g": 0,
-			"r": 255
-		},
-		{
-			"b": 16,
-			"g": 16,
-			"r": 16
-		},
-		null
-	],
 	"scale": 1
 }

--- a/assets/shared/images/noteSplashes/noteSplashes-sparkles.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-sparkles.json
@@ -2,41 +2,41 @@
 	"animations": {
 		"blue": {
 			"offsets": [
-				69,
-				68
+				-48,
+				-48
 			],
 			"noteData": 1,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash sparkles blue 10",
+			"prefix": "splash sparkles blue 1",
 			"indices": [],
 			"name": "blue"
 		},
 		"purple": {
 			"offsets": [
-				76,
-				68
+				-48,
+				-48
 			],
 			"noteData": 0,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash sparkles purple 10",
+			"prefix": "splash sparkles purple 1",
 			"indices": [],
 			"name": "purple"
 		},
 		"green": {
-			"prefix": "splash sparkles green 10",
+			"prefix": "splash sparkles green 1",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				70,
-				70
+				-48,
+				-48
 			],
 			"indices": [],
 			"name": "green",
@@ -44,15 +44,15 @@
 		},
 		"red": {
 			"offsets": [
-				66,
-				68
+				-48,
+				-48
 			],
 			"noteData": 3,
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "splash sparkles red 10",
+			"prefix": "splash sparkles red 1",
 			"indices": [],
 			"name": "red"
 		}

--- a/assets/shared/images/noteSplashes/noteSplashes-vanilla.json
+++ b/assets/shared/images/noteSplashes/noteSplashes-vanilla.json
@@ -3,112 +3,112 @@
 		"purple": {
 			"noteData": 0,
 			"offsets": [
-				95,
-				105
+				-26,
+				-20
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash purple 10",
+			"prefix": "vanilla splash purple 1",
 			"name": "purple",
 			"indices": []
 		},
 		"blue2": {
 			"noteData": 5,
 			"offsets": [
-				105,
-				90
+				-14,
+				-16
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash blue 20",
+			"prefix": "vanilla splash blue 2",
 			"name": "blue2",
 			"indices": []
 		},
 		"red2": {
 			"noteData": 7,
 			"offsets": [
-				95,
-				100
+				-14,
+				-16
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash red 20",
+			"prefix": "vanilla splash red 2",
 			"name": "red2",
 			"indices": []
 		},
 		"red": {
 			"noteData": 3,
 			"offsets": [
-				80,
-				100
+				-26,
+				-20
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash red 10",
+			"prefix": "vanilla splash red 1",
 			"name": "red",
 			"indices": []
 		},
 		"purple2": {
 			"noteData": 4,
 			"offsets": [
-				105,
-				90
+				-14,
+				-16
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash purple 20",
+			"prefix": "vanilla splash purple 2",
 			"name": "purple2",
 			"indices": []
 		},
 		"blue": {
 			"noteData": 1,
 			"offsets": [
-				87,
-				103
+				-26,
+				-20
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash blue 10",
+			"prefix": "vanilla splash blue 1",
 			"name": "blue",
 			"indices": []
 		},
 		"green2": {
 			"noteData": 6,
 			"offsets": [
-				94,
-				100
+				-14,
+				-16
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash green 20",
+			"prefix": "vanilla splash green 2",
 			"name": "green2",
 			"indices": []
 		},
 		"green": {
 			"noteData": 2,
 			"offsets": [
-				90,
-				100
+				-26,
+				-20
 			],
 			"fps": [
 				22,
 				26
 			],
-			"prefix": "vanilla splash green 10",
+			"prefix": "vanilla splash green 1",
 			"name": "green",
 			"indices": []
 		}

--- a/assets/shared/images/noteSplashes/noteSplashes.json
+++ b/assets/shared/images/noteSplashes/noteSplashes.json
@@ -1,112 +1,112 @@
 {
 	"animations": {
 		"blue2": {
-			"prefix": "note splash blue 20",
+			"prefix": "note splash blue 2",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				70,
-				76
+				-52,
+				-48
 			],
 			"indices": [],
 			"name": "blue2",
 			"noteData": 5
 		},
 		"purple": {
-			"prefix": "note splash purple 10",
+			"prefix": "note splash purple 1",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				60,
-				60
+				-58,
+				-55
 			],
 			"indices": [],
 			"name": "purple",
 			"noteData": 0
 		},
 		"red": {
-			"prefix": "note splash red 10",
+			"prefix": "note splash red 1",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				57,
-				58
+				-58,
+				-55
 			],
 			"indices": [],
 			"name": "red",
 			"noteData": 3
 		},
 		"red2": {
-			"prefix": "note splash red 20",
+			"prefix": "note splash red 2",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				66,
-				80
+				-52,
+				-48
 			],
 			"indices": [],
 			"name": "red2",
 			"noteData": 7
 		},
 		"blue": {
-			"prefix": "note splash blue 10",
+			"prefix": "note splash blue 1",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				55,
-				60
+				-58,
+				-55
 			],
 			"indices": [],
 			"name": "blue",
 			"noteData": 1
 		},
 		"purple2": {
-			"prefix": "note splash purple 20",
+			"prefix": "note splash purple 2",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				76,
-				80
+				-52,
+				-48
 			],
 			"indices": [],
 			"name": "purple2",
 			"noteData": 4
 		},
 		"green": {
-			"prefix": "note splash green 10",
+			"prefix": "note splash green 1",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				57,
-				61
+				-58,
+				-55
 			],
 			"indices": [],
 			"name": "green",
 			"noteData": 2
 		},
 		"green2": {
-			"prefix": "note splash green 20",
+			"prefix": "note splash green 2",
 			"fps": [
 				22,
 				26
 			],
 			"offsets": [
-				70,
-				80
+				-52,
+				-48
 			],
 			"indices": [],
 			"name": "green2",

--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -25,6 +25,9 @@ typedef NoteSplashData = {
 	useGlobalShader:Bool, //breaks r/g/b but makes it copy default colors for your custom note
 	useRGBShader:Bool,
 	antialiasing:Bool,
+	r:FlxColor,
+	g:FlxColor,
+	b:FlxColor,
 	a:Float
 }
 
@@ -101,6 +104,9 @@ class Note extends FlxSprite
 		antialiasing: !PlayState.isPixelStage,
 		useGlobalShader: false,
 		useRGBShader: (PlayState.SONG != null) ? !(PlayState.SONG.disableNoteRGB == true) : true,
+		r: -1,
+		g: -1,
+		b: -1,
 		a: ClientPrefs.data.splashAlpha
 	};
 
@@ -185,7 +191,7 @@ class Note extends FlxSprite
 	}
 
 	private function set_noteType(value:String):String {
-		noteSplashData.texture = PlayState.SONG != null ? PlayState.SONG.splashSkin : 'noteSplashes';
+		noteSplashData.texture = PlayState.SONG != null ? PlayState.SONG.splashSkin : 'noteSplashes/noteSplashes';
 		defaultRGB();
 
 		if(noteData > -1 && noteType != value) {
@@ -202,9 +208,9 @@ class Note extends FlxSprite
 					rgbShader.b = 0xFF990022;
 
 					// splash data and colors
-					//noteSplashData.r = 0xFFFF0000;
-					//noteSplashData.g = 0xFF101010;
-					noteSplashData.texture = 'noteSplashes-electric';
+					noteSplashData.r = 0xFFFF0000;
+					noteSplashData.g = 0xFF101010;
+					noteSplashData.texture = 'noteSplashes/noteSplashes-electric';
 
 					// gameplay data
 					lowPriority = true;

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -1,20 +1,16 @@
 package objects;
 
 import backend.animation.PsychAnimationController;
-
 import shaders.RGBPalette;
-
-import states.editors.NoteSplashEditorState;
-
 import flixel.system.FlxAssets.FlxShader;
 
-private typedef RGB = {
+typedef RGB = {
 	r:Null<Int>,
 	g:Null<Int>,
 	b:Null<Int>
 }
 
-private typedef NoteSplashAnim = {
+typedef NoteSplashAnim = {
 	name:String,
 	noteData:Int,
 	prefix:String,
@@ -34,20 +30,26 @@ typedef NoteSplashConfig = {
 class NoteSplash extends FlxSprite
 {
 	public var rgbShader:PixelSplashShaderRef;
-	public var skin:String;
+	public var texture:String;
 	public var config(default, set):NoteSplashConfig;
-
-	public static var DEFAULT_SKIN:String = "noteSplashes/noteSplashes";
-	public static var configs:Map<String, NoteSplashConfig> = new Map();
-
 	public var babyArrow:StrumNote;
+	public var noteData:Int = 0;
+
+	public var copyX:Bool = true;
+	public var copyY:Bool = true;
+	public var inEditor:Bool = false;
+
+	var spawned:Bool = false;
 	var noteDataMap:Map<Int, String> = new Map();
 
-	public function new(?splash:String)
-	{
-		super();
+	public static var defaultNoteSplash(default, never):String = "noteSplashes/noteSplashes";
+	public static var configs:Map<String, NoteSplashConfig> = new Map();
 
-        animation = new PsychAnimationController(this);
+	public function new(?x:Float = 0, ?y:Float = 0, ?splash:String)
+	{
+		super(x, y);
+
+		animation = new PsychAnimationController(this);
 
 		rgbShader = new PixelSplashShaderRef();
 		shader = rgbShader.shader;
@@ -55,33 +57,39 @@ class NoteSplash extends FlxSprite
 		loadSplash(splash);
 	}
 
+	public var maxAnims(default, set):Int = 0;
 	public function loadSplash(?splash:String)
 	{
-		config = null; // Reset config to the default so when reloaded it can be set properly
-		skin = null;
+		config = null;
+		maxAnims = 0;
 
-		var skin:String = splash;
-		if (skin == null || skin.length < 1)
-			skin = try PlayState.SONG.splashSkin catch(e) null;
-
-		if (skin == null || skin.length < 1)
-			skin = DEFAULT_SKIN + getSplashSkinPostfix();
-
-		this.skin = skin;
-
-		try frames = Paths.getSparrowAtlas(skin) catch (e) {
-			skin = DEFAULT_SKIN; // The splash skin was not found, return to the default
-			this.skin = skin;
-			try frames = Paths.getSparrowAtlas(skin) catch (e) {
-				active = visible = false;
+		texture = splash;
+		frames = Paths.getSparrowAtlas(texture);
+		if (frames == null)
+		{
+			texture = defaultNoteSplash + getSplashSkinPostfix();
+			frames = Paths.getSparrowAtlas(texture);
+			if (frames == null)
+			{
+				texture = defaultNoteSplash;
+				frames = Paths.getSparrowAtlas(texture);
 			}
 		}
 
-		var path:String = 'images/$skin.json';
-		if (configs.exists(path)) this.config = configs.get(path);
-		else if (Paths.fileExists(path, TEXT))
+		var path:String = 'images/$texture';
+		if (configs.exists(path))
 		{
-			var config:Dynamic = haxe.Json.parse(Paths.getTextFromFile(path));
+			this.config = configs.get(path);
+			for (anim in this.config.animations)
+			{
+				if (anim.noteData % 4 == 0)
+					maxAnims++;
+			}
+			return;
+		}
+		else if (Paths.fileExists('$path.json', TEXT))
+		{
+			var config:Dynamic = haxe.Json.parse(Paths.getTextFromFile('$path.json'));
 			if (config != null)
 			{
 				var tempConfig:NoteSplashConfig = {
@@ -94,58 +102,112 @@ class NoteSplash extends FlxSprite
 
 				for (i in Reflect.fields(config.animations))
 				{
-					tempConfig.animations.set(i, Reflect.field(config.animations, i));
+					var anim:NoteSplashAnim = Reflect.field(config.animations, i);
+					tempConfig.animations.set(i, anim);
+					if (anim.noteData % 4 == 0)
+						maxAnims++;
 				}
 
 				this.config = tempConfig;
-				configs.set(path, tempConfig);
+				configs.set(path, this.config);
+				return;
 			}
 		}
+
+		// Splashes with no json
+		var tempConfig:NoteSplashConfig = createConfig();
+		var anim:String = 'note splash';
+		var fps:Array<Null<Int>> = [22, 26];
+		var offsets:Array<Array<Float>> = [[0, 0]];
+		if (Paths.fileExists('$path.txt', TEXT)) // Backwards compatibility with 0.7 splash txts
+		{
+			var configFile:Array<String> = CoolUtil.listFromString(Paths.getTextFromFile('$path.txt'));
+			if (configFile.length > 0)
+			{
+				anim = configFile[0];
+				if (configFile.length > 1)
+				{
+					var framerates:Array<String> = configFile[1].split(' ');
+					fps = [Std.parseInt(framerates[0]), Std.parseInt(framerates[1])];
+					if (fps[0] == null) fps[0] = 22;
+					if (fps[1] == null) fps[1] = 26;
+
+					if (configFile.length > 2)
+					{
+						offsets = [];
+						for (i in 2...configFile.length)
+						{
+							if (configFile[i].trim() != '')
+							{
+								var animOffs:Array<String> = configFile[i].split(' ');
+								var x:Float = Std.parseFloat(animOffs[0]);
+								var y:Float = Std.parseFloat(animOffs[1]);
+								if (Math.isNaN(x)) x = 0;
+								if (Math.isNaN(y)) y = 0;
+								offsets.push([x, y]);
+							}
+						}
+					}
+				}
+			}
+		}
+
+		var failedToFind:Bool = false;
+		while (true)
+		{
+			for (v in Note.colArray)
+			{
+				if (!checkForAnim('$anim $v ${maxAnims+1}'))
+				{
+					failedToFind = true;
+					break;
+				}
+			}
+			if (failedToFind) break;
+			maxAnims++;
+		}
+
+		for (animNum in 0...maxAnims)
+		{
+			for (i => col in Note.colArray)
+			{
+				var data:Int = i % Note.colArray.length + (animNum * Note.colArray.length);
+				var name:String = animNum > 0 ? '$col' + (animNum + 1) : col;
+				var offset:Array<Float> = offsets[FlxMath.wrap(data, 0, Std.int(offsets.length-1))];
+				addAnimationToConfig(tempConfig, 1, name, '$anim $col ${animNum + 1}', fps, offset, [], data);
+			}
+		}
+
+		this.config = tempConfig;
+		configs.set(path, this.config);
 	}
 
-	public function spawnSplashNote(note:Note, ?noteData:Null<Int>, ?randomize:Bool = true)
-	{	
-		if (note != null && note.noteSplashData.texture != null)
-			loadSplash(note.noteSplashData.texture);
-
+	public function spawnSplashNote(?x:Float = 0, ?y:Float = 0, ?noteData:Int = 0, ?note:Note, ?randomize:Bool = true)
+	{
 		if (note != null && note.noteSplashData.disabled)
 			return;
 
-		if (babyArrow != null)
-			setPosition(babyArrow.x, babyArrow.y); // To prevent it from being misplaced for one game tick
+		aliveTime = 0;
 
-		if (noteData == null)
-			noteData = note != null ? note.noteData : 0;
-
-		if (randomize)
+		if (!inEditor)
 		{
-			var anims:Int = 0;
-			var datas:Int = 0;
-			var animArray:Array<Int> = [];
+			var loadedTexture:String = defaultNoteSplash + getSplashSkinPostfix();
+			if (note != null && note.noteSplashData.texture != null) loadedTexture = note.noteSplashData.texture;
+			else if (PlayState.SONG != null && PlayState.SONG.splashSkin != null && PlayState.SONG.splashSkin.length > 0) loadedTexture = PlayState.SONG.splashSkin;
 
-			while (true)
-			{
-				var data:Int = noteData % Note.colArray.length + (datas * Note.colArray.length); 
-				if (!noteDataMap.exists(data) || !animation.exists(noteDataMap[data]))
-					break;
-
-				datas++;
-				anims++;
-			}
-
-			if (anims > 1)
-			{
-				for (i in 0...anims)
-				{
-					var data = noteData % Note.colArray.length + (i * Note.colArray.length);
-					if (!animArray.contains(data))
-						animArray.push(data);
-				}
-			}
-
-			if (animArray.length > 1)
-				noteData = animArray[FlxG.random.bool() ? 0 : 1];
+			if (texture != loadedTexture) loadSplash(loadedTexture);
 		}
+
+		setPosition(x, y);
+
+		if (babyArrow != null)
+			setPosition(babyArrow.x - Note.swagWidth * 0.95, babyArrow.y - Note.swagWidth); // To prevent it from being misplaced for one game tick
+
+		if (note != null)
+			noteData = note.noteData;
+
+		if (randomize && maxAnims > 1)
+			noteData = noteData % Note.colArray.length + (FlxG.random.int(0, maxAnims - 1) * Note.colArray.length);
 
 		this.noteData = noteData;
 		var anim:String = playDefaultAnim();
@@ -153,31 +215,22 @@ class NoteSplash extends FlxSprite
 		var tempShader:RGBPalette = null;
 		if (config.allowRGB)
 		{
-			if (note == null)
-				note = new Note(0, noteData);
-
 			Note.initializeGlobalRGBShader(noteData % Note.colArray.length);
-			function useDefault()
+			if (inEditor || (note == null || note.noteSplashData.useRGBShader) && (PlayState.SONG == null || !PlayState.SONG.disableNoteRGB))
 			{
-				tempShader = Note.globalRgbShaders[noteData % Note.colArray.length];
-			}
-
-			if(((cast FlxG.state) is NoteSplashEditorState) || 
-				((note.noteSplashData.useRGBShader) && (PlayState.SONG == null || !PlayState.SONG.disableNoteRGB)))
-			{
+				tempShader = new RGBPalette();
 				// If Note RGB is enabled:
-				if((!note.noteSplashData.useGlobalShader || ((cast FlxG.state) is NoteSplashEditorState)))
+				if ((note == null || !note.noteSplashData.useGlobalShader) || inEditor)
 				{
 					var colors = config.rgb;
 					if (colors != null)
 					{
-						tempShader = new RGBPalette();
 						for (i in 0...colors.length)
 						{
 							if (i > 2) break;
 
 							var arr:Array<FlxColor> = ClientPrefs.data.arrowRGB[noteData % Note.colArray.length];
-							if(PlayState.isPixelStage) arr = ClientPrefs.data.arrowRGBPixel[noteData % Note.colArray.length];
+							if (PlayState.isPixelStage) arr = ClientPrefs.data.arrowRGBPixel[noteData % Note.colArray.length];
 
 							var rgb = colors[i];
 							if (rgb == null)
@@ -200,78 +253,110 @@ class NoteSplash extends FlxSprite
 							if (i == 0) tempShader.r = color;
 							else if (i == 1) tempShader.g = color;
 							else if (i == 2) tempShader.b = color;
-						} 
+						}
 					}
-					else useDefault();
+					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
+
+					if (note != null)
+					{
+						if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
+						if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
+						if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
+					}
 				}
-				else useDefault();
+				else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
 			}
 		}
 		rgbShader.copyValues(tempShader);
+		if (!config.allowPixel) rgbShader.pixelAmount = 1;
+		else if (PlayState.isPixelStage) rgbShader.pixelAmount = 6;
 
-		if(!config.allowPixel) rgbShader.pixelAmount = 1;
-
-		var conf = config.animations.get(anim);
+		offset.set(10, 10);
+		var conf:NoteSplashAnim = config.animations.get(anim);
 		var offsets:Array<Float> = [0, 0];
-
-		if (conf != null)
-			offsets = conf.offsets;
-
+		if (conf != null) offsets = conf.offsets;
 		if (offsets != null)
 		{
-			centerOffsets();
-			offset.set(offsets[0], offsets[1]);
+			offset.x += offsets[0];
+			offset.y += offsets[1];
 		}
 
-		animation.finishCallback = function(name:String)
-		{
+		animation.finishCallback = function(name:String) {
 			kill();
-		};
-		
-        alpha = ClientPrefs.data.splashAlpha;
-		if(note != null) alpha = note.noteSplashData.a;
+			spawned = false;
+		}
 
-		if(note != null) antialiasing = note.noteSplashData.antialiasing;
-		if(PlayState.isPixelStage) antialiasing = false;
+		alpha = ClientPrefs.data.splashAlpha;
+		if (note != null) alpha = note.noteSplashData.a;
 
-		if(animation.curAnim != null && conf != null)
+		antialiasing = ClientPrefs.data.antialiasing;
+		if (note != null) antialiasing = note.noteSplashData.antialiasing;
+		if (PlayState.isPixelStage && config.allowPixel) antialiasing = false;
+
+		var minFps:Int = 22;
+		var maxFps:Int = 26;
+		if (conf != null)
 		{
-			var minFps = conf.fps[0];
+			minFps = conf.fps[0];
 			if (minFps < 0) minFps = 0;
 
-			var maxFps = conf.fps[1];
+			maxFps = conf.fps[1];
 			if (maxFps < 0) maxFps = 0;
-
-			animation.curAnim.frameRate = FlxG.random.int(minFps, maxFps);
 		}
+
+		if (animation.curAnim != null)
+			animation.curAnim.frameRate = FlxG.random.int(minFps, maxFps);
+
+		spawned = true;
 	}
 	
-	public var noteData:Int = 0;
 	public function playDefaultAnim()
 	{
-		var animation:String = noteDataMap.get(noteData);
-		if (animation != null && this.animation.exists(animation))
-			this.animation.play(animation, true);
-		else
-			visible = false;
-		return animation;
+		var anim:String = noteDataMap.get(noteData);
+		if (anim != null && animation.exists(anim))
+			animation.play(anim, true);
+
+		return anim;
 	}
 
+	function checkForAnim(anim:String)
+	{
+		var animFrames = [];
+		@:privateAccess
+		animation.findByPrefix(animFrames, anim); // adds valid frames to animFrames
+
+		return animFrames.length > 0;
+	}
+
+	var aliveTime:Float = 0;
+	static var buggedKillTime:Float = 0.5; //automatically kills note splashes if they break to prevent it from flooding your HUD
 	override function update(elapsed:Float)
 	{
-		super.update(elapsed);
+		if (spawned)
+		{
+			aliveTime += elapsed;
+			if (animation.curAnim == null && aliveTime >= buggedKillTime)
+			{
+				kill();
+				spawned = false;
+			}
+		}
 
 		if (babyArrow != null)
 		{
-			//cameras = babyArrow.cameras;
-			setPosition(babyArrow.x, babyArrow.y);
+			if (copyX)
+				x = babyArrow.x - Note.swagWidth * 0.95;
+
+			if (copyY)
+				y = babyArrow.y - Note.swagWidth;
 		}
+		super.update(elapsed);
 	}
 
-    public static function getSplashSkinPostfix()
+	public static function getSplashSkinPostfix()
 	{
 		var skin:String = '';
-		if(ClientPrefs.data.splashSkin != ClientPrefs.defaultData.splashSkin)
+		if (ClientPrefs.data.splashSkin != ClientPrefs.defaultData.splashSkin)
 			skin = '-' + ClientPrefs.data.splashSkin.trim().toLowerCase().replace(' ', '-');
 		return skin;
 	}
@@ -300,6 +385,8 @@ class NoteSplash extends FlxSprite
 	{
 		if (value == null) value = createConfig();
 
+		@:privateAccess
+		animation.clearAnimations();
 		noteDataMap.clear();
 
 		for (i in value.animations)
@@ -307,7 +394,7 @@ class NoteSplash extends FlxSprite
 			var key:String = i.name;
 			if (i.prefix.length > 0 && key != null && key.length > 0)
 			{
-				if (i.indices != null && i.indices.length > 0 && key != null && key.length > 0)
+				if (i.indices != null && i.indices.length > 0)
 					animation.addByIndices(key, i.prefix, i.indices, "", i.fps[1], false);
 				else
 					animation.addByPrefix(key, i.prefix, i.fps[1], false);
@@ -319,6 +406,12 @@ class NoteSplash extends FlxSprite
 		scale.set(value.scale, value.scale);
 		return config = value;
 	}
+
+	function set_maxAnims(value:Int)
+	{
+		noteData = Std.int(FlxMath.wrap(noteData, 0, (value * Note.colArray.length) - 1));
+		return maxAnims = value;
+	}
 }
 
 class PixelSplashShaderRef 
@@ -329,7 +422,7 @@ class PixelSplashShaderRef
 
 	public function copyValues(tempShader:RGBPalette)
 	{
-		if(tempShader != null)
+		if (tempShader != null)
 		{
 			for (i in 0...3)
 			{
@@ -368,7 +461,7 @@ class PixelSplashShaderRef
 		reset();
 		enabled = true;
 
-		if(!PlayState.isPixelStage) pixelAmount = 1;
+		if (!PlayState.isPixelStage) pixelAmount = 1;
 		else pixelAmount = PlayState.daPixelZoom;
 		//trace('Created shader ' + Conductor.songPosition);
 	}
@@ -392,7 +485,7 @@ class PixelSplashShader extends FlxShader
 				return color;
 			}
 
-			if(color.a == 0.0 || mult == 0.0) {
+			if (color.a == 0.0 || mult == 0.0) {
 				return color * openfl_Alphav;
 			}
 
@@ -402,7 +495,7 @@ class PixelSplashShader extends FlxShader
 
 			color = mix(color, newColor, mult);
 
-			if(color.a > 0.0) {
+			if (color.a > 0.0) {
 				return vec4(color.rgb, color.a);
 			}
 			return vec4(0.0, 0.0, 0.0, 0.0);

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -409,7 +409,11 @@ class NoteSplash extends FlxSprite
 
 	function set_maxAnims(value:Int)
 	{
-		noteData = Std.int(FlxMath.wrap(noteData, 0, (value * Note.colArray.length) - 1));
+		if (value > 0)
+			noteData = Std.int(FlxMath.wrap(noteData, 0, (value * Note.colArray.length) - 1));
+		else
+			noteData = 0;
+
 		return maxAnims = value;
 	}
 }

--- a/source/options/NotesColorSubState.hx
+++ b/source/options/NotesColorSubState.hx
@@ -707,4 +707,10 @@ class NotesColorSubState extends MusicBeatSubstate
 	function setShaderColor(value:FlxColor) dataArray[curSelectedNote][curSelectedMode] = value;
 	function getShaderColor() return dataArray[curSelectedNote][curSelectedMode];
 	function getShader() return Note.globalRgbShaders[curSelectedNote];
+
+	override function destroy()
+	{
+		Note.globalRgbShaders = [];
+		super.destroy();
+	}
 }

--- a/source/options/VisualsSettingsSubState.hx
+++ b/source/options/VisualsSettingsSubState.hx
@@ -22,22 +22,15 @@ class VisualsSettingsSubState extends BaseOptionsMenu
 		for (i in 0...Note.colArray.length)
 		{
 			var note:StrumNote = new StrumNote(370 + (560 / Note.colArray.length) * i, -200, i, 0);
-			note.centerOffsets();
-			note.centerOrigin();
-			note.playAnim('static');
+			changeNoteSkin(note);
 			notes.add(note);
 			
-			var splash:NoteSplash = new NoteSplash();
-			splash.noteData = i;
-			splash.setPosition(note.x, noteY);
-			splash.loadSplash();
-			splash.visible = false;
-			splash.alpha = ClientPrefs.data.splashAlpha;
-			splash.animation.finishCallback = function(name:String) splash.visible = false;
+			var splash:NoteSplash = new NoteSplash(0, 0, NoteSplash.defaultNoteSplash + NoteSplash.getSplashSkinPostfix());
+			splash.inEditor = true;
+			splash.babyArrow = note;
+			splash.ID = i;
+			splash.kill();
 			splashes.add(splash);
-			
-			Note.initializeGlobalRGBShader(i % Note.colArray.length);
-			splash.rgbShader.copyValues(Note.globalRgbShaders[i % Note.colArray.length]);
 		}
 
 		// options
@@ -237,37 +230,60 @@ class VisualsSettingsSubState extends BaseOptionsMenu
 
 	function onChangeSplashSkin()
 	{
+		var skin:String = NoteSplash.defaultNoteSplash + NoteSplash.getSplashSkinPostfix();
 		for (splash in splashes)
-			splash.loadSplash();
+			splash.loadSplash(skin);
 
 		playNoteSplashes();
 	}
 
 	function playNoteSplashes()
 	{
+		var rand:Int = 0;
+		if (splashes.members[0] != null && splashes.members[0].maxAnims > 1)
+			rand = FlxG.random.int(0, splashes.members[0].maxAnims - 1); // For playing the same random animation on all 4 splashes
+
 		for (splash in splashes)
 		{
+			splash.revive();
+
+			splash.spawnSplashNote(0, 0, splash.ID, null, false);
+			if (splash.maxAnims > 1)
+				splash.noteData = splash.noteData % Note.colArray.length + (rand * Note.colArray.length);
+
 			var anim:String = splash.playDefaultAnim();
-			splash.visible = true;
-			splash.alpha = ClientPrefs.data.splashAlpha;
-			
 			var conf = splash.config.animations.get(anim);
 			var offsets:Array<Float> = [0, 0];
 
+			var minFps:Int = 22;
+			var maxFps:Int = 26;
 			if (conf != null)
+			{
 				offsets = conf.offsets;
 
+				minFps = conf.fps[0];
+				if (minFps < 0) minFps = 0;
+
+				maxFps = conf.fps[1];
+				if (maxFps < 0) maxFps = 0;
+			}
+
+			splash.offset.set(10, 10);
 			if (offsets != null)
 			{
-				splash.centerOffsets();
-				splash.offset.set(offsets[0], offsets[1]);
+				splash.offset.x += offsets[0];
+				splash.offset.y += offsets[1];
 			}
+
+			if (splash.animation.curAnim != null)
+				splash.animation.curAnim.frameRate = FlxG.random.int(minFps, maxFps);
 		}
 	}
 
 	override function destroy()
 	{
 		if(changedMusic && !OptionsState.onPlayState) FlxG.sound.playMusic(Paths.music('freakyMenu'), 1, true);
+		Note.globalRgbShaders = [];
 		super.destroy();
 	}
 

--- a/source/shaders/RGBPalette.hx
+++ b/source/shaders/RGBPalette.hx
@@ -10,6 +10,21 @@ class RGBPalette {
 	public var b(default, set):FlxColor;
 	public var mult(default, set):Float;
 
+	public function copyValues(tempShader:RGBPalette)
+	{
+		if (tempShader != null)
+		{
+			for (i in 0...3)
+			{
+				shader.r.value[i] = tempShader.shader.r.value[i];
+				shader.g.value[i] = tempShader.shader.g.value[i];
+				shader.b.value[i] = tempShader.shader.b.value[i];
+			}
+			shader.mult.value[0] = tempShader.shader.mult.value[0];
+		}
+		else shader.mult.value[0] = 0.0;
+	}
+
 	private function set_r(color:FlxColor) {
 		r = color;
 		shader.r.value = [color.redFloat, color.greenFloat, color.blueFloat];

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -338,7 +338,7 @@ class LoadingState extends MusicBeatState
 			//
 
 			// LOAD NOTE SPLASH IMAGE
-			var noteSplash:String = NoteSplash.DEFAULT_SKIN;
+			var noteSplash:String = NoteSplash.defaultNoteSplash;
 			if(PlayState.SONG.splashSkin != null && PlayState.SONG.splashSkin.length > 0) noteSplash = PlayState.SONG.splashSkin;
 			else noteSplash += NoteSplash.getSplashSkinPostfix();
 			imagesToPrepare.push(noteSplash);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3099,14 +3099,14 @@ class PlayState extends MusicBeatState
 		if(note != null) {
 			var strum:StrumNote = playerStrums.members[note.noteData];
 			if(strum != null)
-				spawnNoteSplash(note, strum);
+				spawnNoteSplash(strum.x, strum.y, note.noteData, note, strum);
 		}
 	}
 
-	public function spawnNoteSplash(note:Note, strum:StrumNote) {
-		var splash:NoteSplash = new NoteSplash();
+	public function spawnNoteSplash(x:Float = 0, y:Float = 0, ?data:Int = 0, ?note:Note, ?strum:StrumNote) {
+		var splash:NoteSplash = grpNoteSplashes.recycle(NoteSplash);
 		splash.babyArrow = strum;
-		splash.spawnSplashNote(note);
+		splash.spawnSplashNote(x, y, data, note);
 		grpNoteSplashes.add(splash);
 	}
 

--- a/source/states/editors/NoteSplashEditorState.hx
+++ b/source/states/editors/NoteSplashEditorState.hx
@@ -46,9 +46,9 @@ class NoteSplashEditorState extends MusicBeatState
         #end
 
         var bg:FlxSprite = new FlxSprite().loadGraphic(Paths.image('menuDesat'));
-		bg.scrollFactor.set();
-		bg.color = 0xFF505050;
-		add(bg);      
+        bg.scrollFactor.set();
+        bg.color = 0xFF505050;
+        add(bg);      
 
         UI = new PsychUIBox(0, 0, 0, 0, ["Animation"]);
         UI.canMove = UI.canMinimize = false;
@@ -362,8 +362,8 @@ class NoteSplashEditorState extends MusicBeatState
 
         var rgbText = new FlxText(allowRGBCheck.x + 20, 0);
         rgbText.text = "Allow RGB?";
-		rgbText.y = allowRGBCheck.y + 2.5;
-		ui.add(rgbText);
+        rgbText.y = allowRGBCheck.y + 2.5;
+        ui.add(rgbText);
 
         ui.add(allowRGBCheck);
 
@@ -378,8 +378,8 @@ class NoteSplashEditorState extends MusicBeatState
 
         var pixelText = new FlxText(allowPixelCheck.x + 20, 0);
         pixelText.text = "Allow Pixel?";
-		pixelText.y = allowPixelCheck.y + 2.5;
-		ui.add(pixelText);
+        pixelText.y = allowPixelCheck.y + 2.5;
+        ui.add(pixelText);
 
         ui.add(allowPixelCheck);
     }
@@ -492,8 +492,8 @@ class NoteSplashEditorState extends MusicBeatState
         //
     }
 
-	var holdingArrowsTime:Float = 0;
-	var holdingArrowsElapsed:Float = 0;
+    var holdingArrowsTime:Float = 0;
+    var holdingArrowsElapsed:Float = 0;
     var copiedOffset:Array<Float> = [0, 0];
     override function update(elapsed:Float)
     { 
@@ -737,36 +737,36 @@ class NoteSplashEditorState extends MusicBeatState
 
     var _file:FileReference;
     function onSaveComplete(_):Void
-	{
-		_file.removeEventListener(Event.COMPLETE, onSaveComplete);
-		_file.removeEventListener(Event.CANCEL, onSaveCancel);
-		_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
-		_file = null;
-		FlxG.log.notice("Successfully saved file.");
-	}
+    {
+        _file.removeEventListener(Event.COMPLETE, onSaveComplete);
+        _file.removeEventListener(Event.CANCEL, onSaveCancel);
+        _file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+        _file = null;
+        FlxG.log.notice("Successfully saved file.");
+    }
 
-	/**
-	 * Called when the save file dialog is cancelled.
-	 */
-	function onSaveCancel(_):Void
-	{
-		_file.removeEventListener(Event.COMPLETE, onSaveComplete);
-		_file.removeEventListener(Event.CANCEL, onSaveCancel);
-		_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
-		_file = null;
-	}
+    /**
+     * Called when the save file dialog is cancelled.
+     */
+    function onSaveCancel(_):Void
+    {
+        _file.removeEventListener(Event.COMPLETE, onSaveComplete);
+        _file.removeEventListener(Event.CANCEL, onSaveCancel);
+        _file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+        _file = null;
+    }
 
-	/**
-	 * Called if there is an error while saving the gameplay recording.
-	 */
-	function onSaveError(_):Void
-	{
-		_file.removeEventListener(Event.COMPLETE, onSaveComplete);
-		_file.removeEventListener(Event.CANCEL, onSaveCancel);
-		_file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
-		_file = null;
-		FlxG.log.error("Problem saving file");
-	}
+    /**
+     * Called if there is an error while saving the gameplay recording.
+     */
+    function onSaveError(_):Void
+    {
+        _file.removeEventListener(Event.COMPLETE, onSaveComplete);
+        _file.removeEventListener(Event.CANCEL, onSaveCancel);
+        _file.removeEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+        _file = null;
+        FlxG.log.error("Problem saving file");
+    }
 
     function saveSplash()
     {
@@ -775,32 +775,32 @@ class NoteSplashEditorState extends MusicBeatState
         if (data.length > 0)
         {
             _file = new FileReference();
-			_file.addEventListener(Event.COMPLETE, onSaveComplete);
-			_file.addEventListener(Event.CANCEL, onSaveCancel);
-			_file.addEventListener(IOErrorEvent.IO_ERROR, onSaveError);
-			_file.save(data, imageSkin + ".json");
+            _file.addEventListener(Event.COMPLETE, onSaveComplete);
+            _file.addEventListener(Event.CANCEL, onSaveCancel);
+            _file.addEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+            _file.save(data, imageSkin + ".json");
         }
     }
 
-	public function loadTxt()
-	{
-		var jsonFilter:FileFilter = new FileFilter('Select a note splash TXT', '*.txt');
-		_file = new FileReference();
-		_file.addEventListener(Event.SELECT, onLoadComplete);
-		_file.addEventListener(Event.CANCEL, onLoadCancel);
-		_file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file.browse([#if !mac jsonFilter #end]);
-	}
+    public function loadTxt()
+    {
+        var jsonFilter:FileFilter = new FileFilter('Select a note splash TXT', '*.txt');
+        _file = new FileReference();
+        _file.addEventListener(Event.SELECT, onLoadComplete);
+        _file.addEventListener(Event.CANCEL, onLoadCancel);
+        _file.addEventListener(IOErrorEvent.IO_ERROR, onLoadError);
+        _file.browse([#if !mac jsonFilter #end]);
+    }
 
-	function onLoadComplete(_):Void
-	{
-		_file.removeEventListener(Event.SELECT, onLoadComplete);
-		_file.removeEventListener(Event.CANCEL, onLoadCancel);
-		_file.removeEventListener(IOErrorEvent.IO_ERROR, onLoadError);
+    function onLoadComplete(_):Void
+    {
+        _file.removeEventListener(Event.SELECT, onLoadComplete);
+        _file.removeEventListener(Event.CANCEL, onLoadCancel);
+        _file.removeEventListener(IOErrorEvent.IO_ERROR, onLoadError);
 
-		try 
-		{
-			var txtLoaded:Dynamic = Json.parse(Json.stringify(_file));
+        try 
+        {
+            var txtLoaded:Dynamic = Json.parse(Json.stringify(_file));
             var txt:String = null;
             var file:String = "config.json";
             #if MODS_ALLOWED
@@ -813,41 +813,41 @@ class NoteSplashEditorState extends MusicBeatState
 
             var conf = parseTxt(txt);
             _file = new FileReference();
-			_file.addEventListener(Event.COMPLETE, onSaveComplete);
-			_file.addEventListener(Event.CANCEL, onSaveCancel);
-			_file.addEventListener(IOErrorEvent.IO_ERROR, onSaveError);
-			_file.save(Json.stringify(conf, "\t"), file);
+            _file.addEventListener(Event.COMPLETE, onSaveComplete);
+            _file.addEventListener(Event.CANCEL, onSaveCancel);
+            _file.addEventListener(IOErrorEvent.IO_ERROR, onSaveError);
+            _file.save(Json.stringify(conf, "\t"), file);
             #end
-		}
-		catch (e)
-		{
-			trace(e.stack);
-		}
-	}
+        }
+        catch (e)
+        {
+            trace(e.stack);
+        }
+    }
 
-	/**
-	 * Called when the save file dialog is cancelled.
-	 */
-	function onLoadCancel(_):Void
-	{
-		_file.removeEventListener(Event.SELECT, onLoadComplete);
-		_file.removeEventListener(Event.CANCEL, onLoadCancel);
-		_file.removeEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file = null;
-		trace("Cancelled file loading.");
-	}
+    /**
+     * Called when the save file dialog is cancelled.
+     */
+    function onLoadCancel(_):Void
+    {
+        _file.removeEventListener(Event.SELECT, onLoadComplete);
+        _file.removeEventListener(Event.CANCEL, onLoadCancel);
+        _file.removeEventListener(IOErrorEvent.IO_ERROR, onLoadError);
+        _file = null;
+        trace("Cancelled file loading.");
+    }
 
-	/**
-	 * Called if there is an error while saving the gameplay recording.
-	 */
-	function onLoadError(_):Void
-	{
-		_file.removeEventListener(Event.SELECT, onLoadComplete);
-		_file.removeEventListener(Event.CANCEL, onLoadCancel);
-		_file.removeEventListener(IOErrorEvent.IO_ERROR, onLoadError);
-		_file = null;
-		trace("Problem loading file");
-	}
+    /**
+     * Called if there is an error while saving the gameplay recording.
+     */
+    function onLoadError(_):Void
+    {
+        _file.removeEventListener(Event.SELECT, onLoadComplete);
+        _file.removeEventListener(Event.CANCEL, onLoadCancel);
+        _file.removeEventListener(IOErrorEvent.IO_ERROR, onLoadError);
+        _file = null;
+        trace("Problem loading file");
+    }
 
     override function destroy()
     {
@@ -856,72 +856,72 @@ class NoteSplashEditorState extends MusicBeatState
 
         FlxG.sound.music.volume = 1;
         FlxG.sound.muteKeys = [FlxKey.ZERO];
-	    FlxG.sound.volumeDownKeys = [FlxKey.NUMPADMINUS, FlxKey.MINUS];
-	    FlxG.sound.volumeUpKeys = [FlxKey.NUMPADPLUS, FlxKey.PLUS];
+        FlxG.sound.volumeDownKeys = [FlxKey.NUMPADMINUS, FlxKey.MINUS];
+        FlxG.sound.volumeUpKeys = [FlxKey.NUMPADPLUS, FlxKey.PLUS];
     }
 
     public static function parseTxt(content:String):NoteSplashConfig
-	{
-		var config = NoteSplash.createConfig();
-		if (content == null)
-			return config;
+    {
+        var config = NoteSplash.createConfig();
+        if (content == null)
+            return config;
 
-		var trim:String = content.trim();
-		if (trim.length < 1) // empty txt
-			return config;
+        var trim:String = content.trim();
+        if (trim.length < 1) // empty txt
+            return config;
 
-		var configs = content.split('\n');
-		// checks for empty txts
-		if (configs.length < 2 || configs[0].trim() == "")
-			return config;
+        var configs = content.split('\n');
+        // checks for empty txts
+        if (configs.length < 2 || configs[0].trim() == "")
+            return config;
 
-		var animation:String = configs[0].rtrim();
-		var fps:Array<Null<Int>> = [22, 26];
-		if (configs[1] != null && configs[1].trim() != "")
-		{
-			var newFps = configs[1].trim().split(" ");
-			fps = [Std.parseInt(newFps[0]), Std.parseInt(newFps[1])];
-			if (fps[0] == null) fps[0] = 22;
-			if (fps[1] == null) fps[1] = 26;
-		}
+        var animation:String = configs[0].rtrim();
+        var fps:Array<Null<Int>> = [22, 26];
+        if (configs[1] != null && configs[1].trim() != "")
+        {
+            var newFps = configs[1].trim().split(" ");
+            fps = [Std.parseInt(newFps[0]), Std.parseInt(newFps[1])];
+            if (fps[0] == null) fps[0] = 22;
+            if (fps[1] == null) fps[1] = 26;
+        }
 
-		var offsets:Array<Array<Null<Float>>> = [[0, 0]];
-		if (configs.length > 2)
-		{
-			offsets = [];
-			for (i in 2...configs.length)
-			{
-				var offset = configs[i].trim();
-				if (offset != "")
-				{
-					var offset:Array<String> = offset.split(" ");
-					var x:Float = Std.parseFloat(offset[0]);
-					var y:Float = Std.parseFloat(offset[1]);
-					if (Math.isNaN(x)) x = 0;
-					if (Math.isNaN(y)) y = 0;
-					offsets.push([x, y]);
-				}
-			}
-		}
+        var offsets:Array<Array<Null<Float>>> = [[0, 0]];
+        if (configs.length > 2)
+        {
+            offsets = [];
+            for (i in 2...configs.length)
+            {
+                var offset = configs[i].trim();
+                if (offset != "")
+                {
+                    var offset:Array<String> = offset.split(" ");
+                    var x:Float = Std.parseFloat(offset[0]);
+                    var y:Float = Std.parseFloat(offset[1]);
+                    if (Math.isNaN(x)) x = 0;
+                    if (Math.isNaN(y)) y = 0;
+                    offsets.push([x, y]);
+                }
+            }
+        }
 
-		var i = 0;
-		var k = 1;
-		while (true)
-		{
-			for (col in Note.colArray)
-			{
-				var anim = k <= 1 ? col : '$col' + k;
-				var offset = offsets[FlxMath.wrap(i, 0, Std.int(offsets.length - 1))];
+        var i = 0;
+        var k = 1;
+        while (true)
+        {
+            for (col in Note.colArray)
+            {
+                var anim = k <= 1 ? col : '$col' + k;
+                var offset = offsets[FlxMath.wrap(i, 0, Std.int(offsets.length - 1))];
 
-				config = NoteSplash.addAnimationToConfig(config, 1, anim, '$animation $col $k', fps, offset, [], i);
-				i++;
-			}
-			if (offsets[i] == null) break;
-			k++;
-		}
+                config = NoteSplash.addAnimationToConfig(config, 1, anim, '$animation $col $k', fps, offset, [], i);
+                i++;
+            }
+            if (offsets[i] == null) break;
+            k++;
+        }
 
-		return config;
-	}
+        return config;
+    }
 }
 
 
@@ -935,35 +935,35 @@ class NoteSplashEditorHelpSubState extends MusicBeatSubstate
         bg.alpha = 0.6;
         add(bg);
 
-		var str:Array<String> = ["Click on a Strum or Press Space",
-		"to spawn a Splash",
-		"",
-		"Arrow Keys - Move Offset",
-		"Hold Shift - Move Offsets 10x faster",
-		"",
-		"Ctrl + C - Copy Current Offset",
-		"Ctrl + V - Paste Copied Offset on Current Splash",
-		"Ctrl + R - Reset Current Offset",
-		"",
-		"On every 4 subsequent note datas",
-		"an extra set of animations will be added"];
+        var str:Array<String> = ["Click on a Strum or Press Space",
+        "to spawn a Splash",
+        "",
+        "Arrow Keys - Move Offset",
+        "Hold Shift - Move Offsets 10x faster",
+        "",
+        "Ctrl + C - Copy Current Offset",
+        "Ctrl + V - Paste Copied Offset on Current Splash",
+        "Ctrl + R - Reset Current Offset",
+        "",
+        "On every 4 subsequent note datas",
+        "an extra set of animations will be added"];
 
-		var helpTexts:FlxSpriteGroup = new FlxSpriteGroup();
-		for (i => txt in str)
-		{
-			if(txt.length < 1) continue;
+        var helpTexts:FlxSpriteGroup = new FlxSpriteGroup();
+        for (i => txt in str)
+        {
+            if(txt.length < 1) continue;
 
-			var helpText:FlxText = new FlxText(0, 0, 0, txt, 24);
-			helpText.setFormat(null, 24, FlxColor.WHITE, CENTER, OUTLINE_FAST, FlxColor.BLACK);
-			helpText.borderColor = FlxColor.BLACK;
-			helpText.scrollFactor.set();
-			helpText.borderSize = 1;
-			helpText.screenCenter();
-			add(helpText);
-			helpText.y += ((i - str.length/2) * 32) + 16;
-			helpTexts.add(helpText);
-		}
-		add(helpTexts);
+            var helpText:FlxText = new FlxText(0, 0, 0, txt, 24);
+            helpText.setFormat(null, 24, FlxColor.WHITE, CENTER, OUTLINE_FAST, FlxColor.BLACK);
+            helpText.borderColor = FlxColor.BLACK;
+            helpText.scrollFactor.set();
+            helpText.borderSize = 1;
+            helpText.screenCenter();
+            add(helpText);
+            helpText.y += ((i - str.length/2) * 32) + 16;
+            helpTexts.add(helpText);
+        }
+        add(helpTexts);
 
         var noteDataText:FlxText = new FlxText();
         noteDataText.setFormat(null, 24, FlxColor.WHITE, RIGHT, OUTLINE_FAST, FlxColor.BLACK);

--- a/source/states/editors/NoteSplashEditorState.hx
+++ b/source/states/editors/NoteSplashEditorState.hx
@@ -33,7 +33,7 @@ class NoteSplashEditorState extends MusicBeatState
     override function create()
     {
         if (imageSkin == null)
-            imageSkin =  NoteSplash.DEFAULT_SKIN + NoteSplash.getSplashSkinPostfix();
+            imageSkin =  NoteSplash.defaultNoteSplash + NoteSplash.getSplashSkinPostfix();
 
         FlxG.mouse.visible = true;
 
@@ -72,9 +72,9 @@ class NoteSplashEditorState extends MusicBeatState
         add(shaderUI);
 
         var tipText:FlxText = new FlxText();
-        tipText.setFormat(null, 32);
+        tipText.setFormat(null, 24);
         tipText.text = "Press F1 for Help";
-        tipText.setPosition(properUI.x - properUI.width - 60, UI.y);
+        tipText.setPosition(properUI.x - properUI.width + 15, UI.y);
         add(tipText);
 
         for (i in 0...4)
@@ -89,7 +89,8 @@ class NoteSplashEditorState extends MusicBeatState
         add(strums);
         add(splashes);
 
-        splash = new NoteSplash(imageSkin); // this cannot be recycled 
+        splash = new NoteSplash(0, 0, imageSkin); // this cannot be recycled
+        splash.inEditor = true;
         splash.alpha = .0;
         splashes.add(splash);
 
@@ -98,7 +99,7 @@ class NoteSplashEditorState extends MusicBeatState
 
         parseRGB();
 
-        addProperitiesTab();
+        addPropertiesTab();
         addAnimTab();
         addShadersTab();
 
@@ -246,13 +247,6 @@ class NoteSplashEditorState extends MusicBeatState
             curAnim = name_input.text;
             playStrumAnim(curAnim, cast numericStepperData.value);
             setAnimDropDown();
-
-            if (errorText.alpha == 1)
-            {
-                config.animations.remove(curAnim);
-                curAnim = null;
-                setAnimDropDown();
-            }
             //if (animDropDown.list)
         }); 
         UI.add(addButton);
@@ -326,7 +320,7 @@ class NoteSplashEditorState extends MusicBeatState
 
     var imageInputText:PsychUIInputText;
     var scaleNumericStepper:PsychUINumericStepper;
-    function addProperitiesTab()
+    function addPropertiesTab()
     {
         var ui = properUI.getTab("Properties").menu;
 
@@ -409,7 +403,7 @@ class NoteSplashEditorState extends MusicBeatState
 
         var red = new PsychUINumericStepper(60, 30, 1, redShader[0], 0, 255, 0);
         red.onValueChange = () -> {
-            var shader = switch changeShader.selectedLabel
+            var shader = switch (changeShader.selectedLabel)
             {
                 case "Red": redShader[0] = Std.int(red.value);
                 case "Green": greenShader[0] = Std.int(red.value);
@@ -419,9 +413,9 @@ class NoteSplashEditorState extends MusicBeatState
         };
         tab.add(red);
 
-        var green = new PsychUINumericStepper(60, 50, 1, redShader[2], 0, 255, 0);
+        var green = new PsychUINumericStepper(60, 50, 1, redShader[1], 0, 255, 0);
         green.onValueChange = () -> {
-            var shader = switch changeShader.selectedLabel
+            var shader = switch (changeShader.selectedLabel)
             {
                 case "Red": redShader[1] = Std.int(green.value);
                 case "Green": greenShader[1] = Std.int(green.value);
@@ -431,9 +425,9 @@ class NoteSplashEditorState extends MusicBeatState
         };
         tab.add(green);
 
-        var blue = new PsychUINumericStepper(60, 70, 1, redShader[1], 0, 255, 0);
+        var blue = new PsychUINumericStepper(60, 70, 1, redShader[2], 0, 255, 0);
         blue.onValueChange = () -> {
-            var shader = switch changeShader.selectedLabel
+            var shader = switch (changeShader.selectedLabel)
             {
                 case "Red": redShader[2] = Std.int(blue.value);
                 case "Green": greenShader[2] = Std.int(blue.value);
@@ -451,7 +445,7 @@ class NoteSplashEditorState extends MusicBeatState
                 shaderUI.alpha = 0.6;
 
             if (change)
-                switch changeShader.selectedLabel
+                switch (changeShader.selectedLabel)
                 {
                     case "Red": redEnabled = !defaultButton.checked;
                     case "Green": greenEnabled = !defaultButton.checked;
@@ -464,7 +458,7 @@ class NoteSplashEditorState extends MusicBeatState
         add(new FlxText(shaderUI.x + 20, shaderUI.y + 135, 0, "Color to Replace:"));
         changeShader = new PsychUIDropDownMenu(shaderUI.x + 20, shaderUI.y + 150, ["Red", "Green", "Blue"], function(id:Int, name:String)
         {
-            var shader = switch name
+            var shader = switch (name)
             {
                 case "Red": redShader;
                 case "Green": greenShader;
@@ -476,11 +470,11 @@ class NoteSplashEditorState extends MusicBeatState
             blue.value = shader[2];
 
             // changing checked doesn't initiate onCheck!!
-            defaultButton.checked = !(switch name {
-                case "Red": redEnabled;
-                case "Green": greenEnabled;
-                case _: blueEnabled;
-            });
+            defaultButton.checked = switch (name) {
+                case "Red": !redEnabled;
+                case "Green": !greenEnabled;
+                case _: !blueEnabled;
+            }
             onCheck(false);
         });
         add(changeShader);
@@ -618,45 +612,11 @@ class NoteSplashEditorState extends MusicBeatState
                         strum.playAnim('confirm', true);
                         //strum.holdTimer = Math.POSITIVE_INFINITY;
 
-                        var splash:NoteSplash = new NoteSplash(imageSkin);
-                        splash.alpha = 0.00001;
+                        var splash:NoteSplash = new NoteSplash(0, 0, imageSkin);
+                        splash.inEditor = true;
                         splash.config = config;
-
-                        var anims:Int = 0;
-                        var datas:Int = 0;
-                        var animArray:Array<Int> = [];
-
-                        while (true)
-                        {
-                            var data:Int = strum.ID % 4 + (datas * 4); 
-                            if (!splash.noteDataMap.exists(data) || !splash.animation.exists(splash.noteDataMap[data]))
-                                break;
-
-                            datas++;
-                            anims++;
-                        }
-
-                        if (anims > 1)
-                        {
-                            for (i in 0...anims)
-                            {
-                                animArray.push(strum.ID % 4 + (i * 4));
-                            }
-                        }
-
-                        var int:Int = strum.ID % 4;
-                        if (!splash.noteDataMap.exists(int) && splash.noteDataMap.exists(strum.ID % 4 + 4))
-                            int = strum.ID % 4 + 4;
-
-                        if (animArray.length > 1)
-                        {
-                            var r:Int = FlxG.random.bool() ? 0 : 1;
-                            int = animArray[r];
-                        }
-
                         splash.babyArrow = strum;
-                        splash.spawnSplashNote(null, int);
-                        splash.alpha = 1;
+                        splash.spawnSplashNote(0, 0, strum.ID % 4);
                         splashes.add(splash);
                     }
                 }
@@ -672,21 +632,20 @@ class NoteSplashEditorState extends MusicBeatState
 
     function playStrumAnim(?name:String, noteData:Int)
     {
-        var splash:NoteSplash = new NoteSplash(imageSkin);
-        splash.alpha = 1;
+        var splash:NoteSplash = new NoteSplash(0, 0, imageSkin);
+        splash.inEditor = true;
         splash.config = config;
         if (noteData < 0) noteData = 0;
 
-        if (name != null && splash.animation.exists(name) && noteData > -1)
+        if (name != null && splash.animation.exists(name))
         {
             splash.babyArrow = strums.members[noteData % 4];
-            splash.spawnSplashNote(null, noteData, false);
+            splash.spawnSplashNote(0, 0, noteData, null, false);
             splash.alpha = 1;
             splashes.add(splash);
         }
         else
         {
-            splashes.remove(splash);
             errorText.alpha = 1;
             errorText.text = "ERROR while playing splash";
             
@@ -892,6 +851,7 @@ class NoteSplashEditorState extends MusicBeatState
 
     override function destroy()
     {
+        NoteSplash.configs.clear();
         super.destroy();
 
         FlxG.sound.music.volume = 1;
@@ -925,68 +885,39 @@ class NoteSplashEditorState extends MusicBeatState
 			if (fps[1] == null) fps[1] = 26;
 		}
 
-		var hasOneOffset = false;
 		var offsets:Array<Array<Null<Float>>> = [[0, 0]];
-		if (configs.length == 3 || configs.length == 2)
-		{
-			hasOneOffset = true;
-			if (configs.length == 3)
-			{
-                offsets = [];
-				var offset = configs[2].trim();
-				if (offset != "")
-				{
-					var offset:Array<String> = offset.split(" ");
-					var x:Null<Float> = Std.parseFloat(offset[0]);
-					var y:Null<Float> = Std.parseFloat(offset[1]);
-					if (x == null) x = 0;
-					if (y == null) y = 0;
-					offsets.push([x, y]);
-				}
-			}
-		}
-		else if (configs.length > 3)
+		if (configs.length > 2)
 		{
 			offsets = [];
-			var i = 2;
-			while (true)
+			for (i in 2...configs.length)
 			{
 				var offset = configs[i].trim();
 				if (offset != "")
 				{
 					var offset:Array<String> = offset.split(" ");
-					var x:Null<Float> = Std.parseFloat(offset[0]);
-					var y:Null<Float> = Std.parseFloat(offset[1]);
-					if (x == null) x = 0;
-					if (y == null) y = 0;
+					var x:Float = Std.parseFloat(offset[0]);
+					var y:Float = Std.parseFloat(offset[1]);
+					if (Math.isNaN(x)) x = 0;
+					if (Math.isNaN(y)) y = 0;
 					offsets.push([x, y]);
 				}
-				i++;
-
-				if (i + 1 > configs.length)
-					break;
 			}
 		}
 
-		for (i in 0...Note.colArray.length)
+		var i = 0;
+		var k = 1;
+		while (true)
 		{
-			var offset = offsets[hasOneOffset ? 0 : i];
-			if (i + 1 > configs.length && !hasOneOffset)
-				break;
-
-			config = NoteSplash.addAnimationToConfig(config, 1, Note.colArray[i], '$animation ${Note.colArray[i]} 10', fps, offset, [], i);
-		}
-
-		if (offsets.length > 4)
-		{
-			for (i in 0...Note.colArray.length)
+			for (col in Note.colArray)
 			{
-				var offset = offsets[i + 4];
-				if (i + 1 > offsets.length)
-					break;
+				var anim = k <= 1 ? col : '$col' + k;
+				var offset = offsets[FlxMath.wrap(i, 0, Std.int(offsets.length - 1))];
 
-				config = NoteSplash.addAnimationToConfig(config, 1, Note.colArray[i] + "2", '$animation ${Note.colArray[i]} 20', fps, offset, [], i + 4);
+				config = NoteSplash.addAnimationToConfig(config, 1, anim, '$animation $col $k', fps, offset, [], i);
+				i++;
 			}
+			if (offsets[i] == null) break;
+			k++;
 		}
 
 		return config;
@@ -1010,18 +941,20 @@ class NoteSplashEditorHelpSubState extends MusicBeatSubstate
 		"Arrow Keys - Move Offset",
 		"Hold Shift - Move Offsets 10x faster",
 		"",
-		"",
 		"Ctrl + C - Copy Current Offset",
 		"Ctrl + V - Paste Copied Offset on Current Splash",
-		"Ctrl + R - Reset Current Offset"];
+		"Ctrl + R - Reset Current Offset",
+		"",
+		"On every 4 subsequent note datas",
+		"an extra set of animations will be added"];
 
 		var helpTexts:FlxSpriteGroup = new FlxSpriteGroup();
 		for (i => txt in str)
 		{
 			if(txt.length < 1) continue;
 
-			var helpText:FlxText = new FlxText(0, 0, 0, txt, 32);
-			helpText.setFormat(null, 32, FlxColor.WHITE, CENTER, OUTLINE_FAST, FlxColor.BLACK);
+			var helpText:FlxText = new FlxText(0, 0, 0, txt, 24);
+			helpText.setFormat(null, 24, FlxColor.WHITE, CENTER, OUTLINE_FAST, FlxColor.BLACK);
 			helpText.borderColor = FlxColor.BLACK;
 			helpText.scrollFactor.set();
 			helpText.borderSize = 1;
@@ -1033,8 +966,8 @@ class NoteSplashEditorHelpSubState extends MusicBeatSubstate
 		add(helpTexts);
 
         var noteDataText:FlxText = new FlxText();
-        noteDataText.setFormat(null, 32, FlxColor.WHITE, RIGHT, OUTLINE_FAST, FlxColor.BLACK);
-        noteDataText.text = "NOTE DATAS:\nLEFT: 0 and 4\nDOWN: 1 and 5\nUP: 2 and 6\nRIGHT: 3 and 7";
+        noteDataText.setFormat(null, 24, FlxColor.WHITE, RIGHT, OUTLINE_FAST, FlxColor.BLACK);
+        noteDataText.text = "NOTE DATAS:\nLEFT: 0\nDOWN: 1\nUP: 2\nRIGHT: 3";
         noteDataText.x = FlxG.width - noteDataText.width - 5;
         noteDataText.y = FlxG.height - noteDataText.height - 5;
 


### PR DESCRIPTION
Note: Check the commit labelled "Note Splash Revamp". The "Indentation Update" commit was purposely made into a separate commit so that you can see the changes easier

If you have any improvements or found any bugs, please comment it down here

Changes:
  - Re-added support for non-JSON splashes and TXT splashes
  - Re-added noteSplashData.r/g/b
  - Re-added infinite animations
  - Optimized random animations
  - Reverts splash strum positions to how they were in 0.7 (Presumably more accurate on the strum)
  - Changed `DEFAULT_SKIN` to `defaultNoteSplash` for consistency
  - Splashes will now disappear after 0.5 seconds if they break instead of disappearing at the start (Re-added from 0.7)
  - Added `copyX` and `copyY` to NoteSplash
  - On VisualsSettingsSubState, splashes will now play the same random animation on all 4 splashes
  - Added `copyValues` function to RGBPalette
  - PlayState recycles splashes now
  - Added tip on NoteSplashEditorState on how to add an extra set of animations
  - Made tip text a bit smaller on NoteSplashEditorState

Fixes:
  - Splash config changes from NoteSplashEditorState staying even if you didn't save
  - Splashes not having their correct color or pixel config in VisualsSettingsSubState
  - Note RGB transferring to other menus after leaving NotesColorSubState
  - Indentation Fixes
  - Formatting Fixes