### PR TITLE
Fix default note type going to "0"

### DIFF
--- a/source/backend/Song.hx
+++ b/source/backend/Song.hx
@@ -113,7 +113,7 @@ class Song
 				var gottaHitNote:Bool = (note[1] < 4) ? section.mustHitSection : !section.mustHitSection;
 				note[1] = (note[1] % 4) + (gottaHitNote ? 0 : 4);
 
-				if(note[3] != null && !Std.isOfType(note[3], String))
+				if(!Std.isOfType(note[3], String))
 					note[3] = Note.defaultNoteTypes[note[3]]; //compatibility with Week 7 and 0.1-0.3 psych charts
 			}
 		}

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1338,7 +1338,7 @@ class PlayState extends MusicBeatState
 				var spawnTime: Float = songNotes[0];
 				var noteColumn: Int = Std.int(songNotes[1] % totalColumns);
 				var holdLength: Float = songNotes[2];
-				var noteType: String = songNotes[3];
+				var noteType: String = !Std.isOfType(songNotes[3], String) ? Note.defaultNoteTypes[songNotes[3]] : songNotes[3];
 				if (Math.isNaN(holdLength))
 					holdLength = 0.0;
 


### PR DESCRIPTION
Was found by TheConcealedCow

If the notetype index in the sectionNotes part of the json doesn't exist, it replaces it with 0 for some reason