### PR TITLE
Playback rate fix for timeTxt and Skip Time

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1755,7 +1755,7 @@ class PlayState extends MusicBeatState
 			var songCalc:Float = (songLength - curTime);
 			if(ClientPrefs.data.timeBarType == 'Time Elapsed') songCalc = curTime;
 
-			var secondsTotal:Int = Math.floor(songCalc / 1000) / playbackRate;
+			var secondsTotal:Int = Math.floor((songCalc / 1000) / playbackRate);
 			if(secondsTotal < 0) secondsTotal = 0;
 
 			if(ClientPrefs.data.timeBarType != 'Song Name')

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1755,7 +1755,7 @@ class PlayState extends MusicBeatState
 			var songCalc:Float = (songLength - curTime);
 			if(ClientPrefs.data.timeBarType == 'Time Elapsed') songCalc = curTime;
 
-			var secondsTotal:Int = Math.floor(songCalc / 1000);
+			var secondsTotal:Int = Math.floor(songCalc / 1000) / playbackRate;
 			if(secondsTotal < 0) secondsTotal = 0;
 
 			if(ClientPrefs.data.timeBarType != 'Song Name')

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1257,8 +1257,8 @@ class PlayState extends MusicBeatState
 
 		// Song duration in a float, useful for the time left feature
 		songLength = FlxG.sound.music.length;
-		FlxTween.tween(timeBar, {alpha: 1}, 0.5, {ease: FlxEase.circOut});
-		FlxTween.tween(timeTxt, {alpha: 1}, 0.5, {ease: FlxEase.circOut});
+		FlxTween.tween(timeBar, {alpha: 1}, 0.5 / playbackRate, {ease: FlxEase.circOut});
+		FlxTween.tween(timeTxt, {alpha: 1}, 0.5 / playbackRate, {ease: FlxEase.circOut});
 
 		#if DISCORD_ALLOWED
 		// Updating Discord Rich Presence (with Time Left)

--- a/source/substates/PauseSubState.hx
+++ b/source/substates/PauseSubState.hx
@@ -431,5 +431,5 @@ class PauseSubState extends MusicBeatSubstate
 	}
 
 	function updateSkipTimeText()
-		skipTimeText.text = FlxStringUtil.formatTime(Math.max(0, Math.floor(curTime / 1000)), false) + ' / ' + FlxStringUtil.formatTime(Math.max(0, Math.floor(FlxG.sound.music.length / 1000)), false);
+		skipTimeText.text = FlxStringUtil.formatTime(Math.max(0, Math.floor((curTime / 1000) / PlayState.instance.playbackRate)), false) + ' / ' + FlxStringUtil.formatTime(Math.max(0, Math.floor((FlxG.sound.music.length / 1000) / PlayState.instance.playbackRate)), false);
 }

--- a/source/substates/PauseSubState.hx
+++ b/source/substates/PauseSubState.hx
@@ -280,15 +280,15 @@ class PauseSubState extends MusicBeatSubstate
 				case 'Skip Time':
 					if(curTime < Conductor.songPosition)
 					{
-						PlayState.startOnTime = curTime;
+						PlayState.startOnTime = curTime * playbackRate;
 						restartSong(true);
 					}
 					else
 					{
 						if (curTime != Conductor.songPosition)
 						{
-							PlayState.instance.clearNotesBefore(curTime);
-							PlayState.instance.setSongTime(curTime);
+							PlayState.instance.clearNotesBefore(curTime * playbackRate);
+							PlayState.instance.setSongTime(curTime * playbackRate);
 						}
 						close();
 					}

--- a/source/substates/PauseSubState.hx
+++ b/source/substates/PauseSubState.hx
@@ -280,15 +280,15 @@ class PauseSubState extends MusicBeatSubstate
 				case 'Skip Time':
 					if(curTime < Conductor.songPosition)
 					{
-						PlayState.startOnTime = curTime * playbackRate;
+						PlayState.startOnTime = curTime * PlayState.instance.playbackRate;
 						restartSong(true);
 					}
 					else
 					{
 						if (curTime != Conductor.songPosition)
 						{
-							PlayState.instance.clearNotesBefore(curTime * playbackRate);
-							PlayState.instance.setSongTime(curTime * playbackRate);
+							PlayState.instance.clearNotesBefore(curTime * PlayState.instance.playbackRate);
+							PlayState.instance.setSongTime(curTime * PlayState.instance.playbackRate);
 						}
 						close();
 					}


### PR DESCRIPTION
Reiteration of #14888

Shows the ACTUAL time on the text
Skip Time will also no longer skip parts of the song as its adjusted to fit the rate (idk how to explain it lol)
timeTxt and timeBar will now fade in faster or slower depending on the rate

Example (pay attention to the timer)
1x rate:
![Screenshot_2025-02-03-08-16-39-938_com shadowmario psychenginemodified](https://github.com/user-attachments/assets/9215e299-ca48-4baf-870b-4900781da7d4)

0.5x rate:
![Screenshot_2025-02-03-08-22-19-830_com.shadowmario.psychenginemodified.jpg](https://github.com/user-attachments/assets/6d443499-732d-4497-8e4e-49fb8e698863)

2x rate:
![Screenshot_2025-02-03-08-17-11-300_com shadowmario psychenginemodified](https://github.com/user-attachments/assets/d325365c-a2b5-4e7d-bf2b-a57704bb8363)