### PR TITLE
Add Camera Parameter to startVideo Function

### DIFF
--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -22,12 +22,12 @@ class VideoSprite extends FlxSpriteGroup {
 
 	public var waiting:Bool = false;
 
-	public function new(videoName:String, isWaiting:Bool, canSkip:Bool = false, shouldLoop:Dynamic = false, autoPause = true) {
+	public function new(videoName:String, isWaiting:Bool, canSkip:Bool = false, shouldLoop:Dynamic = false, autoPause = true, ?camera:Dynamic) {
 		super();
 
 		this.videoName = videoName;
 		scrollFactor.set();
-		cameras = [FlxG.cameras.list[FlxG.cameras.list.length - 1]];
+                cameras = [camera ?? FlxG.cameras.list[FlxG.cameras.list.length - 1]];
 
 		waiting = isWaiting;
 		if(!waiting)

--- a/source/psychlua/FunkinLua.hx
+++ b/source/psychlua/FunkinLua.hx
@@ -1279,7 +1279,7 @@ class FunkinLua {
 			}
 			return false;
 		});
-		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, ?canSkip:Bool = true, ?forMidSong:Bool = false, ?shouldLoop:Bool = false, ?playOnLoad:Bool = true) {
+		Lua_helper.add_callback(lua, "startVideo", function(videoFile:String, ?canSkip:Bool = true, ?forMidSong:Bool = false, ?shouldLoop:Bool = false, ?playOnLoad:Bool = true, ?camera:String) {
 			#if VIDEOS_ALLOWED
 			if(FileSystem.exists(Paths.video(videoFile)))
 			{
@@ -1288,7 +1288,7 @@ class FunkinLua {
 					game.remove(game.videoCutscene);
 					game.videoCutscene.destroy();
 				}
-				game.videoCutscene = game.startVideo(videoFile, forMidSong, canSkip, shouldLoop, playOnLoad);
+				game.videoCutscene = game.startVideo(videoFile, forMidSong, canSkip, shouldLoop, playOnLoad, LuaUtils.cameraFromString(camera));
 				return true;
 			}
 			else

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -823,7 +823,7 @@ class PlayState extends MusicBeatState
 	}
 
 	public var videoCutscene:VideoSprite = null;
-	public function startVideo(name:String, forMidSong:Bool = false, canSkip:Bool = true, loop:Bool = false, playOnLoad:Bool = true)
+	public function startVideo(name:String, forMidSong:Bool = false, canSkip:Bool = true, loop:Bool = false, playOnLoad:Bool = true, ?camera:Dynamic)
 	{
 		#if VIDEOS_ALLOWED
 		inCutscene = !forMidSong;
@@ -841,7 +841,7 @@ class PlayState extends MusicBeatState
 
 		if (foundFile)
 		{
-			videoCutscene = new VideoSprite(fileName, forMidSong, canSkip, loop, false);
+			videoCutscene = new VideoSprite(fileName, forMidSong, canSkip, loop, false, camera);
 			videoCutscene.videoSprite.bitmap.rate = playbackRate;
 
 			// Finish callback


### PR DESCRIPTION
Right now, startVideo always uses the default camera, which can be limiting for modders who want more control over where their videos appear. By adding a camera parameter, this update makes video rendering way more flexible.

Updated objects.VideoSprite to take a camera parameter. If none is provided (Null), it defaults to the last camera using a simple null check.
Modified startVideo in FunkinLua to properly pass the camera argument.
Updated PlayState to make sure everything works smoothly with the new camera option.