### PR TITLE
Move window position to the center of the screen after adjusting the DPI for it + README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Refer to [the Build Instructions](/docs/BUILDING.md)
 
 ## Customization:
 
-if you wish to disable things like *Lua Scripts* or *Video Cutscenes*, you can read over to `Project.xml`
+If you wish to disable things like *Lua Scripts* or *Video Cutscenes*, you can refer to the `Project.xml` file.
 
-inside `Project.xml`, you will find several variables to customize Psych Engine to your liking
+Inside `Project.xml`, you will find several variables to customize Psych Engine to your liking.
 
-to start you off, disabling Videos should be simple, simply Delete the line `"VIDEOS_ALLOWED"` or comment it out by wrapping the line in XML-like comments, like this `<!-- YOUR_LINE_HERE -->`
+To start you off, disabling *Video Cutscenes* should be simple, simply delete the line `"VIDEOS_ALLOWED"` or comment it out by wrapping the line in XML-like comments, like this: `<!-- YOUR_LINE_HERE -->`
 
-same goes for *Lua Scripts*, comment out or delete the line with `LUA_ALLOWED`, this and other customization options are all available within the `Project.xml` file
+Same goes for *Lua Scripts*, comment out or delete the line with `LUA_ALLOWED`, this and other customization options are all available within the `Project.xml` file.
 
 ## Credits:
 * Shadow Mario - Head Developer, Programmer.

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -95,6 +95,9 @@ class Main extends Sprite
 			var dpiScale:Float = display.dpi / 96;
 			Application.current.window.width = Std.int(game.width * dpiScale);
 			Application.current.window.height = Std.int(game.height * dpiScale);
+
+			Application.current.window.x = Std.int((Application.current.window.display.bounds.width - Application.current.window.width) / 2);
+			Application.current.window.y = Std.int((Application.current.window.display.bounds.height - Application.current.window.height) / 2);
 		}
 		#end
 


### PR DESCRIPTION
Currently the window is offseted a bit to the top left after the window has been scaled, this will position the window to the absolute center of your screen.

There is probably a better way to write this, but oh well I think this works for now.

UPDATE: I've adjusted some parts in the README as well so that the flow of English in said parts are more fluent