### PR TITLE
Fix move to top button in Mods menu

### DIFF
--- a/source/states/ModsMenuState.hx
+++ b/source/states/ModsMenuState.hx
@@ -216,13 +216,13 @@ class ModsMenuState extends MusicBeatState
 		button.icon.animation.play('icon', true);
 		add(button);
 		buttons.push(button);
-
+		
 		var button = new MenuButton(buttonsX + 100, buttonsY, 80, 80, Paths.image('modsMenuButtons'), function() moveModToPosition(curSelectedMod - 1), 54, 54); //Move up
 		button.icon.animation.add('icon', [1]);
 		button.icon.animation.play('icon', true);
 		add(button);
 		buttons.push(button);
-
+		
 		var button = new MenuButton(buttonsX + 200, buttonsY, 80, 80, Paths.image('modsMenuButtons'), function() moveModToPosition(curSelectedMod + 1), 54, 54); //Move down
 		button.icon.animation.add('icon', [2]);
 		button.icon.animation.play('icon', true);
@@ -960,9 +960,9 @@ class MenuButton extends FlxSpriteGroup
 			return;
 		}
 
-		if(!ignoreCheck && !Controls.instance.controllerMode && FlxG.mouse.justMoved && FlxG.mouse.visible)
+		if(!ignoreCheck && !Controls.instance.controllerMode && (FlxG.mouse.justPressed || FlxG.mouse.justMoved) && FlxG.mouse.visible)
 			onFocus = FlxG.mouse.overlaps(this);
-
+		
 		if(onFocus && onClick != null && FlxG.mouse.justPressed)
 			onClick();
 


### PR DESCRIPTION
the Move mod to top button in the Mods menu only has a chance to work when the cursor is being moved.
while i honest to god have no idea why the same issue doesn't happen to the rest of the buttons (it's only present on the first added button), this fixes the issue by checking if theres a cursor overlap also when the cursor has been pressed instead of just moved