### PR TITLE
Add a field to check if it uses noteRGB instead of config.rgb or globalRGBShaders

### DIFF
--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -24,6 +24,7 @@ typedef NoteSplashData = {
 	texture:String,
 	useGlobalShader:Bool, //breaks r/g/b but makes it copy default colors for your custom note
 	useRGBShader:Bool,
+	useNoteRGB:Bool,
 	antialiasing:Bool,
 	r:FlxColor,
 	g:FlxColor,
@@ -104,6 +105,7 @@ class Note extends FlxSprite
 		antialiasing: !PlayState.isPixelStage,
 		useGlobalShader: false,
 		useRGBShader: (PlayState.SONG != null) ? !(PlayState.SONG.disableNoteRGB == true) : true,
+		useNoteRGB: false,
 		r: -1,
 		g: -1,
 		b: -1,

--- a/source/objects/Note.hx
+++ b/source/objects/Note.hx
@@ -105,7 +105,7 @@ class Note extends FlxSprite
 		antialiasing: !PlayState.isPixelStage,
 		useGlobalShader: false,
 		useRGBShader: (PlayState.SONG != null) ? !(PlayState.SONG.disableNoteRGB == true) : true,
-		useNoteRGB: false,
+		useNoteRGB: true,
 		r: -1,
 		g: -1,
 		b: -1,

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -257,15 +257,15 @@ class NoteSplash extends FlxSprite
 						}
 					}
 					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
+
+					if (note != null)
+					{
+						if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
+						if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
+						if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
+					}
 				}
 				else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
-
-				if (note != null)
-				{
-					if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
-					if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
-					if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
-				}
 			}
 		}
 		rgbShader.copyValues(tempShader);

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -223,13 +223,7 @@ class NoteSplash extends FlxSprite
 				if ((note == null || !note.noteSplashData.useGlobalShader) || inEditor)
 				{
 					var colors = config.rgb;
-					if (note != null && note.noteSplashData.useNoteRGB)
-					{
-					    tempShader = note.rgbShader.parent;
-					    if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
-					    if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
-					    if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
-					}
+					if (note != null && note.noteSplashData.useNoteRGB) tempShader = note.rgbShader.parent;
 					else if (colors != null)
 					{
 						for (i in 0...colors.length)
@@ -265,6 +259,13 @@ class NoteSplash extends FlxSprite
 					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
 				}
 				else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
+
+				if (note != null)
+				{
+					if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
+					if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
+					if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
+				}
 			}
 		}
 		rgbShader.copyValues(tempShader);

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -257,8 +257,8 @@ class NoteSplash extends FlxSprite
 					}
 					else if (note != null)
 					{
-						tempShader = note.rgbShader.parent;
-					    	if (!note.noteSplashData.useNoteRGB)
+						if (note.noteSplashData.useNoteRGB) tempShader = note.rgbShader.parent;
+					    	else
 					   	{
 						      if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
 						      if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -223,7 +223,14 @@ class NoteSplash extends FlxSprite
 				if ((note == null || !note.noteSplashData.useGlobalShader) || inEditor)
 				{
 					var colors = config.rgb;
-					if (colors != null)
+					if (note != null && note.noteSplashData.useNoteRGB)
+					{
+					    tempShader = note.rgbShader.parent;
+					    if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
+					    if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
+					    if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
+					}
+					else if (colors != null)
 					{
 						for (i in 0...colors.length)
 						{
@@ -254,16 +261,6 @@ class NoteSplash extends FlxSprite
 							else if (i == 1) tempShader.g = color;
 							else if (i == 2) tempShader.b = color;
 						}
-					}
-					else if (note != null)
-					{
-						if (note.noteSplashData.useNoteRGB) tempShader = note.rgbShader.parent;
-					    	else
-					   	{
-						      if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
-						      if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
-						      if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
-					    	}
 					}
 					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
 				}

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -255,15 +255,17 @@ class NoteSplash extends FlxSprite
 							else if (i == 2) tempShader.b = color;
 						}
 					}
+					else if (note != null)
+					{
+						tempShader = note.rgbShader.parent;
+					    	if (!note.noteSplashData.useNoteRGB)
+					   	{
+						      if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
+						      if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
+						      if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
+					    	}
+					}
 					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
-
-					if (note.noteSplashData.r == -1 && note.noteSplashData.g == -1 && note.noteSplashData.b == -1) tempShader = note.rgbShader.parent;
-				    	else
-				   	{
-					      if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
-					      if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
-					      if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
-				    	}
 				}
 				else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
 			}

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -257,12 +257,13 @@ class NoteSplash extends FlxSprite
 					}
 					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
 
-					if (note != null)
-					{
-						if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
-						if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
-						if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
-					}
+					if (note.noteSplashData.r == -1 && note.noteSplashData.g == -1 && note.noteSplashData.b == -1) tempShader = note.rgbShader.parent;
+				    	else
+				   	{
+					      if (note.noteSplashData.r != -1) tempShader.r = note.noteSplashData.r;
+					      if (note.noteSplashData.g != -1) tempShader.g = note.noteSplashData.g;
+					      if (note.noteSplashData.b != -1) tempShader.b = note.noteSplashData.b;
+				    	}
 				}
 				else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
 			}

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -223,8 +223,7 @@ class NoteSplash extends FlxSprite
 				if ((note == null || !note.noteSplashData.useGlobalShader) || inEditor)
 				{
 					var colors = config.rgb;
-					if (note != null && note.noteSplashData.useNoteRGB) tempShader = note.rgbShader.parent;
-					else if (colors != null)
+					if (colors != null)
 					{
 						for (i in 0...colors.length)
 						{
@@ -256,7 +255,11 @@ class NoteSplash extends FlxSprite
 							else if (i == 2) tempShader.b = color;
 						}
 					}
-					else tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
+					else 
+					{
+						tempShader.copyValues(Note.globalRgbShaders[noteData % Note.colArray.length]);
+           					if (note != null && note.noteSplashData.useNoteRGB) tempShader = note.rgbShader.parent;
+					}
 
 					if (note != null)
 					{

--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -82,7 +82,7 @@ class NoteSplash extends FlxSprite
 			this.config = configs.get(path);
 			for (anim in this.config.animations)
 			{
-				if (anim.noteData % 4 == 0)
+				if (anim.noteData % Note.colArray.length == 0)
 					maxAnims++;
 			}
 			return;
@@ -104,7 +104,7 @@ class NoteSplash extends FlxSprite
 				{
 					var anim:NoteSplashAnim = Reflect.field(config.animations, i);
 					tempConfig.animations.set(i, anim);
-					if (anim.noteData % 4 == 0)
+					if (anim.noteData % Note.colArray.length == 0)
 						maxAnims++;
 				}
 


### PR DESCRIPTION
This is because when config.rgb is null, copying the values from globalRgbShaders doesn't account for when the Note itself changes rgb. And I added the check to allow the override incase it uses noteSplashData.r/g/b