### PR TITLE
Add substate functionality to removeLuaSprite/setObjectOrder/getObjectOrder/removeLuaText

### DIFF
--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -447,7 +447,8 @@ class FunkinLua {
 						return -1;
 					}
 				}
-				return LuaUtils.getTargetInstance().members.indexOf(leObj);
+				var groupOrArray:Dynamic = CustomSubstate.instance != null ? CustomSubstate.instance : LuaUtils.getTargetInstance();
+				return groupOrArray.members.indexOf(leObj);
 			}
 			luaTrace('getObjectOrder: Object $obj doesn\'t exist!', false, false, FlxColor.RED);
 			return -1;
@@ -475,7 +476,7 @@ class FunkinLua {
 				}
 				else
 				{
-					var groupOrArray:FlxState = LuaUtils.getTargetInstance();
+					var groupOrArray:Dynamic = CustomSubstate.instance != null ? CustomSubstate.instance : LuaUtils.getTargetInstance();
 					groupOrArray.remove(leObj, true);
 					groupOrArray.insert(position, leObj);
 				}

--- a/source/psychlua/TextFunctions.hx
+++ b/source/psychlua/TextFunctions.hx
@@ -191,7 +191,8 @@ class TextFunctions
 			var text:FlxText = variables.get(tag);
 			if(text == null) return;
 
-			LuaUtils.getTargetInstance().remove(text, true);
+			var instance:Dynamic = CustomSubstate.instance != null ? CustomSubstate.instance : LuaUtils.getTargetInstance();
+			instance.remove(text, true);
 			if(destroy)
 			{
 				text.destroy();


### PR DESCRIPTION
Allows you to remove or set orders of substate sprites/texts