### PR TITLE
Tiny NoteSplash Fix

### DIFF
--- a/source/objects/NoteSplash.hx
+++ b/source/objects/NoteSplash.hx
@@ -64,16 +64,15 @@ class NoteSplash extends FlxSprite
 		maxAnims = 0;
 
 		texture = splash;
+		if (texture == null || texture.length < 1) texture = defaultNoteSplash;
+		if (texture == defaultNoteSplash) texture += getSplashSkinPostfix();
+
 		frames = Paths.getSparrowAtlas(texture);
 		if (frames == null)
 		{
-			texture = defaultNoteSplash + getSplashSkinPostfix();
+			texture = defaultNoteSplash;
 			frames = Paths.getSparrowAtlas(texture);
-			if (frames == null)
-			{
-				texture = defaultNoteSplash;
-				frames = Paths.getSparrowAtlas(texture);
-			}
+			// if (frames == null) active = visible = false;
 		}
 
 		var path:String = 'images/$texture';


### PR DESCRIPTION
the new notesplash code doesn't check if the string is null, which would cause for the game to try and load something that doesn't exist and cause a tiny (yet noticable, or maybe it was just noticeable on my end) lagspike when using the default notesplash
![image](https://github.com/user-attachments/assets/de64e861-f1e4-4a25-922d-bf5804e10f9c)