### PR TITLE
Use the ammount of threads the CPU has for loading screens

### DIFF
--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -23,6 +23,12 @@ import sys.thread.Mutex;
 import objects.Note;
 import objects.NoteSplash;
 
+#if cpp
+@:headerCode('
+#include <iostream>
+#include <thread>
+')
+#end
 class LoadingState extends MusicBeatState
 {
 	public static var loaded:Int = 0;

--- a/source/states/LoadingState.hx
+++ b/source/states/LoadingState.hx
@@ -316,7 +316,7 @@ class LoadingState extends MusicBeatState
 	static var dontPreloadDefaultVoices:Bool = false;
 	public static function prepareToSong()
 	{
-		threadPool = new FixedThreadPool(#if MULTITHREADED_LOADING 8 #else 1 #end); // 10 threads are enough
+		threadPool = new FixedThreadPool(#if MULTITHREADED_LOADING #if cpp getCPUThreadsCount() #else 8 #end #else 1 #end);
 
 		imagesToPrepare = [];
 		soundsToPrepare = [];
@@ -706,4 +706,15 @@ class LoadingState extends MusicBeatState
 
 		return null;
 	}
+	
+	#if cpp
+	@:functionCode('
+		return std::thread::hardware_concurrency();
+    	')
+	@:noCompletion
+    	public static function getCPUThreadsCount():Int
+    	{
+        	return -1;
+    	}
+    	#end
 }


### PR DESCRIPTION
The CPP native method used in here worked on both Windows and Linux with me
Pretty sure it should work on MacOS as well