### PR TITLE
fix window scaling on windows

### DIFF
--- a/source/Main.hx
+++ b/source/Main.hx
@@ -89,6 +89,13 @@ class Main extends Sprite
 		// this shouldn't be needed for other systems
 		// Credit to YoshiCrafter29 for finding this function
 		untyped __cpp__("SetProcessDPIAware();");
+
+		var display = lime.system.System.getDisplay(0);
+		if (display != null) {
+			var dpiScale:Float = display.dpi / 96;
+			Application.current.window.width = Std.int(game.width * dpiScale);
+			Application.current.window.height = Std.int(game.height * dpiScale);
+		}
 		#end
 
 		// Credits to MAJigsaw77 (he's the og author for this code)


### PR DESCRIPTION
makes the game respect window scaling on high dpi screens
also fixes an issue of the title bar being short until the window is resized

before:
the game ignores window scaling for some reason when high dpi enabled (im using 150%) and shows as literally 1280x720

<img src="https://github.com/user-attachments/assets/8e20c752-e989-42dd-a533-418dca5f3418" width="50%">

after:

<img src="https://github.com/user-attachments/assets/d364858e-baca-47f9-9ad6-c6772a1dfce1" width="50%">
