### PR TITLE
Fix Chart Saving in Linux and MacOS, Display App Icon in MacOS

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -189,7 +189,7 @@
 
 	<!-- _________________________________ Custom _______________________________ -->
 
-	<assets path='art/icons/iconOG.png' rename='icon.png' if="linux" />
+	<assets path='art/icons/iconOG.png' rename='icon.png' if="linux || mac" />
 	
 	<icon path="art/icons/icon16.png" size='16'/>
 	<icon path="art/icons/icon32.png" size='32'/>

--- a/source/Main.hx
+++ b/source/Main.hx
@@ -23,7 +23,7 @@ import crowplexus.iris.Iris;
 import psychlua.HScript.HScriptInfos;
 #end
 
-#if linux
+#if (linux || mac)
 import lime.graphics.Image;
 #end
 
@@ -192,7 +192,7 @@ class Main extends Sprite
 		}
 		#end
 
-		#if linux
+		#if (linux || mac) // fix the app icon not showing up on the Linux Panel / Mac Dock
 		var icon = Image.fromFile("icon.png");
 		Lib.current.stage.window.setIcon(icon);
 		#end

--- a/source/backend/Song.hx
+++ b/source/backend/Song.hx
@@ -126,7 +126,11 @@ class Song
 		if(folder == null) folder = jsonInput;
 		PlayState.SONG = getChart(jsonInput, folder);
 		loadedSongName = folder;
-		chartPath = _lastPath.replace('/', '\\');
+		chartPath = _lastPath;
+		#if windows
+		// prevent any saving errors by fixing the path on Windows (being the only OS to ever use backslashes instead of forward slashes for paths)
+		chartPath = chartPath.replace('/', '\\');
+		#end
 		StageData.loadDirectory(PlayState.SONG);
 		return PlayState.SONG;
 	}


### PR DESCRIPTION
fixes a bug with Linux and Mac where the files saved by the chart editor do not correspond to where they are actually saved on Windows (i.e: file named and saved as "assets\shared\data\test\test-hard.json" instead of "test-hard.json" in the "assets/shared/data/test" folder)

also fixes the app icon not showing up in the MacOS dock

SHOULD fix #16441 