### PR TITLE
Video Sprite Fixes & Improvements

### DIFF
--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -21,9 +21,8 @@ class VideoSprite extends FlxSpriteGroup {
 	private var videoName:String;
 
 	public var waiting:Bool = false;
-	public var didPlay:Bool = false;
 
-	public function new(videoName:String, isWaiting:Bool, canSkip:Bool = false, shouldLoop:Dynamic = false) {
+	public function new(videoName:String, isWaiting:Bool, canSkip:Bool = false, shouldLoop:Dynamic = false, autoPause = true) {
 		super();
 
 		this.videoName = videoName;
@@ -43,27 +42,12 @@ class VideoSprite extends FlxSpriteGroup {
 		// initialize sprites
 		videoSprite = new FlxVideoSprite();
 		videoSprite.antialiasing = ClientPrefs.data.antialiasing;
+		videoSprite.autoPause = autoPause;
 		add(videoSprite);
 		if(canSkip) this.canSkip = true;
 
 		// callbacks
-		if(!shouldLoop)
-		{
-			videoSprite.bitmap.onEndReached.add(function() {
-				if(alreadyDestroyed) return;
-	
-				trace('Video destroyed');
-				if(cover != null)
-				{
-					remove(cover);
-					cover.destroy();
-				}
-		
-				PlayState.instance.remove(this);
-				destroy();
-				alreadyDestroyed = true;
-			});
-		}
+		if(!shouldLoop) videoSprite.bitmap.onEndReached.add(destroy);
 
 		videoSprite.bitmap.onFormatSetup.add(function()
 		{
@@ -88,10 +72,7 @@ class VideoSprite extends FlxSpriteGroup {
 	override function destroy()
 	{
 		if(alreadyDestroyed)
-		{
-			super.destroy();
 			return;
-		}
 
 		trace('Video destroyed');
 		if(cover != null)
@@ -104,7 +85,16 @@ class VideoSprite extends FlxSpriteGroup {
 			finishCallback();
 		onSkip = null;
 
-		PlayState.instance.remove(this);
+		if(FlxG.state != null)
+		{
+			if(FlxG.state.members.contains(this))
+				FlxG.state.remove(this);
+
+			if(FlxG.state.subState != null && FlxG.state.subState.members.contains(this))
+				FlxG.state.subState.remove(this);
+		}
+		super.destroy();
+		alreadyDestroyed = true;
 	}
 
 	override function update(elapsed:Float)
@@ -126,9 +116,7 @@ class VideoSprite extends FlxSpriteGroup {
 				if(onSkip != null) onSkip();
 				finishCallback = null;
 				videoSprite.bitmap.onEndReached.dispatch();
-				PlayState.instance.remove(this);
 				trace('Skipped video');
-				super.destroy();
 				return;
 			}
 		}
@@ -167,6 +155,7 @@ class VideoSprite extends FlxSpriteGroup {
 		skipSprite.alpha = FlxMath.remapToRange(skipSprite.amount, 0.025, 1, 0, 1);
 	}
 
+	public function play() videoSprite?.play();
 	public function resume() videoSprite?.resume();
 	public function pause() videoSprite?.pause();
 	#end

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -1263,7 +1263,7 @@ class FunkinLua {
 			}
 			return false;
 		});
-		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, ?canSkip:Bool = true) {
+		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, ?canSkip:Bool = true, ?forMidSong:Bool = false, ?shouldLoop:Bool = false, ?playOnLoad:Bool = true) {
 			#if VIDEOS_ALLOWED
 			if(FileSystem.exists(Paths.video(videoFile)))
 			{
@@ -1272,7 +1272,7 @@ class FunkinLua {
 					game.remove(game.videoCutscene);
 					game.videoCutscene.destroy();
 				}
-				game.videoCutscene = game.startVideo(videoFile, false, canSkip);
+				game.videoCutscene = game.startVideo(videoFile, forMidSong, canSkip, shouldLoop, playOnLoad);
 				return true;
 			}
 			else

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -673,6 +673,7 @@ class PlayState extends MusicBeatState
 		playbackRate = value;
 		FlxG.animationTimeScale = value;
 		Conductor.safeZoneOffset = (ClientPrefs.data.safeFrames / 60) * 1000 * value;
+		if(videoCutscene != null) videoCutscene.videoSprite.bitmap.rate = value;
 		setOnScripts('playbackRate', playbackRate);
 		#else
 		playbackRate = 1.0; // ensuring -Crow
@@ -837,7 +838,8 @@ class PlayState extends MusicBeatState
 
 		if (foundFile)
 		{
-			videoCutscene = new VideoSprite(fileName, forMidSong, canSkip, loop);
+			videoCutscene = new VideoSprite(fileName, forMidSong, canSkip, loop, false);
+			videoCutscene.videoSprite.bitmap.rate = playbackRate;
 
 			// Finish callback
 			if (!forMidSong)

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -822,8 +822,8 @@ class PlayState extends MusicBeatState
 	public function startVideo(name:String, forMidSong:Bool = false, canSkip:Bool = true, loop:Bool = false, playOnLoad:Bool = true)
 	{
 		#if VIDEOS_ALLOWED
-		inCutscene = true;
-		canPause = false;
+		inCutscene = !forMidSong;
+		canPause = forMidSong;
 
 		var foundFile:Bool = false;
 		var fileName:String = Paths.video(name);
@@ -844,23 +844,24 @@ class PlayState extends MusicBeatState
 			{
 				function onVideoEnd()
 				{
-					if (generatedMusic && PlayState.SONG.notes[Std.int(curStep / 16)] != null && !endingSong && !isCameraOnForcedPos)
+					if (isDead && generatedMusic && PlayState.SONG.notes[Std.int(curStep / 16)] != null && !endingSong && !isCameraOnForcedPos)
 					{
 						moveCameraSection();
 						FlxG.camera.snapToTarget();
 					}
 					videoCutscene = null;
-					canPause = false;
+					canPause = true;
 					inCutscene = false;
 					startAndEnd();
 				}
 				videoCutscene.finishCallback = onVideoEnd;
 				videoCutscene.onSkip = onVideoEnd;
 			}
-			add(videoCutscene);
+			if (GameOverSubstate.instance != null && isDead) GameOverSubstate.instance.add(videoCutscene);
+			else add(videoCutscene);
 
 			if (playOnLoad)
-				videoCutscene.videoSprite.play();
+				videoCutscene.play();
 			return videoCutscene;
 		}
 		#if (LUA_ALLOWED || HSCRIPT_ALLOWED)
@@ -1565,6 +1566,7 @@ class PlayState extends MusicBeatState
 			}
 			FlxTimer.globalManager.forEach(function(tmr:FlxTimer) if(!tmr.finished) tmr.active = false);
 			FlxTween.globalManager.forEach(function(twn:FlxTween) if(!twn.finished) twn.active = false);
+			if(videoCutscene != null) videoCutscene.pause();
 		}
 
 		super.openSubState(SubState);
@@ -1584,6 +1586,7 @@ class PlayState extends MusicBeatState
 			}
 			FlxTimer.globalManager.forEach(function(tmr:FlxTimer) if(!tmr.finished) tmr.active = true);
 			FlxTween.globalManager.forEach(function(twn:FlxTween) if(!twn.finished) twn.active = true);
+			if(videoCutscene != null) videoCutscene.resume();
 
 			paused = false;
 			callOnScripts('onResume');
@@ -1593,16 +1596,23 @@ class PlayState extends MusicBeatState
 
 	override public function onFocus():Void
 	{
-		if (health > 0 && !paused) resetRPC(Conductor.songPosition > 0.0);
+		if (!paused)
+		{
+			if (health > 0) resetRPC(Conductor.songPosition > 0.0);
+			if (videoCutscene != null) videoCutscene.resume();
+		}
 		super.onFocus();
 	}
 
 	override public function onFocusLost():Void
 	{
-		#if DISCORD_ALLOWED
-		if (health > 0 && !paused && autoUpdateRPC) DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
-		#end
-
+		if (!paused)
+		{
+			#if DISCORD_ALLOWED
+			if (health > 0 && autoUpdateRPC) DiscordClient.changePresence(detailsPausedText, SONG.song + " (" + storyDifficultyText + ")", iconP2.getCharacter());
+			#end
+			if (videoCutscene != null) videoCutscene.pause();
+		}
 		super.onFocusLost();
 	}
 
@@ -1966,6 +1976,11 @@ class PlayState extends MusicBeatState
 				paused = true;
 				canResync = false;
 				canPause = false;
+				if(videoCutscene != null)
+				{
+					videoCutscene.destroy();
+					videoCutscene = null;
+				}
 
 				persistentUpdate = false;
 				persistentDraw = false;
@@ -3138,6 +3153,12 @@ class PlayState extends MusicBeatState
 		hscriptArray = null;
 		#end
 		stagesFunc(function(stage:BaseStage) stage.destroy());
+
+		if(videoCutscene != null)
+		{
+			videoCutscene.destroy();
+			videoCutscene = null;
+		}
 
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_DOWN, onKeyPress);
 		FlxG.stage.removeEventListener(KeyboardEvent.KEY_UP, onKeyRelease);

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -846,7 +846,7 @@ class PlayState extends MusicBeatState
 			{
 				function onVideoEnd()
 				{
-					if (isDead && generatedMusic && PlayState.SONG.notes[Std.int(curStep / 16)] != null && !endingSong && !isCameraOnForcedPos)
+					if (!isDead && generatedMusic && PlayState.SONG.notes[Std.int(curStep / 16)] != null && !endingSong && !isCameraOnForcedPos)
 					{
 						moveCameraSection();
 						FlxG.camera.snapToTarget();


### PR DESCRIPTION
- Added a `play` function to `VideoSprite` for easier handling
- Added an `autoPause` argument to `VideoSprite`'s constructor (used in PlayState to set to false to allow substate pausing correctly and whatnot)
- `VideoSprite` now removes itself from the state/substate its added in instead of only PlayState
- `videoCutscene` will now pause when a substate is opened and resumes when closed, the autoPause from the hxvlc class will be disabled for manual handling as said above
- While the video is playing, `videoCutscene` will now be removed from PlayState when the player leaves or dies
- `videoCutscene` will now follow the playback rate
- Fixes some stuff with mid-song in `startVideo`
- Added the rest of `startVideo`'s arguments to Lua's `startVideo`
- `startVideo` will now add to GameOverSubstate if the player is dead
- Code optimizations regarding `destroy`