### PR TITLE
Fix some hscript crashes

### DIFF
--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -444,8 +444,17 @@ class HScript extends Iris
 			#end
 			Iris.error(Printer.errorToString(e, false), pos);
 		}
-		catch (e:ValueException) { // this is thrown for invalid field access and stuff
-			Iris.error('$funcToRun: $e');
+		catch (e:ValueException) {
+			var pos:HScriptInfos = cast this.interp.posInfos();
+			pos.funcName = funcToRun;
+			#if LUA_ALLOWED
+			if (parentLua != null)
+			{
+				pos.isLua = true;
+				if (parentLua.lastCalledFunction != '') pos.funcName = parentLua.lastCalledFunction;
+			}
+			#end
+			Iris.error('$funcToRun: $e', pos);
 		}
 		return null;
 	}

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -454,7 +454,7 @@ class HScript extends Iris
 				if (parentLua.lastCalledFunction != '') pos.funcName = parentLua.lastCalledFunction;
 			}
 			#end
-			Iris.error('$funcToRun: $e', pos);
+			Iris.error('$e', pos);
 		}
 		return null;
 	}

--- a/source/psychlua/HScript.hx
+++ b/source/psychlua/HScript.hx
@@ -15,6 +15,8 @@ import crowplexus.iris.IrisConfig;
 import crowplexus.hscript.Expr.Error as IrisError;
 import crowplexus.hscript.Printer;
 
+import haxe.ValueException;
+
 typedef HScriptInfos = {
 	> haxe.PosInfos,
 	var ?funcName:String;
@@ -442,6 +444,9 @@ class HScript extends Iris
 			#end
 			Iris.error(Printer.errorToString(e, false), pos);
 		}
+		catch (e:ValueException) { // this is thrown for invalid field access and stuff
+			Iris.error('$funcToRun: $e');
+		}
 		return null;
 	}
 
@@ -530,6 +535,23 @@ class CustomInterp extends crowplexus.hscript.Interp
 	public function new()
 	{
 		super();
+	}
+
+	override function fcall(o:Dynamic, funcToRun:String, args:Array<Dynamic>):Dynamic {
+		for (_using in usings) {
+			var v = _using.call(o, funcToRun, args);
+			if (v != null)
+				return v;
+		}
+
+		var f = get(o, funcToRun);
+
+		if (f == null) {
+			Iris.error('Tried to call null function $funcToRun', posInfos());
+			return null;
+		}
+
+		return Reflect.callMethod(o, f, args);
 	}
 
 	override function resolve(id: String): Dynamic {


### PR DESCRIPTION
This PR fixes 2 crashes with HScript:

'Null Function Pointer' crash:
```hx
function onCountdownStarted()
{
  game.notes.thiswillcauseanerror(); // crash - null function pointer
}
```

'invalid field:<field>' crash:
```hx
import flixel.FlxBasic;

function onCountdownStarted()
{
  var example = new FlxBasic();
  example.invalid = '123'; // crash - Invalid field:invalid
}
```

Fixes #16328 