### PR TITLE
fix video crash when exiting state

### DIFF
--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -80,8 +80,10 @@ class VideoSprite extends FlxSpriteGroup {
 			cover.destroy();
 		}
 
-		if(finishCallback != null)
+		if(finishCallback != null) {
 			finishCallback();
+			finishCallback = null;
+		}
 		onSkip = null;
 
 		if(FlxG.state != null)

--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -46,7 +46,7 @@ class VideoSprite extends FlxSpriteGroup {
 		if(canSkip) this.canSkip = true;
 
 		// callbacks
-		if(!shouldLoop) videoSprite.bitmap.onEndReached.add(destroy);
+		if(!shouldLoop) videoSprite.bitmap.onEndReached.add(finishVideo);
 
 		videoSprite.bitmap.onFormatSetup.add(function()
 		{
@@ -79,11 +79,8 @@ class VideoSprite extends FlxSpriteGroup {
 			remove(cover);
 			cover.destroy();
 		}
-
-		if(finishCallback != null) {
-			finishCallback();
-			finishCallback = null;
-		}
+		
+		finishCallback = null;
 		onSkip = null;
 
 		if(FlxG.state != null)
@@ -96,6 +93,16 @@ class VideoSprite extends FlxSpriteGroup {
 		}
 		super.destroy();
 		alreadyDestroyed = true;
+	}
+	function finishVideo()
+	{
+		if (!alreadyDestroyed)
+		{
+			if(finishCallback != null)
+				finishCallback();
+			
+			super.destroy();
+		}
 	}
 
 	override function update(elapsed:Float)

--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -101,7 +101,7 @@ class VideoSprite extends FlxSpriteGroup {
 			if(finishCallback != null)
 				finishCallback();
 			
-			super.destroy();
+			destroy();
 		}
 	}
 

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3170,7 +3170,6 @@ class PlayState extends MusicBeatState
 		#if VIDEOS_ALLOWED
 		if(videoCutscene != null)
 		{
-			videoCutscene.finishCallback = null;
 			videoCutscene.destroy();
 			videoCutscene = null;
 		}

--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -3170,6 +3170,7 @@ class PlayState extends MusicBeatState
 		#if VIDEOS_ALLOWED
 		if(videoCutscene != null)
 		{
+			videoCutscene.finishCallback = null;
 			videoCutscene.destroy();
 			videoCutscene = null;
 		}


### PR DESCRIPTION
simply separates the part that calls the VideoSprite finish callback so it isnt called when the video is just destroyed, which for instance causes a crash in PlayState. This should allow it so you can pause during mid-song cutscenes without risking a game crash due to exiting to the menu